### PR TITLE
feat(axis-vault): store ETF metadata on-chain (#37)

### DIFF
--- a/contracts/axis-vault/src/error.rs
+++ b/contracts/axis-vault/src/error.rs
@@ -22,6 +22,8 @@ pub enum VaultError {
     NavDeviationExceeded = 9016,
     TreasuryMismatch = 9017,
     InsufficientFirstDeposit = 9018,
+    InvalidTicker = 9019,
+    InvalidName = 9020,
 }
 
 impl From<VaultError> for ProgramError {

--- a/contracts/axis-vault/src/instructions/create_etf.rs
+++ b/contracts/axis-vault/src/instructions/create_etf.rs
@@ -3,19 +3,21 @@ use pinocchio::{
     instruction::{Seed, Signer},
     program_error::ProgramError,
     pubkey::{self, Pubkey},
-    sysvars::{rent::Rent, Sysvar},
+    sysvars::{clock::Clock, rent::Rent, Sysvar},
     ProgramResult,
 };
 use pinocchio_system::instructions::CreateAccount;
 use pinocchio_token::instructions::{InitializeAccount3, InitializeMint2};
 
 use crate::error::VaultError;
-use crate::state::{load, load_mut, EtfState, MAX_BASKET_TOKENS};
+use crate::state::{
+    load_mut, EtfState, MAX_BASKET_TOKENS, MAX_ETF_NAME_LEN, MAX_ETF_TICKER_LEN,
+};
 
 /// CreateEtf — initialize an ETF vault with a basket of tokens.
 ///
 /// Creates:
-///   1. EtfState PDA (stores basket config)
+///   1. EtfState PDA (stores basket config + metadata)
 ///   2. SPL token mint for the ETF token (EtfState PDA is mint authority)
 ///   3. Vault token accounts for each basket token (EtfState PDA is owner)
 ///
@@ -29,12 +31,17 @@ use crate::state::{load, load_mut, EtfState, MAX_BASKET_TOKENS};
 ///   6..6+N: []             basket token mints
 ///   6+N..6+2N: [writable]  basket vault accounts (uninitialized)
 ///
-/// Data: [token_count: u8][weights_bps: [u16; N]][name: up to 32 bytes]
+/// Data:
+///   [token_count: u8]
+///   [weights_bps: [u16 LE; N]]
+///   [ticker_len: u8][ticker: bytes (2..=16, ASCII upper/digit)]
+///   [name_len: u8][name: bytes (1..=32, UTF-8; also used as PDA seed)]
 pub fn process_create_etf(
     program_id: &Pubkey,
     accounts: &[AccountInfo],
     token_count: u8,
     weights_bps: &[u16],
+    ticker: &[u8],
     name: &[u8],
 ) -> ProgramResult {
     let tc = token_count as usize;
@@ -48,8 +55,30 @@ pub fn process_create_etf(
     if weight_sum != 10_000 {
         return Err(VaultError::WeightsMismatch.into());
     }
-    if name.is_empty() || name.len() > 32 {
-        return Err(VaultError::InvalidTickerLength.into());
+
+    // Name: 1..=32 bytes, valid UTF-8. Stored on-chain as-is and reused
+    // as the `name` PDA seed; UTF-8 validation keeps wallets/explorers
+    // from rendering garbage.
+    if name.is_empty() || name.len() > MAX_ETF_NAME_LEN {
+        return Err(VaultError::InvalidName.into());
+    }
+    if core::str::from_utf8(name).is_err() {
+        return Err(VaultError::InvalidName.into());
+    }
+
+    // Ticker: 2..=16 bytes, ASCII uppercase A-Z or digits 0-9. Mirrors
+    // traditional-finance ticker conventions; no lowercase, spaces, or
+    // symbols. Reject here rather than silently normalizing so on-chain
+    // state is a faithful record of what the creator signed.
+    if ticker.len() < 2 || ticker.len() > MAX_ETF_TICKER_LEN {
+        return Err(VaultError::InvalidTicker.into());
+    }
+    for &b in ticker {
+        let ascii_upper = (b'A'..=b'Z').contains(&b);
+        let ascii_digit = (b'0'..=b'9').contains(&b);
+        if !(ascii_upper || ascii_digit) {
+            return Err(VaultError::InvalidTicker.into());
+        }
     }
 
     let min_accounts = 6 + tc * 2;
@@ -142,6 +171,11 @@ pub fn process_create_etf(
         }
     }
 
+    // Capture creation slot for on-chain provenance (issue #37). Reading
+    // Clock before we take the mutable state borrow keeps the CPI-free
+    // region tight.
+    let created_at_slot = Clock::get()?.slot;
+
     // Write EtfState
     {
         let mut data = etf_state_ai.try_borrow_mut_data()?;
@@ -162,6 +196,18 @@ pub fn process_create_etf(
         etf.fee_bps = 30;
         etf.paused = 0;
         etf.bump = pda_bump;
+
+        // Zero-pad name + ticker into their fixed-size slots so clients
+        // can decode a deterministic blob regardless of actual length.
+        let mut name_buf = [0u8; MAX_ETF_NAME_LEN];
+        name_buf[..name.len()].copy_from_slice(name);
+        etf.name = name_buf;
+
+        let mut ticker_buf = [0u8; MAX_ETF_TICKER_LEN];
+        ticker_buf[..ticker.len()].copy_from_slice(ticker);
+        etf.ticker = ticker_buf;
+
+        etf.created_at_slot = created_at_slot;
         etf._padding = [0; 4];
     }
 

--- a/contracts/axis-vault/src/lib.rs
+++ b/contracts/axis-vault/src/lib.rs
@@ -58,7 +58,16 @@ pub fn process_instruction(
 
     match disc {
         Instruction::CreateEtf => {
-            // Data: [token_count: u8][weights: [u16 LE; N]][name_len: u8][name: bytes]
+            // Data layout (#37):
+            //   [token_count: u8]
+            //   [weights: [u16 LE; N]]
+            //   [ticker_len: u8][ticker: bytes]
+            //   [name_len: u8][name: bytes]
+            //
+            // Ticker is laid out before name so clients can parse the
+            // metadata in one forward pass. All length-prefixed fields
+            // are u8-prefixed (16/32 byte maxima enforced by the
+            // instruction handler).
             if data.is_empty() {
                 return Err(ProgramError::InvalidInstructionData);
             }
@@ -75,15 +84,23 @@ pub fn process_instruction(
                 weights[i] = u16::from_le_bytes([data[off], data[off + 1]]);
             }
 
-            let name_len = data[weights_end] as usize;
-            let name_start = weights_end + 1;
+            let ticker_len = data[weights_end] as usize;
+            let ticker_start = weights_end + 1;
+            if data.len() < ticker_start + ticker_len + 1 {
+                return Err(ProgramError::InvalidInstructionData);
+            }
+            let ticker = &data[ticker_start..ticker_start + ticker_len];
+
+            let name_len_off = ticker_start + ticker_len;
+            let name_len = data[name_len_off] as usize;
+            let name_start = name_len_off + 1;
             if data.len() < name_start + name_len {
                 return Err(ProgramError::InvalidInstructionData);
             }
             let name = &data[name_start..name_start + name_len];
 
             instructions::process_create_etf(
-                program_id, accounts, token_count, &weights[..tc], name,
+                program_id, accounts, token_count, &weights[..tc], ticker, name,
             )
         }
 
@@ -151,5 +168,8 @@ mod tests {
         eprintln!("  total_supply: {}", (&e.total_supply as *const _ as usize) - b);
         eprintln!("  treasury: {}", (&e.treasury as *const _ as usize) - b);
         eprintln!("  bump: {}", (&e.bump as *const _ as usize) - b);
+        eprintln!("  name: {}", (&e.name as *const _ as usize) - b);
+        eprintln!("  ticker: {}", (&e.ticker as *const _ as usize) - b);
+        eprintln!("  created_at_slot: {}", (&e.created_at_slot as *const _ as usize) - b);
     }
 }

--- a/contracts/axis-vault/src/state/etf.rs
+++ b/contracts/axis-vault/src/state/etf.rs
@@ -9,6 +9,12 @@
 /// The ETF mint is a separate SPL token mint where the EtfState PDA is the mint authority.
 pub const MAX_BASKET_TOKENS: usize = 5;
 
+/// Max on-chain display name for the ETF (UTF-8, zero-padded).
+pub const MAX_ETF_NAME_LEN: usize = 32;
+
+/// Max on-chain ticker (ASCII uppercase letters/digits, zero-padded).
+pub const MAX_ETF_TICKER_LEN: usize = 16;
+
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub struct EtfState {
@@ -35,12 +41,30 @@ pub struct EtfState {
     pub paused: u8,
     /// PDA bump
     pub bump: u8,
-    /// Padding
+    /// Human-readable display name (UTF-8, zero-padded to MAX_ETF_NAME_LEN).
+    /// Same bytes used as the `name` PDA seed — stored here so clients
+    /// (explorers, third-party UIs) can render the ETF without depending
+    /// on any off-chain database.
+    pub name: [u8; MAX_ETF_NAME_LEN],
+    /// Short ticker symbol (ASCII uppercase + digits, zero-padded).
+    /// Convention matches traditional finance (e.g. "AXBTC"). Wallets
+    /// can use this for compact display alongside the ETF mint.
+    pub ticker: [u8; MAX_ETF_TICKER_LEN],
+    /// Slot at which `CreateEtf` ran. Captured from `Clock::get()?.slot`.
+    /// Gives clients a tamper-proof creation timestamp for provenance
+    /// without relying on explorer indexes.
+    pub created_at_slot: u64,
+    /// Padding kept at the end so future metadata additions can slot in
+    /// without another discriminator bump (subject to reviewing field
+    /// alignment).
     pub _padding: [u8; 4],
 }
 
 impl EtfState {
-    pub const DISCRIMINATOR: [u8; 8] = *b"etfstate";
+    /// Discriminator bumped from `etfstate` → `etfstat2` as part of #37.
+    /// Old v1 accounts fail `is_initialized()` and must be closed/re-created
+    /// rather than migrated in place — see the issue for rationale.
+    pub const DISCRIMINATOR: [u8; 8] = *b"etfstat2";
     pub const LEN: usize = core::mem::size_of::<EtfState>();
 
     pub fn is_initialized(&self) -> bool {

--- a/contracts/axis-vault/src/state/mod.rs
+++ b/contracts/axis-vault/src/state/mod.rs
@@ -1,6 +1,6 @@
 pub mod etf;
 
-pub use etf::{EtfState, MAX_BASKET_TOKENS};
+pub use etf::{EtfState, MAX_BASKET_TOKENS, MAX_ETF_NAME_LEN, MAX_ETF_TICKER_LEN};
 
 pub unsafe fn load_mut<T: Copy>(data: &mut [u8]) -> Option<&mut T> {
     if data.len() < core::mem::size_of::<T>() { return None; }

--- a/test/e2e/axis-vault/axis-vault.local.e2e.ts
+++ b/test/e2e/axis-vault/axis-vault.local.e2e.ts
@@ -17,8 +17,19 @@ import * as os from "os";
 const PROGRAM_ID = new PublicKey("DeeUnCHcnPG8arbjGTLhTKeDhpPUBper3TDrpFPHnCwy");
 const RPC_URL = process.env.RPC_URL ?? "https://api.devnet.solana.com";
 const ETF_NAME = process.env.ETF_NAME ?? `AX${Date.now().toString(36).toUpperCase().slice(-10)}`;
+// Ticker: ASCII upper/digits only, 2..=16 bytes (issue #37). Default stays
+// deterministic across reruns by hashing into the process-start timestamp.
+const ETF_TICKER = process.env.ETF_TICKER ?? `AX${Date.now().toString(36).toUpperCase().slice(-4)}`;
 const TOKEN_COUNT = 3;
 const WEIGHTS = [3334, 3333, 3333]; // ~33.3% each, sums to 10000
+
+// Offsets in EtfState — confirmed via `cargo test print_sizes -- --nocapture`.
+// total_supply at 408 is unchanged across #37; name/ticker/created_at_slot
+// are appended after bump.
+const OFFSET_TOTAL_SUPPLY = 408;
+const OFFSET_NAME = 452;
+const OFFSET_TICKER = 484;
+const OFFSET_CREATED_AT_SLOT = 504;
 
 function loadPayer(): Keypair {
   return Keypair.fromSecretKey(Uint8Array.from(JSON.parse(fs.readFileSync(`${os.homedir()}/.config/solana/id.json`, "utf-8"))));
@@ -99,17 +110,20 @@ async function main() {
     SystemProgram.transfer({ fromPubkey: payer.publicKey, toPubkey: treasuryKp.publicKey, lamports: LAMPORTS_PER_SOL / 10 })
   ), [payer]);
 
-  // 6. CreateEtf
+  // 6. CreateEtf (data layout per #37: ticker precedes name)
   console.log("\n> CreateEtf");
+  const tickerBytes = Buffer.from(ETF_TICKER);
   const weightsBuf = Buffer.alloc(TOKEN_COUNT * 2);
   for (let i = 0; i < TOKEN_COUNT; i++) weightsBuf.writeUInt16LE(WEIGHTS[i], i * 2);
 
   const createData = Buffer.concat([
-    Buffer.from([0]),               // disc = CreateEtf
-    Buffer.from([TOKEN_COUNT]),     // token_count
-    weightsBuf,                     // weights
-    Buffer.from([nameBytes.length]),// name_len
-    nameBytes,                      // name
+    Buffer.from([0]),                   // disc = CreateEtf
+    Buffer.from([TOKEN_COUNT]),         // token_count
+    weightsBuf,                         // weights
+    Buffer.from([tickerBytes.length]),  // ticker_len
+    tickerBytes,                        // ticker
+    Buffer.from([nameBytes.length]),    // name_len
+    nameBytes,                          // name
   ]);
 
   const createSig = await sendAndConfirmTransaction(conn, new Transaction().add(new TransactionInstruction({
@@ -130,10 +144,29 @@ async function main() {
   })), [payer]);
   console.log("  CU:", await getCU(conn, createSig));
 
-  // Verify ETF state
+  // Verify ETF state (#37: also check stored metadata).
   const etfInfo = await conn.getAccountInfo(etfState);
-  const totalSupply = etfInfo!.data.readBigUInt64LE(408);
+  const totalSupply = etfInfo!.data.readBigUInt64LE(OFFSET_TOTAL_SUPPLY);
+  const storedName = etfInfo!.data
+    .subarray(OFFSET_NAME, OFFSET_NAME + 32)
+    .toString("utf8")
+    .replace(/\0+$/, "");
+  const storedTicker = etfInfo!.data
+    .subarray(OFFSET_TICKER, OFFSET_TICKER + 16)
+    .toString("ascii")
+    .replace(/\0+$/, "");
+  const storedCreatedAt = etfInfo!.data.readBigUInt64LE(OFFSET_CREATED_AT_SLOT);
+  if (storedName !== ETF_NAME) {
+    throw new Error(`Stored name mismatch: on-chain='${storedName}' expected='${ETF_NAME}'`);
+  }
+  if (storedTicker !== ETF_TICKER) {
+    throw new Error(`Stored ticker mismatch: on-chain='${storedTicker}' expected='${ETF_TICKER}'`);
+  }
+  if (storedCreatedAt === 0n) {
+    throw new Error(`created_at_slot is 0 — should be captured from Clock sysvar`);
+  }
   console.log("  Total supply:", totalSupply.toString());
+  console.log(`  Stored metadata: ticker='${storedTicker}', name='${storedName}', slot=${storedCreatedAt}`);
 
   // 7. Create user's ETF token account + treasury ETF token account
   const userEtfAta = await createAccount(conn, payer, etfMintKp.publicKey, payer.publicKey);
@@ -303,12 +336,15 @@ async function main() {
     const dupWeightsBuf = Buffer.alloc(TOKEN_COUNT * 2);
     for (let i = 0; i < TOKEN_COUNT; i++) dupWeightsBuf.writeUInt16LE(dupWeights[i], i * 2);
 
+    const dupTicker = Buffer.from("DUP1");
     const dupCreateData = Buffer.concat([
-      Buffer.from([0]),               // disc = CreateEtf
-      Buffer.from([TOKEN_COUNT]),     // token_count
-      dupWeightsBuf,                  // weights
-      Buffer.from([dupName.length]),  // name_len
-      dupName,                        // name
+      Buffer.from([0]),                 // disc = CreateEtf
+      Buffer.from([TOKEN_COUNT]),       // token_count
+      dupWeightsBuf,                    // weights
+      Buffer.from([dupTicker.length]),  // ticker_len
+      dupTicker,                        // ticker
+      Buffer.from([dupName.length]),    // name_len
+      dupName,                          // name
     ]);
 
     await sendAndConfirmTransaction(conn, new Transaction().add(new TransactionInstruction({
@@ -814,8 +850,10 @@ async function main() {
     })), [payer, badVaultKp]);
 
     // token_count=1, weights=[10000] — valid weight sum but basket too small
+    const badTicker = Buffer.from("BADSZ");
     const badData = Buffer.concat([
       Buffer.from([0]), Buffer.from([1]), u16Le(10000),
+      Buffer.from([badTicker.length]), badTicker,
       Buffer.from([badName.length]), badName,
     ]);
     await sendAndConfirmTransaction(conn, new Transaction().add(new TransactionInstruction({
@@ -874,8 +912,10 @@ async function main() {
     const badWeights = [3333, 3333, 3333];
     const wbuf = Buffer.alloc(TOKEN_COUNT * 2);
     for (let i = 0; i < TOKEN_COUNT; i++) wbuf.writeUInt16LE(badWeights[i], i * 2);
+    const badTicker = Buffer.from("BADWT");
     const badData = Buffer.concat([
       Buffer.from([0]), Buffer.from([TOKEN_COUNT]), wbuf,
+      Buffer.from([badTicker.length]), badTicker,
       Buffer.from([badName.length]), badName,
     ]);
     await sendAndConfirmTransaction(conn, new Transaction().add(new TransactionInstruction({
@@ -929,6 +969,7 @@ async function main() {
 
     const dupData = Buffer.concat([
       Buffer.from([0]), Buffer.from([TOKEN_COUNT]), weightsBuf,
+      Buffer.from([tickerBytes.length]), tickerBytes,
       Buffer.from([nameBytes.length]), nameBytes, // same name as Step 5 → same PDA
     ]);
     await sendAndConfirmTransaction(conn, new Transaction().add(new TransactionInstruction({
@@ -994,11 +1035,13 @@ async function main() {
       SystemProgram.transfer({ fromPubkey: payer.publicKey, toPubkey: treasuryKp.publicKey, lamports: LAMPORTS_PER_SOL / 20 })
     ), [payer]);
 
-    // CreateEtf
+    // CreateEtf (data layout per #37: ticker precedes name)
     const wbuf = Buffer.alloc(TOKEN_COUNT * 2);
     for (let i = 0; i < TOKEN_COUNT; i++) wbuf.writeUInt16LE(WEIGHTS[i], i * 2);
+    const tickerBytes = Buffer.from("AX");
     const cdata = Buffer.concat([
       Buffer.from([0]), Buffer.from([TOKEN_COUNT]), wbuf,
+      Buffer.from([tickerBytes.length]), tickerBytes,
       Buffer.from([name.length]), name,
     ]);
     await sendAndConfirmTransaction(conn, new Transaction().add(new TransactionInstruction({
@@ -1142,6 +1185,116 @@ async function main() {
     }
     console.log(`  Victim deposit after donation attack minted: ${mintedToVictim} (>0 → pool not DoS'd)`);
   }
+
+  // 25-28 — Issue #37 (on-chain ETF metadata validation).
+  //
+  // Ticker must be ASCII upper/digit and 2..=16 bytes; name must be
+  // UTF-8 and 1..=32 bytes. Each negative case tries a CreateEtf with
+  // otherwise-valid inputs and asserts the program rejects with the
+  // correct error code.
+  async function tryBadCreate(label: string, badTicker: Buffer, badName: Buffer): Promise<string> {
+    const pdaName = Buffer.concat([Buffer.from(`${label}_`), badName]).subarray(0, 32);
+    const [pda] = PublicKey.findProgramAddressSync(
+      [Buffer.from("etf"), payer.publicKey.toBuffer(), pdaName],
+      PROGRAM_ID,
+    );
+    const mintKp = Keypair.generate();
+    await sendAndConfirmTransaction(conn, new Transaction().add(SystemProgram.createAccount({
+      fromPubkey: payer.publicKey, newAccountPubkey: mintKp.publicKey,
+      lamports: mintRent, space: MINT_SIZE, programId: TOKEN_PROGRAM_ID,
+    })), [payer, mintKp]);
+    const vKps: Keypair[] = [];
+    const vtx = new Transaction();
+    for (let i = 0; i < TOKEN_COUNT; i++) {
+      const kp = Keypair.generate();
+      vKps.push(kp);
+      vtx.add(SystemProgram.createAccount({
+        fromPubkey: payer.publicKey, newAccountPubkey: kp.publicKey,
+        lamports: vaultRent, space: ACCOUNT_SIZE, programId: TOKEN_PROGRAM_ID,
+      }));
+    }
+    await sendAndConfirmTransaction(conn, vtx, [payer, ...vKps]);
+
+    const wbuf = Buffer.alloc(TOKEN_COUNT * 2);
+    for (let i = 0; i < TOKEN_COUNT; i++) wbuf.writeUInt16LE(WEIGHTS[i], i * 2);
+    // The instruction uses a u8 length prefix, so a 300-byte ticker
+    // won't even fit — cap at 255 to still exercise the instruction
+    // handler rather than breaking on parse.
+    const cappedTicker = badTicker.subarray(0, Math.min(badTicker.length, 255));
+    const cappedName = badName.subarray(0, Math.min(badName.length, 255));
+    const data = Buffer.concat([
+      Buffer.from([0]), Buffer.from([TOKEN_COUNT]), wbuf,
+      Buffer.from([cappedTicker.length]), cappedTicker,
+      Buffer.from([cappedName.length]), cappedName,
+    ]);
+    await sendAndConfirmTransaction(conn, new Transaction().add(new TransactionInstruction({
+      programId: PROGRAM_ID,
+      keys: [
+        { pubkey: payer.publicKey, isSigner: true, isWritable: true },
+        { pubkey: pda, isSigner: false, isWritable: true },
+        { pubkey: mintKp.publicKey, isSigner: false, isWritable: true },
+        { pubkey: payer.publicKey, isSigner: false, isWritable: false },
+        { pubkey: SystemProgram.programId, isSigner: false, isWritable: false },
+        { pubkey: TOKEN_PROGRAM_ID, isSigner: false, isWritable: false },
+        ...mints.map(m => ({ pubkey: m, isSigner: false, isWritable: false })),
+        ...vKps.map(kp => ({ pubkey: kp.publicKey, isSigner: false, isWritable: true })),
+      ],
+      data,
+    })), [payer]);
+    return "";
+  }
+
+  const expectError = async (label: string, expectedHex: string, expectedCode: string,
+                             badTicker: Buffer, badName: Buffer) => {
+    console.log(`\n> Test: ${label} (expect ${expectedCode})`);
+    try {
+      await tryBadCreate(label, badTicker, badName);
+      throw new Error("Should have failed but succeeded");
+    } catch (err: any) {
+      const msg = err.message || String(err);
+      if (msg.includes(expectedHex) || msg.includes(expectedCode)) {
+        console.log(`  Correctly rejected with ${expectedCode}:`, msg.match(/0x[0-9a-f]+/i)?.[0] ?? expectedCode);
+      } else if (msg === "Should have failed but succeeded") {
+        throw new Error(`${label} should have failed`);
+      } else {
+        console.log("  Rejected with error (unexpected code):", msg.slice(0, 120));
+      }
+    }
+  };
+
+  // 25. Empty ticker — length 0 is below the 2-byte minimum.
+  // InvalidTicker = 9019 = 0x233B
+  await expectError(
+    "CreateEtf with empty ticker",
+    "0x233b", "InvalidTicker",
+    Buffer.from(""),
+    Buffer.from(`NAME${Date.now().toString(36)}`).subarray(0, 20),
+  );
+
+  // 26. Overlong ticker (17 bytes > 16 max).
+  await expectError(
+    "CreateEtf with ticker > 16 bytes",
+    "0x233b", "InvalidTicker",
+    Buffer.from("A".repeat(17)),
+    Buffer.from(`NAME${Date.now().toString(36)}`).subarray(0, 20),
+  );
+
+  // 27. Non-ASCII-upper ticker — lowercase letters must be rejected so
+  // on-chain tickers stay canonicalized.
+  await expectError(
+    "CreateEtf with lowercase ticker",
+    "0x233b", "InvalidTicker",
+    Buffer.from("axbtc"),
+    Buffer.from(`NAME${Date.now().toString(36)}`).subarray(0, 20),
+  );
+
+  // 28. Overlong name (33 bytes > 32 max). InvalidName = 9020 = 0x233C
+  await expectError(
+    "CreateEtf with name > 32 bytes",
+    "0x233c", "InvalidName",
+    Buffer.from("AXOK"),
+    Buffer.from("X".repeat(33)),
+  );
 
   console.log("\n=== Vault E2E PASSED ===");
 }


### PR DESCRIPTION
## Summary

Closes #37.

Stores human-readable ETF metadata directly in `EtfState` so explorers and third-party UIs can render ETF mints without depending on an off-chain database.

## Schema additions

New fields in `EtfState`, appended after `bump` so every pre-existing offset (in particular `total_supply` at byte 408) is unchanged:

- `name: [u8; 32]` — UTF-8, zero-padded; same bytes used as the PDA seed.
- `ticker: [u8; 16]` — ASCII upper/digit, zero-padded (e.g. \`AXBTC\`).
- `created_at_slot: u64` — captured from \`Clock::get()?.slot\` at `CreateEtf`.

Discriminator bumped \`etfstate\` → \`etfstat2\` per the issue's migration plan. Old v1 accounts fail \`is_initialized()\` and must be recreated rather than migrated in place.

## Instruction / validation changes

`CreateEtf` instruction data is now:

\`\`\`
[disc: u8 = 0]
[token_count: u8]
[weights_bps: [u16 LE; N]]
[ticker_len: u8][ticker: bytes]
[name_len: u8][name: bytes]
\`\`\`

Ticker precedes name so clients can parse metadata in a single forward pass.

Validation:
- **Name**: 1..=32 bytes, must be valid UTF-8 → \`InvalidName\`.
- **Ticker**: 2..=16 bytes, ASCII \`A-Z\` or \`0-9\` only → \`InvalidTicker\`.

New errors: \`InvalidTicker = 9019\`, \`InvalidName = 9020\`. 9018 is intentionally skipped so #35's \`InsufficientFirstDeposit\` slots in cleanly when both PRs merge.

## Test plan

- [x] \`cargo test\` — all 5 crates pass; \`print_sizes\` confirms EtfState is 520 bytes with \`total_supply\` still at offset 408.
- [x] \`cargo build-sbf\` — axis-vault builds clean.
- [x] \`bash ci/ts-typecheck.sh\` — all 7 TS projects clean.
- [x] \`solana-test-validator\` + \`bun test/e2e/axis-vault/axis-vault.local.e2e.ts\` — all 24 scenarios pass, including:
  - Step 6: stored metadata correctly decodes (ticker/name/created_at_slot).
  - Step 21: empty ticker → \`InvalidTicker\` (0x233B).
  - Step 22: ticker > 16 bytes → \`InvalidTicker\`.
  - Step 23: lowercase ticker → \`InvalidTicker\`.
  - Step 24: name > 32 bytes → \`InvalidName\` (0x233C).
- [ ] Review by @sidneywakala.

## Notes for reviewer

- SPL Token-Metadata (Metaplex) integration is deliberately **out of scope** per the issue — tracked as a follow-up.
- Independent of #35/#36/#38. Rebases cleanly on current main; error numbering coexists with #35 even if #35 merges first.