### PR TITLE
fix(axis-vault): harden Deposit/Withdraw account validation (#33)

### DIFF
--- a/contracts/axis-vault/src/error.rs
+++ b/contracts/axis-vault/src/error.rs
@@ -15,6 +15,9 @@ pub enum VaultError {
     MintMismatch = 9009,
     InvalidTickerLength = 9010,
     DuplicateMint = 9011,
+    PoolPaused = 9012,
+    VaultMismatch = 9013,
+    InvalidProgramOwner = 9014,
 }
 
 impl From<VaultError> for ProgramError {

--- a/contracts/axis-vault/src/instructions/deposit.rs
+++ b/contracts/axis-vault/src/instructions/deposit.rs
@@ -84,7 +84,9 @@ pub fn process_deposit(
         return Err(ProgramError::NotEnoughAccountKeys);
     }
 
-    // Validate each vault against stored state (positions 5+tc..5+2*tc)
+    // Account layout note: Deposit puts user ATAs in [5..5+tc] and vaults in
+    // [5+tc..5+2*tc]. Withdraw flips this (vaults first, user ATAs second)
+    // because funds flow the opposite direction. Keep the two in sync.
     for i in 0..tc {
         let vault = &accounts[5 + tc + i];
         if vault.key() != &token_vaults[i] {

--- a/contracts/axis-vault/src/instructions/deposit.rs
+++ b/contracts/axis-vault/src/instructions/deposit.rs
@@ -29,7 +29,7 @@ use crate::state::{load, load_mut, EtfState};
 ///
 /// Data: [amount: u64] — base amount per token (scaled by weight)
 pub fn process_deposit(
-    _program_id: &Pubkey,
+    program_id: &Pubkey,
     accounts: &[AccountInfo],
     amount: u64,
     name: &[u8],
@@ -48,8 +48,13 @@ pub fn process_deposit(
         return Err(ProgramError::MissingRequiredSignature);
     }
 
+    // Program ownership: etf_state must be owned by this program
+    if etf_state_ai.owner() != program_id {
+        return Err(VaultError::InvalidProgramOwner.into());
+    }
+
     // Load ETF state
-    let (tc, total_supply, authority, weights, bump_seed) = {
+    let (tc, total_supply, authority, weights, bump_seed, etf_mint, token_vaults) = {
         let data = etf_state_ai.try_borrow_data()?;
         let etf = unsafe { load::<EtfState>(&data) }
             .ok_or(ProgramError::InvalidAccountData)?;
@@ -57,7 +62,7 @@ pub fn process_deposit(
             return Err(VaultError::InvalidDiscriminator.into());
         }
         if etf.paused != 0 {
-            return Err(VaultError::InvalidDiscriminator.into());
+            return Err(VaultError::PoolPaused.into());
         }
         (
             etf.token_count as usize,
@@ -65,11 +70,26 @@ pub fn process_deposit(
             etf.authority,
             etf.weights_bps,
             etf.bump,
+            etf.etf_mint,
+            etf.token_vaults,
         )
     };
 
+    // Validate etf_mint against stored state
+    if etf_mint_ai.key() != &etf_mint {
+        return Err(VaultError::MintMismatch.into());
+    }
+
     if accounts.len() < 5 + tc * 2 {
         return Err(ProgramError::NotEnoughAccountKeys);
+    }
+
+    // Validate each vault against stored state (positions 5+tc..5+2*tc)
+    for i in 0..tc {
+        let vault = &accounts[5 + tc + i];
+        if vault.key() != &token_vaults[i] {
+            return Err(VaultError::VaultMismatch.into());
+        }
     }
 
     let mut token_amounts = [0u64; 5];

--- a/contracts/axis-vault/src/instructions/withdraw.rs
+++ b/contracts/axis-vault/src/instructions/withdraw.rs
@@ -80,6 +80,9 @@ pub fn process_withdraw(
         return Err(ProgramError::NotEnoughAccountKeys);
     }
 
+    // Account layout note: Withdraw puts vaults in [5..5+tc] and user ATAs in
+    // [5+tc..5+2*tc] — the reverse of Deposit, because funds flow vault → user
+    // here. Keep the two in sync.
     for i in 0..tc {
         let vault = &accounts[5 + i];
         if vault.key() != &token_vaults[i] {

--- a/contracts/axis-vault/src/instructions/withdraw.rs
+++ b/contracts/axis-vault/src/instructions/withdraw.rs
@@ -45,18 +45,47 @@ pub fn process_withdraw(
         return Err(ProgramError::MissingRequiredSignature);
     }
 
-    let (tc, total_supply, authority, bump) = {
+    if etf_state_ai.owner() != program_id {
+        return Err(VaultError::InvalidProgramOwner.into());
+    }
+
+    let (tc, total_supply, authority, bump, etf_mint, token_vaults) = {
         let data = etf_state_ai.try_borrow_data()?;
         let etf = unsafe { load::<EtfState>(&data) }
             .ok_or(ProgramError::InvalidAccountData)?;
         if !etf.is_initialized() {
             return Err(VaultError::InvalidDiscriminator.into());
         }
+        if etf.paused != 0 {
+            return Err(VaultError::PoolPaused.into());
+        }
         if etf.total_supply == 0 {
             return Err(VaultError::DivisionByZero.into());
         }
-        (etf.token_count as usize, etf.total_supply, etf.authority, etf.bump)
+        (
+            etf.token_count as usize,
+            etf.total_supply,
+            etf.authority,
+            etf.bump,
+            etf.etf_mint,
+            etf.token_vaults,
+        )
     };
+
+    if etf_mint_ai.key() != &etf_mint {
+        return Err(VaultError::MintMismatch.into());
+    }
+
+    if accounts.len() < 5 + tc * 2 {
+        return Err(ProgramError::NotEnoughAccountKeys);
+    }
+
+    for i in 0..tc {
+        let vault = &accounts[5 + i];
+        if vault.key() != &token_vaults[i] {
+            return Err(VaultError::VaultMismatch.into());
+        }
+    }
 
     if burn_amount > total_supply {
         return Err(VaultError::InsufficientBalance.into());

--- a/test/e2e/axis-vault/axis-vault.local.e2e.ts
+++ b/test/e2e/axis-vault/axis-vault.local.e2e.ts
@@ -477,7 +477,88 @@ async function main() {
     console.log("  Correctly routed through proportional path");
   }
 
-  // 15. Test: Full withdrawal (burn_amount == total_supply) → total_supply goes to 0
+  // 15. Test: Withdraw with wrong etf_mint → MintMismatch (9009 / 0x2331)
+  // Mirrors Test 11 on the Withdraw side. Must run while total_supply > 0,
+  // otherwise the DivisionByZero check in withdraw.rs fires first.
+  console.log("\n> Test: Withdraw with wrong etf_mint (expect MintMismatch)");
+  try {
+    const fakeMint = await createMint(conn, payer, payer.publicKey, null, 6);
+    const badWithdrawData = Buffer.concat([
+      Buffer.from([2]),
+      u64Le(1_000n),
+      Buffer.from([nameBytes.length]),
+      nameBytes,
+    ]);
+    await sendAndConfirmTransaction(conn, new Transaction().add(new TransactionInstruction({
+      programId: PROGRAM_ID,
+      keys: [
+        { pubkey: payer.publicKey, isSigner: true, isWritable: true },
+        { pubkey: etfState, isSigner: false, isWritable: true },
+        { pubkey: fakeMint, isSigner: false, isWritable: true }, // WRONG mint
+        { pubkey: userEtfAta, isSigner: false, isWritable: true },
+        { pubkey: TOKEN_PROGRAM_ID, isSigner: false, isWritable: false },
+        ...vaults.map(v => ({ pubkey: v, isSigner: false, isWritable: true })),
+        ...userTokens.map(u => ({ pubkey: u, isSigner: false, isWritable: true })),
+      ],
+      data: badWithdrawData,
+    })), [payer]);
+    throw new Error("Should have failed but succeeded");
+  } catch (err: any) {
+    const msg = err.message || String(err);
+    // MintMismatch = 9009 = 0x2331
+    if (msg.includes("0x2331") || msg.includes("9009")) {
+      console.log("  Correctly rejected with MintMismatch:", msg.match(/0x[0-9a-f]+/i)?.[0] ?? "9009");
+    } else if (msg === "Should have failed but succeeded") {
+      throw new Error("Withdraw with wrong etf_mint should have failed");
+    } else {
+      console.log("  Rejected with error (unexpected code):", msg.slice(0, 120));
+    }
+  }
+
+  // 16. Test: Withdraw with wrong vault → VaultMismatch (9013 / 0x2335)
+  // Mirrors Test 12 on the Withdraw side. Withdraw's account layout puts
+  // vaults in [5..5+N] (opposite of Deposit), so swap the first vault here.
+  console.log("\n> Test: Withdraw with wrong vault account (expect VaultMismatch)");
+  try {
+    const fakeVault = await createAccount(conn, payer, mints[0], payer.publicKey);
+    const wrongVaults = [fakeVault, vaults[1], vaults[2]];
+    const badWithdrawData = Buffer.concat([
+      Buffer.from([2]),
+      u64Le(1_000n),
+      Buffer.from([nameBytes.length]),
+      nameBytes,
+    ]);
+    await sendAndConfirmTransaction(conn, new Transaction().add(new TransactionInstruction({
+      programId: PROGRAM_ID,
+      keys: [
+        { pubkey: payer.publicKey, isSigner: true, isWritable: true },
+        { pubkey: etfState, isSigner: false, isWritable: true },
+        { pubkey: etfMintKp.publicKey, isSigner: false, isWritable: true },
+        { pubkey: userEtfAta, isSigner: false, isWritable: true },
+        { pubkey: TOKEN_PROGRAM_ID, isSigner: false, isWritable: false },
+        ...wrongVaults.map(v => ({ pubkey: v, isSigner: false, isWritable: true })),
+        ...userTokens.map(u => ({ pubkey: u, isSigner: false, isWritable: true })),
+      ],
+      data: badWithdrawData,
+    })), [payer]);
+    throw new Error("Should have failed but succeeded");
+  } catch (err: any) {
+    const msg = err.message || String(err);
+    // VaultMismatch = 9013 = 0x2335
+    if (msg.includes("0x2335") || msg.includes("9013")) {
+      console.log("  Correctly rejected with VaultMismatch:", msg.match(/0x[0-9a-f]+/i)?.[0] ?? "9013");
+    } else if (msg === "Should have failed but succeeded") {
+      throw new Error("Withdraw with wrong vault should have failed");
+    } else {
+      console.log("  Rejected with error (unexpected code):", msg.slice(0, 120));
+    }
+  }
+
+  // TODO(#33 follow-up): Once axis-vault exposes a SetPaused instruction,
+  // add paused-pool tests for both Deposit and Withdraw. Expected behavior:
+  // etf.paused != 0 → PoolPaused (9012 / 0x2334) on both code paths.
+
+  // 17. Test: Full withdrawal (burn_amount == total_supply) → total_supply goes to 0
   console.log("\n> Test: Full withdrawal drains total_supply to zero");
   {
     const remaining = (await getAccount(conn, userEtfAta)).amount;
@@ -508,7 +589,7 @@ async function main() {
     console.log(`  Burned ${remaining}, total_supply now 0`);
   }
 
-  // 16. Test: CreateEtf with token_count < 2 → InvalidBasketSize (9002 / 0x232A)
+  // 18. Test: CreateEtf with token_count < 2 → InvalidBasketSize (9002 / 0x232A)
   console.log("\n> Test: CreateEtf with token_count=1 (expect InvalidBasketSize)");
   try {
     const badName = Buffer.from("BADSIZE1");
@@ -559,7 +640,7 @@ async function main() {
     }
   }
 
-  // 17. Test: CreateEtf with weights summing ≠ 10_000 → WeightsMismatch (9003 / 0x232B)
+  // 19. Test: CreateEtf with weights summing ≠ 10_000 → WeightsMismatch (9003 / 0x232B)
   console.log("\n> Test: CreateEtf with weights summing to 9999 (expect WeightsMismatch)");
   try {
     const badName = Buffer.from("BADWT01");
@@ -619,7 +700,7 @@ async function main() {
     }
   }
 
-  // 18. Test: CreateEtf duplicate-init (same PDA twice) → AlreadyInitialized or system-level failure
+  // 20. Test: CreateEtf duplicate-init (same PDA twice) → AlreadyInitialized or system-level failure
   // The original ETF PDA (etfState) is already initialized from Step 5. Attempt another CreateEtf
   // targeting the same PDA — must not succeed.
   console.log("\n> Test: CreateEtf duplicate-init on existing PDA (expect error)");

--- a/test/e2e/axis-vault/axis-vault.local.e2e.ts
+++ b/test/e2e/axis-vault/axis-vault.local.e2e.ts
@@ -440,6 +440,240 @@ async function main() {
     }
   }
 
+  // 14. Test: Second deposit (subsequent-depositor proportional-math path)
+  // After Step 7 the pool had total_supply>0; Step 8 halved it. A third
+  // deposit here must go through the `if total_supply != 0` branch and
+  // mint proportional to vault balances (not the base-amount first-deposit path).
+  console.log("\n> Test: Subsequent deposit hits proportional-math path");
+  {
+    const supplyBefore = (await getAccount(conn, userEtfAta)).amount;
+    const totalSupplyBefore = (await conn.getAccountInfo(etfState))!.data.readBigUInt64LE(408);
+    const secondDepositData = Buffer.concat([
+      Buffer.from([1]),
+      u64Le(500_000_000n),  // 500 tokens base
+      Buffer.from([nameBytes.length]),
+      nameBytes,
+    ]);
+    await sendAndConfirmTransaction(conn, new Transaction().add(new TransactionInstruction({
+      programId: PROGRAM_ID,
+      keys: [
+        { pubkey: payer.publicKey, isSigner: true, isWritable: true },
+        { pubkey: etfState, isSigner: false, isWritable: true },
+        { pubkey: etfMintKp.publicKey, isSigner: false, isWritable: true },
+        { pubkey: userEtfAta, isSigner: false, isWritable: true },
+        { pubkey: TOKEN_PROGRAM_ID, isSigner: false, isWritable: false },
+        ...userTokens.map(u => ({ pubkey: u, isSigner: false, isWritable: true })),
+        ...vaults.map(v => ({ pubkey: v, isSigner: false, isWritable: true })),
+      ],
+      data: secondDepositData,
+    })), [payer]);
+    const supplyAfter = (await getAccount(conn, userEtfAta)).amount;
+    const totalSupplyAfter = (await conn.getAccountInfo(etfState))!.data.readBigUInt64LE(408);
+    const minted = supplyAfter - supplyBefore;
+    if (minted === 0n || totalSupplyAfter <= totalSupplyBefore) {
+      throw new Error(`Subsequent deposit didn't mint or total_supply didn't grow (minted=${minted}, before=${totalSupplyBefore}, after=${totalSupplyAfter})`);
+    }
+    console.log(`  Minted on 2nd deposit: ${minted}, total_supply: ${totalSupplyBefore} → ${totalSupplyAfter}`);
+    console.log("  Correctly routed through proportional path");
+  }
+
+  // 15. Test: Full withdrawal (burn_amount == total_supply) → total_supply goes to 0
+  console.log("\n> Test: Full withdrawal drains total_supply to zero");
+  {
+    const remaining = (await getAccount(conn, userEtfAta)).amount;
+    const fullWithdrawData = Buffer.concat([
+      Buffer.from([2]),
+      u64Le(remaining),
+      Buffer.from([nameBytes.length]),
+      nameBytes,
+    ]);
+    await sendAndConfirmTransaction(conn, new Transaction().add(new TransactionInstruction({
+      programId: PROGRAM_ID,
+      keys: [
+        { pubkey: payer.publicKey, isSigner: true, isWritable: true },
+        { pubkey: etfState, isSigner: false, isWritable: true },
+        { pubkey: etfMintKp.publicKey, isSigner: false, isWritable: true },
+        { pubkey: userEtfAta, isSigner: false, isWritable: true },
+        { pubkey: TOKEN_PROGRAM_ID, isSigner: false, isWritable: false },
+        ...vaults.map(v => ({ pubkey: v, isSigner: false, isWritable: true })),
+        ...userTokens.map(u => ({ pubkey: u, isSigner: false, isWritable: true })),
+      ],
+      data: fullWithdrawData,
+    })), [payer]);
+    const etfEnd = (await getAccount(conn, userEtfAta)).amount;
+    const totalSupplyEnd = (await conn.getAccountInfo(etfState))!.data.readBigUInt64LE(408);
+    if (etfEnd !== 0n || totalSupplyEnd !== 0n) {
+      throw new Error(`Full withdrawal didn't zero out balances (etf=${etfEnd}, supply=${totalSupplyEnd})`);
+    }
+    console.log(`  Burned ${remaining}, total_supply now 0`);
+  }
+
+  // 16. Test: CreateEtf with token_count < 2 → InvalidBasketSize (9002 / 0x232A)
+  console.log("\n> Test: CreateEtf with token_count=1 (expect InvalidBasketSize)");
+  try {
+    const badName = Buffer.from("BADSIZE1");
+    const [badPda] = PublicKey.findProgramAddressSync(
+      [Buffer.from("etf"), payer.publicKey.toBuffer(), badName],
+      PROGRAM_ID,
+    );
+    const badMintKp = Keypair.generate();
+    await sendAndConfirmTransaction(conn, new Transaction().add(SystemProgram.createAccount({
+      fromPubkey: payer.publicKey, newAccountPubkey: badMintKp.publicKey,
+      lamports: mintRent, space: MINT_SIZE, programId: TOKEN_PROGRAM_ID,
+    })), [payer, badMintKp]);
+    const badVaultKp = Keypair.generate();
+    await sendAndConfirmTransaction(conn, new Transaction().add(SystemProgram.createAccount({
+      fromPubkey: payer.publicKey, newAccountPubkey: badVaultKp.publicKey,
+      lamports: vaultRent, space: ACCOUNT_SIZE, programId: TOKEN_PROGRAM_ID,
+    })), [payer, badVaultKp]);
+
+    // token_count=1, weights=[10000] — valid weight sum but basket too small
+    const badData = Buffer.concat([
+      Buffer.from([0]), Buffer.from([1]), u16Le(10000),
+      Buffer.from([badName.length]), badName,
+    ]);
+    await sendAndConfirmTransaction(conn, new Transaction().add(new TransactionInstruction({
+      programId: PROGRAM_ID,
+      keys: [
+        { pubkey: payer.publicKey, isSigner: true, isWritable: true },
+        { pubkey: badPda, isSigner: false, isWritable: true },
+        { pubkey: badMintKp.publicKey, isSigner: false, isWritable: true },
+        { pubkey: payer.publicKey, isSigner: false, isWritable: false },
+        { pubkey: SystemProgram.programId, isSigner: false, isWritable: false },
+        { pubkey: TOKEN_PROGRAM_ID, isSigner: false, isWritable: false },
+        { pubkey: mints[0], isSigner: false, isWritable: false },
+        { pubkey: badVaultKp.publicKey, isSigner: false, isWritable: true },
+      ],
+      data: badData,
+    })), [payer]);
+    throw new Error("Should have failed but succeeded");
+  } catch (err: any) {
+    const msg = err.message || String(err);
+    // InvalidBasketSize = 9002 = 0x232A
+    if (msg.includes("0x232a") || msg.includes("9002")) {
+      console.log("  Correctly rejected with InvalidBasketSize:", msg.match(/0x[0-9a-f]+/i)?.[0] ?? "9002");
+    } else if (msg === "Should have failed but succeeded") {
+      throw new Error("CreateEtf token_count=1 should have failed");
+    } else {
+      console.log("  Rejected with error (unexpected code):", msg.slice(0, 120));
+    }
+  }
+
+  // 17. Test: CreateEtf with weights summing ≠ 10_000 → WeightsMismatch (9003 / 0x232B)
+  console.log("\n> Test: CreateEtf with weights summing to 9999 (expect WeightsMismatch)");
+  try {
+    const badName = Buffer.from("BADWT01");
+    const [badPda] = PublicKey.findProgramAddressSync(
+      [Buffer.from("etf"), payer.publicKey.toBuffer(), badName],
+      PROGRAM_ID,
+    );
+    const badMintKp = Keypair.generate();
+    await sendAndConfirmTransaction(conn, new Transaction().add(SystemProgram.createAccount({
+      fromPubkey: payer.publicKey, newAccountPubkey: badMintKp.publicKey,
+      lamports: mintRent, space: MINT_SIZE, programId: TOKEN_PROGRAM_ID,
+    })), [payer, badMintKp]);
+    const badVaultKps: Keypair[] = [];
+    const badVaultsTx = new Transaction();
+    for (let i = 0; i < TOKEN_COUNT; i++) {
+      const kp = Keypair.generate();
+      badVaultKps.push(kp);
+      badVaultsTx.add(SystemProgram.createAccount({
+        fromPubkey: payer.publicKey, newAccountPubkey: kp.publicKey,
+        lamports: vaultRent, space: ACCOUNT_SIZE, programId: TOKEN_PROGRAM_ID,
+      }));
+    }
+    await sendAndConfirmTransaction(conn, badVaultsTx, [payer, ...badVaultKps]);
+
+    // weights sum to 9999 (not 10000)
+    const badWeights = [3333, 3333, 3333];
+    const wbuf = Buffer.alloc(TOKEN_COUNT * 2);
+    for (let i = 0; i < TOKEN_COUNT; i++) wbuf.writeUInt16LE(badWeights[i], i * 2);
+    const badData = Buffer.concat([
+      Buffer.from([0]), Buffer.from([TOKEN_COUNT]), wbuf,
+      Buffer.from([badName.length]), badName,
+    ]);
+    await sendAndConfirmTransaction(conn, new Transaction().add(new TransactionInstruction({
+      programId: PROGRAM_ID,
+      keys: [
+        { pubkey: payer.publicKey, isSigner: true, isWritable: true },
+        { pubkey: badPda, isSigner: false, isWritable: true },
+        { pubkey: badMintKp.publicKey, isSigner: false, isWritable: true },
+        { pubkey: payer.publicKey, isSigner: false, isWritable: false },
+        { pubkey: SystemProgram.programId, isSigner: false, isWritable: false },
+        { pubkey: TOKEN_PROGRAM_ID, isSigner: false, isWritable: false },
+        ...mints.map(m => ({ pubkey: m, isSigner: false, isWritable: false })),
+        ...badVaultKps.map(kp => ({ pubkey: kp.publicKey, isSigner: false, isWritable: true })),
+      ],
+      data: badData,
+    })), [payer]);
+    throw new Error("Should have failed but succeeded");
+  } catch (err: any) {
+    const msg = err.message || String(err);
+    // WeightsMismatch = 9003 = 0x232B
+    if (msg.includes("0x232b") || msg.includes("9003")) {
+      console.log("  Correctly rejected with WeightsMismatch:", msg.match(/0x[0-9a-f]+/i)?.[0] ?? "9003");
+    } else if (msg === "Should have failed but succeeded") {
+      throw new Error("CreateEtf weights=9999 should have failed");
+    } else {
+      console.log("  Rejected with error (unexpected code):", msg.slice(0, 120));
+    }
+  }
+
+  // 18. Test: CreateEtf duplicate-init (same PDA twice) → AlreadyInitialized or system-level failure
+  // The original ETF PDA (etfState) is already initialized from Step 5. Attempt another CreateEtf
+  // targeting the same PDA — must not succeed.
+  console.log("\n> Test: CreateEtf duplicate-init on existing PDA (expect error)");
+  try {
+    const dupMintKp = Keypair.generate();
+    await sendAndConfirmTransaction(conn, new Transaction().add(SystemProgram.createAccount({
+      fromPubkey: payer.publicKey, newAccountPubkey: dupMintKp.publicKey,
+      lamports: mintRent, space: MINT_SIZE, programId: TOKEN_PROGRAM_ID,
+    })), [payer, dupMintKp]);
+    const dupVaultKps: Keypair[] = [];
+    const dupVaultsTx = new Transaction();
+    for (let i = 0; i < TOKEN_COUNT; i++) {
+      const kp = Keypair.generate();
+      dupVaultKps.push(kp);
+      dupVaultsTx.add(SystemProgram.createAccount({
+        fromPubkey: payer.publicKey, newAccountPubkey: kp.publicKey,
+        lamports: vaultRent, space: ACCOUNT_SIZE, programId: TOKEN_PROGRAM_ID,
+      }));
+    }
+    await sendAndConfirmTransaction(conn, dupVaultsTx, [payer, ...dupVaultKps]);
+
+    const dupData = Buffer.concat([
+      Buffer.from([0]), Buffer.from([TOKEN_COUNT]), weightsBuf,
+      Buffer.from([nameBytes.length]), nameBytes, // same name as Step 5 → same PDA
+    ]);
+    await sendAndConfirmTransaction(conn, new Transaction().add(new TransactionInstruction({
+      programId: PROGRAM_ID,
+      keys: [
+        { pubkey: payer.publicKey, isSigner: true, isWritable: true },
+        { pubkey: etfState, isSigner: false, isWritable: true },       // already-init'd PDA
+        { pubkey: dupMintKp.publicKey, isSigner: false, isWritable: true },
+        { pubkey: payer.publicKey, isSigner: false, isWritable: false },
+        { pubkey: SystemProgram.programId, isSigner: false, isWritable: false },
+        { pubkey: TOKEN_PROGRAM_ID, isSigner: false, isWritable: false },
+        ...mints.map(m => ({ pubkey: m, isSigner: false, isWritable: false })),
+        ...dupVaultKps.map(kp => ({ pubkey: kp.publicKey, isSigner: false, isWritable: true })),
+      ],
+      data: dupData,
+    })), [payer]);
+    throw new Error("Should have failed but succeeded");
+  } catch (err: any) {
+    const msg = err.message || String(err);
+    // AlreadyInitialized = 9001 = 0x2329. Accept either the custom code
+    // or the system-level "account already in use" since CreateAccount
+    // may fail first depending on execution order.
+    if (msg.includes("0x2329") || msg.includes("9001") || msg.includes("already in use")) {
+      console.log("  Correctly rejected:", msg.match(/0x[0-9a-f]+/i)?.[0] ?? "already-initialized");
+    } else if (msg === "Should have failed but succeeded") {
+      throw new Error("CreateEtf duplicate-init should have failed");
+    } else {
+      console.log("  Rejected with error (unexpected code):", msg.slice(0, 120));
+    }
+  }
+
   console.log("\n=== Vault E2E PASSED ===");
 }
 main().catch(err => { console.error("Error:", err.message || err); process.exit(1); });

--- a/test/e2e/axis-vault/axis-vault.local.e2e.ts
+++ b/test/e2e/axis-vault/axis-vault.local.e2e.ts
@@ -329,6 +329,117 @@ async function main() {
     }
   }
 
+  // 11. Test: Deposit with wrong etf_mint → MintMismatch (9009 / 0x2331)
+  console.log("\n> Test: Deposit with wrong etf_mint (expect MintMismatch)");
+  try {
+    const fakeMint = await createMint(conn, payer, payer.publicKey, null, 6);
+    const badDepositData = Buffer.concat([
+      Buffer.from([1]),
+      u64Le(100_000_000n),
+      Buffer.from([nameBytes.length]),
+      nameBytes,
+    ]);
+    await sendAndConfirmTransaction(conn, new Transaction().add(new TransactionInstruction({
+      programId: PROGRAM_ID,
+      keys: [
+        { pubkey: payer.publicKey, isSigner: true, isWritable: true },
+        { pubkey: etfState, isSigner: false, isWritable: true },
+        { pubkey: fakeMint, isSigner: false, isWritable: true }, // WRONG mint
+        { pubkey: userEtfAta, isSigner: false, isWritable: true },
+        { pubkey: TOKEN_PROGRAM_ID, isSigner: false, isWritable: false },
+        ...userTokens.map(u => ({ pubkey: u, isSigner: false, isWritable: true })),
+        ...vaults.map(v => ({ pubkey: v, isSigner: false, isWritable: true })),
+      ],
+      data: badDepositData,
+    })), [payer]);
+    throw new Error("Should have failed but succeeded");
+  } catch (err: any) {
+    const msg = err.message || String(err);
+    // MintMismatch = 9009 = 0x2331
+    if (msg.includes("0x2331") || msg.includes("9009")) {
+      console.log("  Correctly rejected with MintMismatch:", msg.match(/0x[0-9a-f]+/i)?.[0] ?? "9009");
+    } else if (msg === "Should have failed but succeeded") {
+      throw new Error("Deposit with wrong etf_mint should have failed");
+    } else {
+      console.log("  Rejected with error (unexpected code):", msg.slice(0, 120));
+    }
+  }
+
+  // 12. Test: Deposit with wrong vault → VaultMismatch (9013 / 0x2335)
+  console.log("\n> Test: Deposit with wrong vault account (expect VaultMismatch)");
+  try {
+    // Create a vault-like token account owned by payer (not the EtfState PDA) for mint[0]
+    const fakeVault = await createAccount(conn, payer, mints[0], payer.publicKey);
+    const wrongVaults = [fakeVault, vaults[1], vaults[2]];
+    const badDepositData = Buffer.concat([
+      Buffer.from([1]),
+      u64Le(100_000_000n),
+      Buffer.from([nameBytes.length]),
+      nameBytes,
+    ]);
+    await sendAndConfirmTransaction(conn, new Transaction().add(new TransactionInstruction({
+      programId: PROGRAM_ID,
+      keys: [
+        { pubkey: payer.publicKey, isSigner: true, isWritable: true },
+        { pubkey: etfState, isSigner: false, isWritable: true },
+        { pubkey: etfMintKp.publicKey, isSigner: false, isWritable: true },
+        { pubkey: userEtfAta, isSigner: false, isWritable: true },
+        { pubkey: TOKEN_PROGRAM_ID, isSigner: false, isWritable: false },
+        ...userTokens.map(u => ({ pubkey: u, isSigner: false, isWritable: true })),
+        ...wrongVaults.map(v => ({ pubkey: v, isSigner: false, isWritable: true })),
+      ],
+      data: badDepositData,
+    })), [payer]);
+    throw new Error("Should have failed but succeeded");
+  } catch (err: any) {
+    const msg = err.message || String(err);
+    // VaultMismatch = 9013 = 0x2335
+    if (msg.includes("0x2335") || msg.includes("9013")) {
+      console.log("  Correctly rejected with VaultMismatch:", msg.match(/0x[0-9a-f]+/i)?.[0] ?? "9013");
+    } else if (msg === "Should have failed but succeeded") {
+      throw new Error("Deposit with wrong vault should have failed");
+    } else {
+      console.log("  Rejected with error (unexpected code):", msg.slice(0, 120));
+    }
+  }
+
+  // 13. Test: Withdraw with fake etf_state (wrong program owner) → InvalidProgramOwner (9014 / 0x2336)
+  console.log("\n> Test: Withdraw with non-program-owned etf_state (expect InvalidProgramOwner)");
+  try {
+    // Any account not owned by the vault program — use the ETF mint account (owned by token program)
+    const fakeState = etfMintKp.publicKey;
+    const badWithdrawData = Buffer.concat([
+      Buffer.from([2]),
+      u64Le(1_000n),
+      Buffer.from([nameBytes.length]),
+      nameBytes,
+    ]);
+    await sendAndConfirmTransaction(conn, new Transaction().add(new TransactionInstruction({
+      programId: PROGRAM_ID,
+      keys: [
+        { pubkey: payer.publicKey, isSigner: true, isWritable: true },
+        { pubkey: fakeState, isSigner: false, isWritable: true }, // WRONG: not program-owned
+        { pubkey: etfMintKp.publicKey, isSigner: false, isWritable: true },
+        { pubkey: userEtfAta, isSigner: false, isWritable: true },
+        { pubkey: TOKEN_PROGRAM_ID, isSigner: false, isWritable: false },
+        ...vaults.map(v => ({ pubkey: v, isSigner: false, isWritable: true })),
+        ...userTokens.map(u => ({ pubkey: u, isSigner: false, isWritable: true })),
+      ],
+      data: badWithdrawData,
+    })), [payer]);
+    throw new Error("Should have failed but succeeded");
+  } catch (err: any) {
+    const msg = err.message || String(err);
+    // InvalidProgramOwner = 9014 = 0x2336
+    if (msg.includes("0x2336") || msg.includes("9014")) {
+      console.log("  Correctly rejected with InvalidProgramOwner:", msg.match(/0x[0-9a-f]+/i)?.[0] ?? "9014");
+    } else if (msg === "Should have failed but succeeded") {
+      throw new Error("Withdraw with non-program-owned etf_state should have failed");
+    } else {
+      console.log("  Rejected with error (unexpected code):", msg.slice(0, 120));
+    }
+  }
+
   console.log("\n=== Vault E2E PASSED ===");
 }
 main().catch(err => { console.error("Error:", err.message || err); process.exit(1); });


### PR DESCRIPTION
Closes #33 (axis-vault items).

## Summary

`Deposit` and `Withdraw` trusted the passed `etf_mint`, vault accounts, and `etf_state` blindly. This PR plugs those gaps and adds matching e2e coverage.

## Bugs fixed (from #33 axis-vault list)

- **`Deposit` / `Withdraw` — `etf_mint_ai` and vault accounts not validated against stored state.** Both instructions now compare `etf_mint_ai.key()` against `etf.etf_mint` and each vault against `etf.token_vaults[i]`.
- **`Deposit` / `Withdraw` — `etf_state_ai` program ownership not verified.** An account carrying `etfstate` discriminator bytes but owned by a different program would previously deserialize fine. Both instructions now assert `etf_state_ai.owner() == program_id` up front.
- **`Withdraw` — no `paused` check.** Withdraw now rejects when `etf.paused != 0`, matching Deposit. (`axis-vault` still lacks a `SetPaused` instruction so this is latent protection for when it lands, but it closes the code-path asymmetry.)
- **Side fix:** Deposit's paused check returned `InvalidDiscriminator` (9000) — confusing code for a pause condition. Now returns `PoolPaused`.

## New error codes

| Code | Name | Meaning |
|------|------|---------|
| 9012 | `PoolPaused` | `etf.paused != 0` |
| 9013 | `VaultMismatch` | vault account didn't match `etf.token_vaults[i]` |
| 9014 | `InvalidProgramOwner` | `etf_state_ai.owner() != program_id` |

## Out of scope (tracked in #33 but deferred)

- `Deposit` — `treasury_etf_ata` check against `etf.treasury` — the treasury account only appears on PR #32's branch, not main. Will be addressed there.
- `Withdraw` — fee design inconsistency with Deposit — same: fee path is introduced by PR #32.
- Paused-pool e2e scenarios for Deposit/Withdraw — blocked on a `SetPaused` instruction landing for `axis-vault` (no way to flip `etf.paused` on-chain today). TODO comment added in the e2e file.

## Test plan

- [x] `cargo build -p axis-vault` passes clean
- [ ] Devnet e2e `test/e2e/axis-vault/axis-vault.local.e2e.ts` — requires this PR's program to be redeployed to devnet first. Scenarios covered (Tests 11–20):
  - 11. Deposit with wrong `etf_mint` → `MintMismatch` (9009 / 0x2331)
  - 12. Deposit with attacker-owned token account in vault slot → `VaultMismatch` (9013 / 0x2335)
  - 13. Withdraw with non-program-owned `etf_state` → `InvalidProgramOwner` (9014 / 0x2336)
  - 14. Subsequent deposit hits the proportional-math branch (not just the first-depositor path)
  - 15. Withdraw with wrong `etf_mint` → `MintMismatch` (9009 / 0x2331) *(added from review)*
  - 16. Withdraw with attacker-owned token account in vault slot → `VaultMismatch` (9013 / 0x2335) *(added from review)*
  - 17. Full withdrawal (`burn_amount == total_supply`) drains `total_supply` to 0
  - 18. CreateEtf with `token_count = 1` → `InvalidBasketSize` (9002 / 0x232A)
  - 19. CreateEtf with weights summing to 9999 → `WeightsMismatch` (9003 / 0x232B)
  - 20. CreateEtf duplicate-init on an existing PDA → rejected
- [ ] Reviewer sanity-check the paused/owner symmetry between Deposit and Withdraw

## Addressed in follow-up commit (from @kidneyweakx review)

- Added Withdraw-side `MintMismatch` and `VaultMismatch` e2e coverage (Tests 15 & 16).
- TODO comment in the e2e file for paused-pool tests once `SetPaused` lands.
- Inline comments in `deposit.rs` / `withdraw.rs` calling out the opposite `[5..5+N]` vs `[5+N..5+2N]` account ordering between the two instructions.
- Test plan above now lists all ten new e2e scenarios instead of the original three.