### PR TITLE
fix(pfda-amm): add authority check to UpdateWeight

### DIFF
--- a/contracts/pfda-amm/src/error.rs
+++ b/contracts/pfda-amm/src/error.rs
@@ -35,6 +35,8 @@ pub enum PfmmError {
     InvalidWindowSlots = 6014,
     /// Account already initialized
     AlreadyInitialized = 6015,
+    /// Caller is not the pool authority
+    Unauthorized = 6016,
 }
 
 impl From<PfmmError> for ProgramError {

--- a/contracts/pfda-amm/src/instructions/initialize_pool.rs
+++ b/contracts/pfda-amm/src/instructions/initialize_pool.rs
@@ -124,6 +124,7 @@ pub fn process_initialize_pool(
             current_window_end: clock.slot + window_slots,
             base_fee_bps,
             fee_discount_bps,
+            authority: *payer.key(),
             bump: pool_bump,
             reentrancy_guard: 0,
             _padding: [0; 2],

--- a/contracts/pfda-amm/src/instructions/update_weight.rs
+++ b/contracts/pfda-amm/src/instructions/update_weight.rs
@@ -45,6 +45,11 @@ pub fn process_update_weight(
         return Err(PfmmError::InvalidDiscriminator.into());
     }
 
+    // Verify authority: only the pool creator can update weights
+    if authority.key() != &pool.authority {
+        return Err(PfmmError::Unauthorized.into());
+    }
+
     // Verify PDA
     let (expected, _) = pubkey::find_program_address(
         &[b"pool", &pool.token_a_mint, &pool.token_b_mint],

--- a/contracts/pfda-amm/src/state/pool_state.rs
+++ b/contracts/pfda-amm/src/state/pool_state.rs
@@ -1,4 +1,4 @@
-/// PoolState - 216 bytes, repr(C)
+/// PoolState - 240 bytes, repr(C)
 ///
 /// PDA seeds: [b"pool", token_a_mint, token_b_mint]
 #[repr(C)]
@@ -36,6 +36,8 @@ pub struct PoolState {
     pub base_fee_bps: u16,
     /// Fee discount for searchers in basis points
     pub fee_discount_bps: u16,
+    /// Pool authority (creator, can update weights)
+    pub authority: [u8; 32],
     /// PDA bump seed
     pub bump: u8,
     /// Reentrancy guard: 0 = open, 1 = locked
@@ -77,4 +79,4 @@ impl PoolState {
 }
 
 // Compile-time size assertion (actual layout = 208 bytes)
-const _: () = assert!(core::mem::size_of::<PoolState>() == 208);
+const _: () = assert!(core::mem::size_of::<PoolState>() == 240);

--- a/test/e2e/pfda-amm-legacy/pfda-amm-legacy.local.e2e.ts
+++ b/test/e2e/pfda-amm-legacy/pfda-amm-legacy.local.e2e.ts
@@ -495,6 +495,69 @@ async function main() {
   console.log(`  CU                : ${cuLog["Claim"]?.toLocaleString()}`);
   console.log(`  Token B 受取量    : ${num(received)} (≈ ${(Number(received) / 1e6).toFixed(4)} tokens)\n`);
 
+  // ── 11. UpdateWeight — correct authority → success ─────────────────
+  console.log("▶ Step 11: UpdateWeight (correct authority → success)");
+  {
+    const targetWeight = 600_000; // shift to 60/40
+    const currentSlot = BigInt(await conn.getSlot("confirmed"));
+    const endSlot = currentSlot + 100n;
+    const data = Buffer.concat([
+      Buffer.from([5]),           // discriminant = UpdateWeight
+      u32Le(targetWeight),
+      u64Le(endSlot),
+    ]);
+    const tx = new Transaction().add(new TransactionInstruction({
+      programId: PROGRAM_ID,
+      keys: [
+        { pubkey: payer.publicKey, isSigner: true,  isWritable: false },
+        { pubkey: poolState,       isSigner: false, isWritable: true  },
+      ],
+      data,
+    }));
+    const sig = await sendAndConfirmTransaction(conn, tx, [payer]);
+    cuLog["UpdateWeight"] = await getCU(conn, sig);
+    console.log(`  ✓ Authority accepted, CU: ${cuLog["UpdateWeight"]?.toLocaleString()}\n`);
+  }
+
+  // ── 12. UpdateWeight — wrong signer → Unauthorized (6016) ────────
+  console.log("▶ Step 12: UpdateWeight (wrong signer → Unauthorized)");
+  {
+    const wrongAuth = Keypair.generate();
+    // Fund the wrong authority so it can sign
+    await sendAndConfirmTransaction(conn, new Transaction().add(
+      SystemProgram.transfer({ fromPubkey: payer.publicKey, toPubkey: wrongAuth.publicKey, lamports: LAMPORTS_PER_SOL / 10 })
+    ), [payer]);
+
+    const currentSlot = BigInt(await conn.getSlot("confirmed"));
+    const endSlot = currentSlot + 100n;
+    const data = Buffer.concat([
+      Buffer.from([5]),           // discriminant = UpdateWeight
+      u32Le(700_000),
+      u64Le(endSlot),
+    ]);
+    const tx = new Transaction().add(new TransactionInstruction({
+      programId: PROGRAM_ID,
+      keys: [
+        { pubkey: wrongAuth.publicKey, isSigner: true,  isWritable: false },
+        { pubkey: poolState,           isSigner: false, isWritable: true  },
+      ],
+      data,
+    }));
+    try {
+      await sendAndConfirmTransaction(conn, tx, [wrongAuth]);
+      console.error("  ✗ FAIL: UpdateWeight should have rejected wrong authority");
+      process.exit(1);
+    } catch (err: any) {
+      const msg = err.message || String(err);
+      if (msg.includes("0x1780") || msg.includes("6016") || msg.includes("custom program error")) {
+        console.log(`  ✓ Correctly rejected: Unauthorized (error 6016 / 0x1780)\n`);
+      } else {
+        console.error(`  ✗ FAIL: Unexpected error: ${msg}`);
+        process.exit(1);
+      }
+    }
+  }
+
   // ── サマリー ──────────────────────────────────────────────────────────
   console.log("╔══════════════════════════════════════════╗");
   console.log("║             CU サマリー                  ║");


### PR DESCRIPTION
## Summary
- Add `authority: [u8; 32]` field to `PoolState` (208 → 240 bytes)
- Store pool creator (payer) as authority during `InitializePool`
- Enforce `authority.key() == pool.authority` in `UpdateWeight` before any state mutation
- Add `Unauthorized` (6016) error variant

Without this fix, any account could call `UpdateWeight` and change pool weights, breaking TFMM price computation. Immutable deployment blocker.

## Files changed
- `contracts/pfda-amm/src/state/pool_state.rs` — added `authority` field
- `contracts/pfda-amm/src/instructions/initialize_pool.rs` — store payer as authority
- `contracts/pfda-amm/src/instructions/update_weight.rs` — enforce authority check
- `contracts/pfda-amm/src/error.rs` — add `Unauthorized` variant

## Test plan
- [x] E2E Step 11: `UpdateWeight` with correct authority → weight transition succeeds
- [x] E2E Step 12: `UpdateWeight` with wrong signer → `Unauthorized` (6016 / 0x1780)
- [x] `cargo check` passes
- [x] All CI checks green

Closes #5