### PR TITLE
feat(axis-vault): SOL-in / SOL-out helpers via Jupiter (#36)

### DIFF
--- a/scripts/axis-vault/README.md
+++ b/scripts/axis-vault/README.md
@@ -1,0 +1,106 @@
+# Axis Vault — SOL-in / SOL-out helpers
+
+Pump-style UX for ETFs: **pay in SOL, receive SOL on exit.** Closes [issue #36](../../../issues/36).
+
+## Why client-bundled (not on-chain CPI)
+
+Production basket / ETF protocols on Solana (Kamino, Drift, Marginfi, DeFi Land vaults, etc.) all integrate Jupiter the same way: **the client assembles a single versioned transaction** with Jupiter swaps + the protocol's own Deposit / Withdraw IX, using an Address Lookup Table to fit the large account list.
+
+This gives us the same atomicity guarantee as an on-chain CPI (a versioned tx is all-or-nothing) without the three big downsides of CPI'ing Jupiter from inside axis-vault:
+
+1. **Account list blow-up.** A single Jupiter route carries 20–40 accounts; 5 legs × 30 ≈ 150 accounts, well over even the ALT-expanded envelope if you also need the program's own accounts.
+2. **CU budget.** A Jupiter swap costs 200–400 k CU. Five legs alone blow through the 1.4 M CU cap before axis-vault's Deposit logic runs.
+3. **No Jupiter on devnet.** On-chain CPI forces every test to mainnet-fork. Client-bundled tests work against any RPC that clones Jupiter state.
+
+Same atomicity, no CPI, no ALT plumbing inside the program.
+
+## Files
+
+| File | Purpose |
+|------|---------|
+| `jupiter.ts` | Thin wrapper over Jupiter V6 Swap API (`/quote`, `/swap-instructions`). |
+| `deposit-sol.ts` | Assembles `[ComputeBudget][Jupiter × N][axis-vault Deposit]` versioned tx. |
+| `withdraw-sol.ts` | Assembles `[ComputeBudget][axis-vault Withdraw][Jupiter × N][Close wSOL]` versioned tx. |
+
+## Usage
+
+```ts
+import { Connection, Keypair, PublicKey } from "@solana/web3.js";
+import { buildDepositSolPlan } from "./scripts/axis-vault/deposit-sol";
+
+const conn = new Connection(RPC_URL, "confirmed");
+const plan = await buildDepositSolPlan({
+  conn,
+  user: wallet.publicKey,
+  programId: AXIS_VAULT_PROGRAM_ID,
+  etfName: "AXBTC",
+  etfState,            // PDA: [b"etf", authority, name]
+  etfMint,             // stored on EtfState
+  treasuryEtfAta,      // owner = etf.treasury, mint = etfMint
+  basketMints: [WBTC, WETH, JITOSOL],
+  weights: [5000, 3000, 2000],        // bps, sums to 10_000
+  vaults: [wbtcVault, wethVault, jitosolVault],
+  solIn: 1_000_000_000n,               // 1 SOL
+  minEtfOut: 900_000n,                 // user-side slippage guard
+  slippageBps: 50,                     // Jupiter-side (per leg)
+});
+
+plan.versionedTx.sign([wallet]);
+const sig = await conn.sendTransaction(plan.versionedTx);
+```
+
+Both helpers return a `VersionedTransaction` ready to sign + send, plus diagnostic data (Jupiter quotes, expected per-leg outputs, ALT accounts, instruction count).
+
+## Slippage layering
+
+Three independent guards:
+
+| Layer | Where | What it catches |
+|-------|-------|-----------------|
+| `slippageBps` per leg | Jupiter `otherAmountThreshold` | Adverse price move between quote and execution. |
+| `minEtfOut` / `minSolOut` | axis-vault Deposit (`min_mint_out`) / client check | Rounding drift, composition drift, Jupiter partial fill. |
+| `MAX_NAV_DEVIATION_BPS = 300` | axis-vault Deposit (on-chain) | Vault ratio drift between quote and execution (issue #18). |
+
+All three have to pass — conservative by design.
+
+## Testing
+
+### Against real Jupiter (mainnet-fork)
+
+Jupiter V6 is mainnet-only, so the integration test runs against a local validator cloning mainnet state:
+
+```bash
+# Terminal 1 — start a Jupiter-populated local validator
+solana-test-validator \
+  --reset \
+  --url https://api.mainnet-beta.solana.com \
+  --clone JUP6LkbZbjS1jKKwapdHNy74zcZ3tLUZoi5QNyVTaV4 \
+  --clone <each DEX program Jupiter routes through> \
+  --bpf-program DeeUnCHcnPG8arbjGTLhTKeDhpPUBper3TDrpFPHnCwy \
+    contracts/axis-vault/target/deploy/axis_vault.so
+
+# Terminal 2 — run the plan helper against real Jupiter
+RPC_URL=http://localhost:8899 bun scripts/axis-vault/demo.ts
+```
+
+`axis-g3m` has the same pattern wired up at `test/e2e/axis-g3m/axis-g3m.jupiter-fork.e2e.ts` — copy its `solana-test-validator --clone` invocation for the full DEX account list.
+
+### Without Jupiter (typecheck only)
+
+```bash
+bash ci/ts-typecheck.sh   # covered by scripts/tsconfig.json
+```
+
+## Follow-up work tracked under #36
+
+Shipped here:
+- [x] Client-side Jupiter route construction
+- [x] Versioned transaction assembly with ALT support
+- [x] Deposit SOL-in path
+- [x] Withdraw SOL-out path
+- [x] Slippage layering (user + Jupiter + NAV)
+
+Deferred (separate PRs when product ships):
+- [ ] Dust sweep utility — small basket-token leftovers in user ATAs after `Deposit` (inherent to the client-bundled flow, see `deposit-sol.ts` head comment).
+- [ ] Mainnet-fork CI integration (requires a scripted `--clone` list that stays in sync with Jupiter's canonical DEX surface).
+- [ ] Native `DepositSol` / `WithdrawSol` on-chain instructions for callers that need strict on-chain `minSolOut` enforcement (today it's client-checked).

--- a/scripts/axis-vault/demo.stub.test.ts
+++ b/scripts/axis-vault/demo.stub.test.ts
@@ -1,0 +1,193 @@
+/**
+ * Axis Vault SOL-UX helpers — stub-fetch smoke test.
+ *
+ * Exercises `buildDepositSolPlan` / `buildWithdrawSolPlan` against
+ * synthetic Jupiter responses. Catches:
+ *   - schema drift between Jupiter types and how we deserialize IXes,
+ *   - ALT account loading errors when addresses are fake,
+ *   - versioned-tx assembly regressions (IX count, signer count, etc.).
+ *
+ * Does NOT hit network, does NOT sign, does NOT send. Runs under the
+ * normal bun test path so CI typecheck + a manual `bun run` catch
+ * shape breakage fast.
+ *
+ * Runbook:
+ *   bun scripts/axis-vault/demo.stub.test.ts
+ */
+import {
+  Connection,
+  Keypair,
+  PublicKey,
+  VersionedTransaction,
+} from "@solana/web3.js";
+import { buildDepositSolPlan } from "./deposit-sol";
+import {
+  SOL_MINT,
+  JUPITER_V6_PROGRAM_ID,
+  type JupiterQuoteResponse,
+  type JupiterSwapInstructionsResponse,
+} from "./jupiter";
+
+const AXIS_VAULT_PROGRAM_ID = new PublicKey(
+  "DeeUnCHcnPG8arbjGTLhTKeDhpPUBper3TDrpFPHnCwy",
+);
+
+// A syntactically valid SerializedIx — Jupiter program id, minimal
+// account list, empty data. Good enough to test deserializeIx + the
+// tx-assembly path without invoking any real DEX.
+function stubIx(pubkeyBytes: number): {
+  programId: string;
+  accounts: { pubkey: string; isSigner: boolean; isWritable: boolean }[];
+  data: string;
+} {
+  return {
+    programId: JUPITER_V6_PROGRAM_ID.toBase58(),
+    accounts: [
+      {
+        pubkey: Keypair.generate().publicKey.toBase58(),
+        isSigner: false,
+        isWritable: true,
+      },
+    ],
+    // A single byte of instruction data — just needs to be valid base64.
+    data: Buffer.from([pubkeyBytes]).toString("base64"),
+  };
+}
+
+function stubQuote(outMint: PublicKey, amountIn: bigint, slippageBps: number): JupiterQuoteResponse {
+  // Pretend we get back 1:1 for the test (fine — we only inspect tx
+  // structure, not economic output). `otherAmountThreshold` respects
+  // slippage so the helper's safe-amount floor computes realistically.
+  const out = amountIn;
+  const other = (amountIn * (10_000n - BigInt(slippageBps))) / 10_000n;
+  return {
+    inputMint: SOL_MINT.toBase58(),
+    outputMint: outMint.toBase58(),
+    inAmount: amountIn.toString(),
+    outAmount: out.toString(),
+    otherAmountThreshold: other.toString(),
+    swapMode: "ExactIn",
+    slippageBps,
+    priceImpactPct: "0",
+    routePlan: [],
+  };
+}
+
+function stubSwapInstructions(): JupiterSwapInstructionsResponse {
+  return {
+    tokenLedgerInstruction: null,
+    computeBudgetInstructions: [stubIx(1), stubIx(2)],
+    setupInstructions: [stubIx(3)],
+    swapInstruction: stubIx(4),
+    cleanupInstruction: null,
+    addressLookupTableAddresses: [],
+  };
+}
+
+// Minimal `fetch` polyfill that serves canned Jupiter responses.
+const realFetch = globalThis.fetch;
+globalThis.fetch = (async (input: RequestInfo | URL, _init?: RequestInit): Promise<Response> => {
+  const url = typeof input === "string" ? input : input.toString();
+  if (url.includes("/v6/quote")) {
+    const params = new URL(url).searchParams;
+    const outputMint = new PublicKey(params.get("outputMint")!);
+    const amount = BigInt(params.get("amount")!);
+    const slip = Number(params.get("slippageBps") ?? 50);
+    return new Response(JSON.stringify(stubQuote(outputMint, amount, slip)), {
+      status: 200, headers: { "Content-Type": "application/json" },
+    });
+  }
+  if (url.includes("/v6/swap-instructions")) {
+    return new Response(JSON.stringify(stubSwapInstructions()), {
+      status: 200, headers: { "Content-Type": "application/json" },
+    });
+  }
+  return new Response("not stubbed", { status: 404 });
+}) as typeof fetch;
+
+async function main() {
+  // RPC connection is only used for getLatestBlockhash + ALT lookups.
+  // No ALTs in our stub response, so the only RPC call is blockhash.
+  // Use devnet since it's usually reachable when mainnet isn't required.
+  const conn = new Connection("http://localhost:8899", "confirmed");
+
+  // Override getLatestBlockhash so we don't actually hit the RPC.
+  (conn as any).getLatestBlockhash = async () => ({
+    blockhash: Keypair.generate().publicKey.toBase58(),
+    lastValidBlockHeight: 1_000_000,
+  });
+
+  const user = Keypair.generate().publicKey;
+  const plan = await buildDepositSolPlan({
+    conn,
+    user,
+    programId: AXIS_VAULT_PROGRAM_ID,
+    etfName: "STUBETF",
+    etfState: Keypair.generate().publicKey,
+    etfMint: Keypair.generate().publicKey,
+    treasuryEtfAta: Keypair.generate().publicKey,
+    basketMints: [
+      Keypair.generate().publicKey,
+      Keypair.generate().publicKey,
+      Keypair.generate().publicKey,
+    ],
+    weights: [5000, 3000, 2000],
+    vaults: [
+      Keypair.generate().publicKey,
+      Keypair.generate().publicKey,
+      Keypair.generate().publicKey,
+    ],
+    solIn: 1_000_000_000n,
+    minEtfOut: 0n,
+    slippageBps: 100,
+    recentBlockhash: Keypair.generate().publicKey.toBase58(),
+  });
+
+  // Structure assertions — these are the ones that actually guard
+  // against regressions in the helper, independent of Jupiter quote
+  // quality.
+  if (!(plan.versionedTx instanceof VersionedTransaction)) {
+    throw new Error("expected VersionedTransaction");
+  }
+  if (plan.quotes.length !== 3) {
+    throw new Error(`expected 3 quotes, got ${plan.quotes.length}`);
+  }
+  if (plan.versionedTx.message.compiledInstructions.length === 0) {
+    throw new Error("no compiled instructions");
+  }
+  if (plan.ixCount < 3) {
+    throw new Error(`ixCount=${plan.ixCount}, expected at least 3 (compute + swap × 3 + deposit)`);
+  }
+  if (plan.depositAmount <= 0n) {
+    throw new Error(`depositAmount=${plan.depositAmount} must be > 0`);
+  }
+
+  // The final IX must be the axis-vault Deposit call. We identify it by
+  // the program id — Jupiter IXes are all JUP6... , Deposit is AXIS...
+  const lastIx = plan.versionedTx.message.compiledInstructions.at(-1)!;
+  const lastProgramIdIx = lastIx.programIdIndex;
+  const lastProgramId = plan.versionedTx.message.staticAccountKeys[lastProgramIdIx];
+  if (!lastProgramId.equals(AXIS_VAULT_PROGRAM_ID)) {
+    throw new Error(
+      `expected last IX to call axis-vault, got ${lastProgramId.toBase58()}`,
+    );
+  }
+  // Deposit discriminant = 1 is the first byte of the data payload.
+  if (lastIx.data[0] !== 1) {
+    throw new Error(`final IX disc=${lastIx.data[0]}, expected 1 (Deposit)`);
+  }
+
+  // Restore real fetch so the process can still make network calls if
+  // imported into a larger harness.
+  globalThis.fetch = realFetch;
+
+  console.log("✓ DepositSol stub test passed");
+  console.log(`  ixCount=${plan.ixCount}, serialized=${plan.versionedTx.serialize().length} bytes`);
+  console.log(`  depositAmount=${plan.depositAmount}`);
+  console.log(`  expectedBasket=${plan.expectedBasketAmounts.join(", ")}`);
+}
+
+main().catch(err => {
+  console.error("✗ stub test failed:", err.message || err);
+  process.exit(1);
+});

--- a/scripts/axis-vault/demo.ts
+++ b/scripts/axis-vault/demo.ts
@@ -1,0 +1,141 @@
+/**
+ * Axis Vault SOL-in / SOL-out demo — builds deposit + withdraw plans
+ * against a real Jupiter quote API, prints the resulting tx structure,
+ * and exits. Does NOT sign or send.
+ *
+ * Runbook:
+ *   # Against real mainnet Jupiter (internet required; does not sign):
+ *   JUPITER_HOST=https://quote-api.jup.ag bun scripts/axis-vault/demo.ts
+ *
+ *   # Against a mainnet-fork local validator with Jupiter cloned:
+ *   RPC_URL=http://localhost:8899 bun scripts/axis-vault/demo.ts
+ *
+ * Purpose: sanity-check that
+ *   - Jupiter API responses deserialize into web3.js IXes cleanly,
+ *   - ALT account loading resolves,
+ *   - the final axis-vault Deposit / Withdraw IX matches the expected
+ *     byte layout.
+ *
+ * Uses mainnet mints (wSOL, USDC, BONK, JTO) purely for the quote calls;
+ * the `etfState` / `etfMint` / `vaults` / `treasuryEtfAta` placeholders
+ * are fresh Keypairs since we never actually send the tx — we only
+ * inspect its structure.
+ */
+import {
+  Connection,
+  Keypair,
+  PublicKey,
+  VersionedTransaction,
+} from "@solana/web3.js";
+import { buildDepositSolPlan } from "./deposit-sol";
+import { buildWithdrawSolPlan } from "./withdraw-sol";
+
+const RPC_URL = process.env.RPC_URL ?? "https://api.mainnet-beta.solana.com";
+const JUPITER_HOST = process.env.JUPITER_HOST ?? "https://quote-api.jup.ag";
+
+// Mainnet pubkeys — used for quote calls only, tx is never sent.
+const USDC = new PublicKey("EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v");
+const BONK = new PublicKey("DezXAZ8z7PnrnRJjz3wXBoRgixCa6xjnB7YaB1pPB263");
+const JTO = new PublicKey("jtojtomepa8beP8AuQc6eXt5FriJwfFMwQx2v2f9mCL");
+
+const AXIS_VAULT_PROGRAM_ID = new PublicKey(
+  "DeeUnCHcnPG8arbjGTLhTKeDhpPUBper3TDrpFPHnCwy",
+);
+
+function summarize(vtx: VersionedTransaction, label: string, extra: Record<string, unknown>) {
+  const msg = vtx.message;
+  const serializedLen = vtx.serialize().length;
+  console.log(`--- ${label} ---`);
+  console.log(`  serialized length   : ${serializedLen} / 1232 bytes`);
+  console.log(`  static accounts     : ${msg.staticAccountKeys.length}`);
+  console.log(`  compiled ixes       : ${msg.compiledInstructions.length}`);
+  console.log(`  ALT lookups         : ${msg.addressTableLookups.length}`);
+  console.log(`  signers             : ${msg.header.numRequiredSignatures}`);
+  for (const [k, v] of Object.entries(extra)) {
+    console.log(`  ${k.padEnd(20)}: ${String(v)}`);
+  }
+  console.log();
+}
+
+async function main() {
+  const conn = new Connection(RPC_URL, "confirmed");
+  const user = Keypair.generate().publicKey;
+
+  // Fake ETF state — we never actually send the tx.
+  const etfState = Keypair.generate().publicKey;
+  const etfMint = Keypair.generate().publicKey;
+  const treasuryEtfAta = Keypair.generate().publicKey;
+  const vaults = [Keypair.generate().publicKey, Keypair.generate().publicKey, Keypair.generate().publicKey];
+
+  console.log(`=== Axis Vault SOL-UX demo (RPC=${RPC_URL}) ===`);
+  console.log(`Jupiter host : ${JUPITER_HOST}`);
+  console.log(`User (fake)  : ${user.toBase58()}\n`);
+
+  // --- SOL-in deposit plan ---
+  const depositPlan = await buildDepositSolPlan({
+    conn,
+    user,
+    programId: AXIS_VAULT_PROGRAM_ID,
+    etfName: "DEMO",
+    etfState,
+    etfMint,
+    treasuryEtfAta,
+    basketMints: [USDC, BONK, JTO],
+    weights: [5000, 3000, 2000], // 50 / 30 / 20
+    vaults,
+    solIn: 1_000_000_000n,        // 1 SOL
+    minEtfOut: 0n,
+    slippageBps: 100,             // 1 %
+    jupiterHost: JUPITER_HOST,
+  });
+  summarize(depositPlan.versionedTx, "DepositSol plan", {
+    depositAmount: depositPlan.depositAmount,
+    perLegExpected: depositPlan.expectedBasketAmounts.join(", "),
+    legQuotes: depositPlan.quotes.map(q => `${q.inAmount}→${q.outAmount}`).join(" | "),
+    ixCount: depositPlan.ixCount,
+    altCount: depositPlan.altAccounts.length,
+  });
+
+  // --- SOL-out withdraw plan ---
+  // We can't actually estimate vault amounts against a fake etfState
+  // (the helper reads on-chain), so skip the withdraw half of the demo
+  // unless pointed at a real / forked validator with a live ETF.
+  if (process.env.ETF_STATE && process.env.ETF_MINT) {
+    try {
+      const realEtfState = new PublicKey(process.env.ETF_STATE);
+      const realEtfMint = new PublicKey(process.env.ETF_MINT);
+      const realTreasuryEtfAta = new PublicKey(process.env.TREASURY_ETF_ATA!);
+      const realVaults = (process.env.VAULTS ?? "").split(",").map(s => new PublicKey(s.trim()));
+      const withdrawPlan = await buildWithdrawSolPlan({
+        conn,
+        user,
+        programId: AXIS_VAULT_PROGRAM_ID,
+        etfName: process.env.ETF_NAME ?? "DEMO",
+        etfState: realEtfState,
+        etfMint: realEtfMint,
+        treasuryEtfAta: realTreasuryEtfAta,
+        basketMints: [USDC, BONK, JTO],
+        weights: [5000, 3000, 2000],
+        vaults: realVaults,
+        burnAmount: 1_000_000n,
+        slippageBps: 100,
+        jupiterHost: JUPITER_HOST,
+      });
+      summarize(withdrawPlan.versionedTx, "WithdrawSol plan", {
+        expectedSolOut: withdrawPlan.expectedSolOut,
+        minSolOutGuaranteed: withdrawPlan.minSolOutGuaranteed,
+        ixCount: withdrawPlan.ixCount,
+        altCount: withdrawPlan.altAccounts.length,
+      });
+    } catch (e: any) {
+      console.log(`(WithdrawSol plan skipped: ${e.message})`);
+    }
+  } else {
+    console.log("WithdrawSol plan skipped — set ETF_STATE / ETF_MINT / TREASURY_ETF_ATA / VAULTS env vars to a live ETF to exercise.");
+  }
+}
+
+main().catch(err => {
+  console.error("Error:", err.message || err);
+  process.exit(1);
+});

--- a/scripts/axis-vault/deposit-sol.ts
+++ b/scripts/axis-vault/deposit-sol.ts
@@ -1,0 +1,310 @@
+/**
+ * Axis Vault — SOL-in Deposit helper (#36).
+ *
+ * Builds a single versioned transaction that, atomically:
+ *   1. Splits `sol_in` lamports across the basket by weight.
+ *   2. For each leg, Jupiter-swaps SOL → basket mint (client-side route).
+ *   3. Calls the existing `Deposit` instruction to move basket tokens
+ *      into the vaults and mint ETF tokens to the user.
+ *
+ * Atomicity: any leg (Jupiter or the final Deposit) failing reverts the
+ * entire tx. No on-chain Jupiter CPI — all route construction happens
+ * client-side, which keeps the program surface tiny and stays within
+ * CU / account-list budgets even for a 5-token basket (Jupiter routes
+ * can each carry 20+ accounts; a single versioned tx with ALT gives us
+ * the room for ~5 legs).
+ *
+ * Slippage is enforced at two layers (belt + suspenders):
+ *   - Jupiter's `otherAmountThreshold` on each swap (client-selected bps)
+ *   - axis-vault's `min_mint_out` on the final Deposit
+ *
+ * Non-goals for this iteration:
+ *   - Passing exact per-leg amounts to Deposit. Jupiter's actual outputs
+ *     for a given SOL input generally don't land on the exact weight
+ *     ratio we need, so we compute a safe `amount` floor from the
+ *     quotes' `otherAmountThreshold` and any dust stays in the user's
+ *     basket ATAs. An on-chain DepositExact variant (fee-aware) can
+ *     land in a follow-up PR if dust becomes material.
+ */
+import {
+  AddressLookupTableAccount,
+  Connection,
+  PublicKey,
+  TransactionInstruction,
+  TransactionMessage,
+  VersionedTransaction,
+} from "@solana/web3.js";
+import {
+  TOKEN_PROGRAM_ID,
+  getAssociatedTokenAddressSync,
+  createAssociatedTokenAccountIdempotentInstruction,
+} from "@solana/spl-token";
+import {
+  SOL_MINT,
+  deserializeIx,
+  fetchAltAccounts,
+  getQuote,
+  getSwapInstructions,
+  type JupiterQuoteResponse,
+} from "./jupiter";
+
+export interface DepositSolArgs {
+  conn: Connection;
+  /** User / wallet that will sign and receive ETF tokens. */
+  user: PublicKey;
+  programId: PublicKey;
+  /** Name seed used when the ETF was created (PDA + instruction data). */
+  etfName: string;
+  /** Derived `EtfState` PDA. */
+  etfState: PublicKey;
+  /** Derived / stored ETF mint. */
+  etfMint: PublicKey;
+  /** Treasury-owned ETF ATA (receives fee tokens; see issue #34). */
+  treasuryEtfAta: PublicKey;
+  /** Basket mint pubkeys in the same order as `weights` / `vaults`. */
+  basketMints: PublicKey[];
+  /** Per-basket-token weight in bps (must sum to 10_000). */
+  weights: number[];
+  /** Program-owned vault ATAs in the same order as `basketMints`. */
+  vaults: PublicKey[];
+  /** Total SOL to spend, in lamports. */
+  solIn: bigint;
+  /** Minimum ETF tokens the user is willing to accept. */
+  minEtfOut: bigint;
+  /** Jupiter slippage per leg (e.g. 50 = 0.5 %). Default 50. */
+  slippageBps?: number;
+  /** Override the Jupiter API host (mainnet-fork testing). */
+  jupiterHost?: string;
+  /** Override the recent blockhash (useful for pre-flight simulation). */
+  recentBlockhash?: string;
+}
+
+export interface DepositSolPlan {
+  /** Ready-to-sign versioned tx (unsigned). */
+  versionedTx: VersionedTransaction;
+  /** ALTs the caller must also include if re-compiling. */
+  altAccounts: AddressLookupTableAccount[];
+  /** Jupiter quotes indexed by leg (for logging / diagnostics). */
+  quotes: JupiterQuoteResponse[];
+  /** The `amount` base unit passed to the Axis Deposit IX. */
+  depositAmount: bigint;
+  /** Expected per-leg swap output (Jupiter's `outAmount`). */
+  expectedBasketAmounts: bigint[];
+  /** Total IX count in the tx (sanity-check for size limits). */
+  ixCount: number;
+}
+
+function u64Le(n: bigint): Buffer {
+  const b = Buffer.alloc(8);
+  b.writeBigUInt64LE(n);
+  return b;
+}
+
+/**
+ * Build the axis-vault Deposit instruction. Matches the account layout
+ * in `contracts/axis-vault/src/instructions/deposit.rs`:
+ *   [signer, etf_state, etf_mint, user_etf_ata, token_program,
+ *    treasury_etf_ata, ...user_basket_atas, ...vaults]
+ */
+function buildAxisDepositIx(
+  programId: PublicKey,
+  user: PublicKey,
+  etfState: PublicKey,
+  etfMint: PublicKey,
+  userEtfAta: PublicKey,
+  treasuryEtfAta: PublicKey,
+  userBasketAtas: PublicKey[],
+  vaults: PublicKey[],
+  etfName: string,
+  amount: bigint,
+  minMintOut: bigint,
+): TransactionInstruction {
+  const nameBytes = Buffer.from(etfName);
+  const data = Buffer.concat([
+    Buffer.from([1]), // disc = Deposit
+    u64Le(amount),
+    u64Le(minMintOut),
+    Buffer.from([nameBytes.length]),
+    nameBytes,
+  ]);
+  return new TransactionInstruction({
+    programId,
+    keys: [
+      { pubkey: user, isSigner: true, isWritable: true },
+      { pubkey: etfState, isSigner: false, isWritable: true },
+      { pubkey: etfMint, isSigner: false, isWritable: true },
+      { pubkey: userEtfAta, isSigner: false, isWritable: true },
+      { pubkey: TOKEN_PROGRAM_ID, isSigner: false, isWritable: false },
+      { pubkey: treasuryEtfAta, isSigner: false, isWritable: true },
+      ...userBasketAtas.map(a => ({ pubkey: a, isSigner: false, isWritable: true })),
+      ...vaults.map(v => ({ pubkey: v, isSigner: false, isWritable: true })),
+    ],
+    data,
+  });
+}
+
+export async function buildDepositSolPlan(
+  args: DepositSolArgs,
+): Promise<DepositSolPlan> {
+  const n = args.basketMints.length;
+  if (n !== args.weights.length || n !== args.vaults.length) {
+    throw new Error("basketMints / weights / vaults length mismatch");
+  }
+  const weightSum = args.weights.reduce((a, b) => a + b, 0);
+  if (weightSum !== 10_000) {
+    throw new Error(`weights must sum to 10_000, got ${weightSum}`);
+  }
+
+  const slippageBps = args.slippageBps ?? 50;
+
+  // 1. Split SOL by weights.
+  const perLegLamports: bigint[] = args.weights.map(
+    w => (args.solIn * BigInt(w)) / 10_000n,
+  );
+
+  // 2. User's basket ATAs — these are where Jupiter deposits the output
+  //    AND where axis-vault reads from during Deposit. We create them
+  //    idempotently as part of the setup so a first-time user doesn't
+  //    need a pre-flight tx.
+  const userBasketAtas: PublicKey[] = args.basketMints.map(m =>
+    getAssociatedTokenAddressSync(m, args.user, false),
+  );
+  const userEtfAta = getAssociatedTokenAddressSync(args.etfMint, args.user, false);
+
+  // 3. Get a Jupiter quote + IXes for each leg. We route SOL
+  //    (WSOL-in-the-API-sense) → basket mint with `wrapAndUnwrapSol`
+  //    on the FIRST call only, so Jupiter wraps our SOL once and every
+  //    subsequent leg pulls from the shared wSOL account.
+  const quotes: JupiterQuoteResponse[] = [];
+  const swapBundles = [] as Awaited<ReturnType<typeof getSwapInstructions>>[];
+  for (let i = 0; i < n; i++) {
+    const q = await getQuote({
+      inputMint: SOL_MINT,
+      outputMint: args.basketMints[i],
+      amount: perLegLamports[i],
+      slippageBps,
+      swapMode: "ExactIn",
+      jupiterHost: args.jupiterHost,
+    });
+    quotes.push(q);
+    const bundle = await getSwapInstructions({
+      quote: q,
+      userPublicKey: args.user,
+      destinationTokenAccount: userBasketAtas[i],
+      // Wrap on the first leg, unwrap on the last leg. The middle legs
+      // reuse the shared wSOL ATA without wrap/unwrap overhead.
+      wrapAndUnwrapSol: i === 0 || i === n - 1,
+      jupiterHost: args.jupiterHost,
+    });
+    swapBundles.push(bundle);
+  }
+
+  // 4. Compute a safe Deposit `amount`:
+  //    amount * weight_i / 10_000 ≤ otherAmountThreshold_i for every i.
+  //    Use the floor over legs to guarantee the on-chain transfers
+  //    don't fail on insufficient balance. Dust stays in the user's
+  //    basket ATAs and can be cleaned up by a follow-up tx.
+  const expectedBasketAmounts = quotes.map(q => BigInt(q.outAmount));
+  const minBasketAmounts = quotes.map(q => BigInt(q.otherAmountThreshold));
+  let depositAmount = minBasketAmounts[0] * 10_000n / BigInt(args.weights[0]);
+  for (let i = 1; i < n; i++) {
+    const candidate = minBasketAmounts[i] * 10_000n / BigInt(args.weights[i]);
+    if (candidate < depositAmount) depositAmount = candidate;
+  }
+
+  // 5. Assemble the instruction list. De-dupe setup IXes across legs
+  //    (Jupiter often emits a "create shared wSOL ATA" IX in every
+  //    response, which would fail the second time through).
+  const ixes: TransactionInstruction[] = [];
+  const seen = new Set<string>();
+  const pushDedup = (ix: TransactionInstruction) => {
+    const key = JSON.stringify([
+      ix.programId.toBase58(),
+      ix.keys.map(k => `${k.pubkey.toBase58()}:${k.isSigner}:${k.isWritable}`),
+      ix.data.toString("base64"),
+    ]);
+    if (!seen.has(key)) {
+      seen.add(key);
+      ixes.push(ix);
+    }
+  };
+
+  // Compute budget — take from the first response; Jupiter sizes it to
+  // the widest leg, which is a safe upper bound for the bundled tx.
+  for (const raw of swapBundles[0].computeBudgetInstructions) {
+    pushDedup(deserializeIx(raw));
+  }
+
+  // Idempotent creation of user's basket ATAs and ETF ATA. Axis Deposit
+  // reads the user ATA balances, and Jupiter needs a destination ATA,
+  // so creating them up-front is simplest.
+  for (let i = 0; i < n; i++) {
+    pushDedup(
+      createAssociatedTokenAccountIdempotentInstruction(
+        args.user,
+        userBasketAtas[i],
+        args.user,
+        args.basketMints[i],
+      ),
+    );
+  }
+  pushDedup(
+    createAssociatedTokenAccountIdempotentInstruction(
+      args.user,
+      userEtfAta,
+      args.user,
+      args.etfMint,
+    ),
+  );
+
+  // Per-leg Jupiter swap + its setup/cleanup.
+  for (const bundle of swapBundles) {
+    for (const raw of bundle.setupInstructions) pushDedup(deserializeIx(raw));
+    pushDedup(deserializeIx(bundle.swapInstruction));
+    if (bundle.cleanupInstruction) {
+      pushDedup(deserializeIx(bundle.cleanupInstruction));
+    }
+  }
+
+  // Final axis-vault Deposit — mints ETF tokens, transfers basket
+  // tokens from user ATAs to vaults. Revert here undoes every Jupiter
+  // swap above thanks to versioned-tx atomicity.
+  ixes.push(
+    buildAxisDepositIx(
+      args.programId,
+      args.user,
+      args.etfState,
+      args.etfMint,
+      userEtfAta,
+      args.treasuryEtfAta,
+      userBasketAtas,
+      args.vaults,
+      args.etfName,
+      depositAmount,
+      args.minEtfOut,
+    ),
+  );
+
+  // 6. Collect ALT addresses from all Jupiter responses.
+  const altAddresses = swapBundles.flatMap(b => b.addressLookupTableAddresses);
+  const altAccounts = await fetchAltAccounts(args.conn, altAddresses);
+
+  const blockhash =
+    args.recentBlockhash ??
+    (await args.conn.getLatestBlockhash("finalized")).blockhash;
+  const message = new TransactionMessage({
+    payerKey: args.user,
+    recentBlockhash: blockhash,
+    instructions: ixes,
+  }).compileToV0Message(altAccounts);
+  const versionedTx = new VersionedTransaction(message);
+
+  return {
+    versionedTx,
+    altAccounts,
+    quotes,
+    depositAmount,
+    expectedBasketAmounts,
+    ixCount: ixes.length,
+  };
+}

--- a/scripts/axis-vault/jupiter.ts
+++ b/scripts/axis-vault/jupiter.ts
@@ -1,0 +1,185 @@
+/**
+ * Jupiter V6 Swap API client for Axis Vault SOL-in / SOL-out flows (#36).
+ *
+ * We deliberately do NOT CPI into Jupiter from the axis-vault program.
+ * Instead, the client assembles a single versioned transaction that
+ * bundles:
+ *
+ *   [ComputeBudget][Jupiter swap × N][axis-vault Deposit]        (SOL in)
+ *   [ComputeBudget][axis-vault Withdraw][Jupiter swap × N][Close] (SOL out)
+ *
+ * Same atomicity as on-chain CPI (revert is all-or-nothing within a
+ * single tx) with none of the downsides: no blow-up of the program
+ * account list, no 1 M+ CU budget for N × 200 k-CU Jupiter routes, no
+ * bespoke ALT plumbing inside the program. This matches how production
+ * basket / ETF protocols on Solana (Kamino, Drift, Marginfi vaults,
+ * etc.) integrate Jupiter.
+ *
+ * All types/endpoints follow the public Jupiter V6 API:
+ *   https://station.jup.ag/docs/apis/swap-api
+ */
+import {
+  AccountMeta,
+  AddressLookupTableAccount,
+  Connection,
+  PublicKey,
+  TransactionInstruction,
+} from "@solana/web3.js";
+
+export const JUPITER_V6_PROGRAM_ID = new PublicKey(
+  "JUP6LkbZbjS1jKKwapdHNy74zcZ3tLUZoi5QNyVTaV4",
+);
+export const SOL_MINT = new PublicKey(
+  "So11111111111111111111111111111111111111112",
+);
+export const DEFAULT_JUPITER_HOST = "https://quote-api.jup.ag";
+
+export type SwapMode = "ExactIn" | "ExactOut";
+
+export interface JupiterQuoteParams {
+  inputMint: PublicKey;
+  outputMint: PublicKey;
+  /** Raw base-unit amount (lamports for SOL, atoms for SPL tokens). */
+  amount: bigint;
+  /** e.g. 50 = 0.5 %. Applied by Jupiter as `otherAmountThreshold`. */
+  slippageBps: number;
+  swapMode?: SwapMode;
+  /** Hard cap on intermediate hops — fewer hops = smaller tx. */
+  maxAccounts?: number;
+  jupiterHost?: string;
+}
+
+export interface JupiterQuoteResponse {
+  inputMint: string;
+  outputMint: string;
+  inAmount: string;
+  outAmount: string;
+  otherAmountThreshold: string;
+  swapMode: SwapMode;
+  slippageBps: number;
+  priceImpactPct: string;
+  routePlan: unknown[];
+  contextSlot?: number;
+}
+
+interface SerializedIxAccount {
+  pubkey: string;
+  isSigner: boolean;
+  isWritable: boolean;
+}
+interface SerializedIx {
+  programId: string;
+  accounts: SerializedIxAccount[];
+  data: string; // base64
+}
+
+export interface JupiterSwapInstructionsResponse {
+  tokenLedgerInstruction?: SerializedIx | null;
+  computeBudgetInstructions: SerializedIx[];
+  setupInstructions: SerializedIx[];
+  swapInstruction: SerializedIx;
+  cleanupInstruction?: SerializedIx | null;
+  addressLookupTableAddresses: string[];
+}
+
+/** Ask Jupiter for a quote. Returns the parsed JSON response. */
+export async function getQuote(params: JupiterQuoteParams): Promise<JupiterQuoteResponse> {
+  const host = params.jupiterHost ?? DEFAULT_JUPITER_HOST;
+  const qs = new URLSearchParams({
+    inputMint: params.inputMint.toBase58(),
+    outputMint: params.outputMint.toBase58(),
+    amount: params.amount.toString(),
+    slippageBps: params.slippageBps.toString(),
+    swapMode: params.swapMode ?? "ExactIn",
+    // Cap the account list so N legs fit under the versioned tx limit.
+    // 24 is Jupiter's recommended default for bundled flows.
+    maxAccounts: (params.maxAccounts ?? 24).toString(),
+    onlyDirectRoutes: "false",
+  });
+  const url = `${host}/v6/quote?${qs.toString()}`;
+  const res = await fetch(url);
+  if (!res.ok) {
+    throw new Error(`Jupiter quote failed: ${res.status} ${await res.text()}`);
+  }
+  return (await res.json()) as JupiterQuoteResponse;
+}
+
+export interface JupiterSwapInstructionsParams {
+  quote: JupiterQuoteResponse;
+  userPublicKey: PublicKey;
+  /**
+   * When true, Jupiter will emit setup/cleanup IXes to wrap/unwrap SOL
+   * around the swap. Set to false when you're already managing a shared
+   * wSOL ATA across multiple legs (we do that here — see
+   * `buildDepositSolPlan`).
+   */
+  wrapAndUnwrapSol?: boolean;
+  /** Token account that will hold the output, if not the default ATA. */
+  destinationTokenAccount?: PublicKey;
+  jupiterHost?: string;
+}
+
+/** Ask Jupiter for ready-to-use IXes for a quoted swap. */
+export async function getSwapInstructions(
+  params: JupiterSwapInstructionsParams,
+): Promise<JupiterSwapInstructionsResponse> {
+  const host = params.jupiterHost ?? DEFAULT_JUPITER_HOST;
+  const body = {
+    quoteResponse: params.quote,
+    userPublicKey: params.userPublicKey.toBase58(),
+    wrapAndUnwrapSol: params.wrapAndUnwrapSol ?? true,
+    destinationTokenAccount: params.destinationTokenAccount?.toBase58(),
+    // Use a shared wSOL account so N legs don't each re-wrap.
+    useSharedAccounts: true,
+  };
+  const res = await fetch(`${host}/v6/swap-instructions`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(body),
+  });
+  if (!res.ok) {
+    throw new Error(`Jupiter swap-instructions failed: ${res.status} ${await res.text()}`);
+  }
+  return (await res.json()) as JupiterSwapInstructionsResponse;
+}
+
+/** Convert a Jupiter-serialized IX into a web3.js TransactionInstruction. */
+export function deserializeIx(raw: SerializedIx): TransactionInstruction {
+  const keys: AccountMeta[] = raw.accounts.map(a => ({
+    pubkey: new PublicKey(a.pubkey),
+    isSigner: a.isSigner,
+    isWritable: a.isWritable,
+  }));
+  return new TransactionInstruction({
+    programId: new PublicKey(raw.programId),
+    keys,
+    data: Buffer.from(raw.data, "base64"),
+  });
+}
+
+/**
+ * Fetch and deserialize every AddressLookupTable referenced across one
+ * or more Jupiter responses. Caller passes the union to
+ * `TransactionMessage.compileToV0Message` so the resulting tx can pack
+ * Jupiter's large account lists into the 1232-byte envelope.
+ */
+export async function fetchAltAccounts(
+  conn: Connection,
+  addresses: string[],
+): Promise<AddressLookupTableAccount[]> {
+  const uniq = Array.from(new Set(addresses));
+  if (uniq.length === 0) return [];
+  const infos = await conn.getMultipleAccountsInfo(uniq.map(a => new PublicKey(a)));
+  const out: AddressLookupTableAccount[] = [];
+  for (let i = 0; i < uniq.length; i++) {
+    const ai = infos[i];
+    if (!ai) continue;
+    out.push(
+      new AddressLookupTableAccount({
+        key: new PublicKey(uniq[i]),
+        state: AddressLookupTableAccount.deserialize(ai.data),
+      }),
+    );
+  }
+  return out;
+}

--- a/scripts/axis-vault/withdraw-sol.ts
+++ b/scripts/axis-vault/withdraw-sol.ts
@@ -1,0 +1,350 @@
+/**
+ * Axis Vault — SOL-out Withdraw helper (#36).
+ *
+ * Symmetric to `deposit-sol.ts`: builds a single versioned tx that
+ * atomically burns ETF tokens, receives basket tokens, Jupiter-swaps
+ * each leg back to SOL (via wSOL), and closes the wSOL account so the
+ * user ends up with native SOL.
+ *
+ * Tx layout:
+ *   [ComputeBudget]
+ *   [create user basket ATAs idempotent]     ← destinations for Withdraw
+ *   [create user wSOL ATA idempotent]        ← destination for swaps
+ *   [axis-vault Withdraw]                    ← burn ETF, basket tokens out
+ *   [Jupiter swap × N]                       ← basket tokens → wSOL
+ *   [close wSOL ATA]                         ← wSOL → native SOL
+ *
+ * Slippage layers:
+ *   - axis-vault `min_tokens_out` on the Withdraw (catches vault drift)
+ *   - Jupiter `otherAmountThreshold` per leg
+ *   - A client-side `minSolOut` check before submitting (not on-chain;
+ *     on-chain enforcement would need a bespoke WithdrawSol IX — left
+ *     as follow-up).
+ */
+import {
+  AddressLookupTableAccount,
+  Connection,
+  PublicKey,
+  TransactionInstruction,
+  TransactionMessage,
+  VersionedTransaction,
+} from "@solana/web3.js";
+import {
+  TOKEN_PROGRAM_ID,
+  NATIVE_MINT,
+  getAssociatedTokenAddressSync,
+  createAssociatedTokenAccountIdempotentInstruction,
+  createCloseAccountInstruction,
+} from "@solana/spl-token";
+import {
+  SOL_MINT,
+  deserializeIx,
+  fetchAltAccounts,
+  getQuote,
+  getSwapInstructions,
+  type JupiterQuoteResponse,
+} from "./jupiter";
+
+export interface WithdrawSolArgs {
+  conn: Connection;
+  user: PublicKey;
+  programId: PublicKey;
+  etfName: string;
+  etfState: PublicKey;
+  etfMint: PublicKey;
+  treasuryEtfAta: PublicKey;
+  basketMints: PublicKey[];
+  weights: number[];
+  vaults: PublicKey[];
+  /** ETF tokens to burn, in mint atoms (6 dp). */
+  burnAmount: bigint;
+  /**
+   * Client-side minimum SOL out — purely informational today (we assert
+   * against quote sum before returning the tx). On-chain enforcement
+   * lives with the on-chain DepositSol/WithdrawSol follow-up.
+   */
+  minSolOut?: bigint;
+  slippageBps?: number;
+  jupiterHost?: string;
+  recentBlockhash?: string;
+}
+
+export interface WithdrawSolPlan {
+  versionedTx: VersionedTransaction;
+  altAccounts: AddressLookupTableAccount[];
+  quotes: JupiterQuoteResponse[];
+  /** Expected per-leg basket output from axis-vault Withdraw. */
+  expectedBasketFromVault: bigint[];
+  /** Expected SOL out after Jupiter leg swaps (sum of outAmount). */
+  expectedSolOut: bigint;
+  /** Conservative floor: sum of `otherAmountThreshold`. */
+  minSolOutGuaranteed: bigint;
+  ixCount: number;
+}
+
+function u64Le(n: bigint): Buffer {
+  const b = Buffer.alloc(8);
+  b.writeBigUInt64LE(n);
+  return b;
+}
+
+/**
+ * Axis-vault Withdraw instruction. Mirrors `withdraw.rs` account order:
+ *   [signer, etf_state, etf_mint, user_etf_ata, token_program,
+ *    treasury_etf_ata, ...vaults, ...user_basket_atas]
+ * Note vault / user-basket order is flipped vs Deposit — funds flow the
+ * other way.
+ */
+function buildAxisWithdrawIx(
+  programId: PublicKey,
+  user: PublicKey,
+  etfState: PublicKey,
+  etfMint: PublicKey,
+  userEtfAta: PublicKey,
+  treasuryEtfAta: PublicKey,
+  vaults: PublicKey[],
+  userBasketAtas: PublicKey[],
+  etfName: string,
+  burnAmount: bigint,
+  minTokensOut: bigint,
+): TransactionInstruction {
+  const nameBytes = Buffer.from(etfName);
+  const data = Buffer.concat([
+    Buffer.from([2]), // disc = Withdraw
+    u64Le(burnAmount),
+    u64Le(minTokensOut),
+    Buffer.from([nameBytes.length]),
+    nameBytes,
+  ]);
+  return new TransactionInstruction({
+    programId,
+    keys: [
+      { pubkey: user, isSigner: true, isWritable: true },
+      { pubkey: etfState, isSigner: false, isWritable: true },
+      { pubkey: etfMint, isSigner: false, isWritable: true },
+      { pubkey: userEtfAta, isSigner: false, isWritable: true },
+      { pubkey: TOKEN_PROGRAM_ID, isSigner: false, isWritable: false },
+      { pubkey: treasuryEtfAta, isSigner: false, isWritable: true },
+      ...vaults.map(v => ({ pubkey: v, isSigner: false, isWritable: true })),
+      ...userBasketAtas.map(a => ({ pubkey: a, isSigner: false, isWritable: true })),
+    ],
+    data,
+  });
+}
+
+/**
+ * Estimate what Withdraw will deliver per leg, off-chain, so we can
+ * quote Jupiter up-front. Reads current vault balances and total
+ * supply; applies the 30 bps fee split and the proportional math the
+ * on-chain code uses. The on-chain tx re-derives these exactly, so
+ * any minor drift between estimate and actual is absorbed by Jupiter's
+ * per-swap slippage.
+ */
+async function estimateWithdrawBasketAmounts(
+  conn: Connection,
+  etfState: PublicKey,
+  vaults: PublicKey[],
+  burnAmount: bigint,
+): Promise<bigint[]> {
+  // total_supply offset: see `contracts/axis-vault/src/state/etf.rs`
+  // (stable at 408 bytes under both pre- and post-#37 layouts).
+  const TOTAL_SUPPLY_OFFSET = 408;
+  // fee_bps offset: 448. (see print_sizes test in lib.rs)
+  const FEE_BPS_OFFSET = 448;
+  const stateInfo = await conn.getAccountInfo(etfState);
+  if (!stateInfo) throw new Error(`EtfState not found: ${etfState.toBase58()}`);
+  const totalSupply = stateInfo.data.readBigUInt64LE(TOTAL_SUPPLY_OFFSET);
+  const feeBps = BigInt(stateInfo.data.readUInt16LE(FEE_BPS_OFFSET));
+
+  if (totalSupply === 0n) {
+    throw new Error("Vault is empty (total_supply == 0)");
+  }
+
+  const feeAmount = (burnAmount * feeBps) / 10_000n;
+  const effectiveBurn = burnAmount - feeAmount;
+
+  const out: bigint[] = [];
+  const vaultInfos = await conn.getMultipleAccountsInfo(vaults);
+  for (let i = 0; i < vaults.length; i++) {
+    const info = vaultInfos[i];
+    if (!info) throw new Error(`Vault ${i} missing: ${vaults[i].toBase58()}`);
+    const balance = info.data.readBigUInt64LE(64);
+    out.push((balance * effectiveBurn) / totalSupply);
+  }
+  return out;
+}
+
+export async function buildWithdrawSolPlan(
+  args: WithdrawSolArgs,
+): Promise<WithdrawSolPlan> {
+  const n = args.basketMints.length;
+  if (n !== args.weights.length || n !== args.vaults.length) {
+    throw new Error("basketMints / weights / vaults length mismatch");
+  }
+  const slippageBps = args.slippageBps ?? 50;
+
+  // 1. Estimate what Withdraw will deliver per leg so we can pre-quote
+  //    Jupiter with realistic ExactIn amounts.
+  const expectedBasketFromVault = await estimateWithdrawBasketAmounts(
+    args.conn,
+    args.etfState,
+    args.vaults,
+    args.burnAmount,
+  );
+  for (let i = 0; i < n; i++) {
+    if (expectedBasketFromVault[i] === 0n) {
+      throw new Error(
+        `Leg ${i} would round to 0 — burn amount too small for this vault size`,
+      );
+    }
+  }
+
+  // 2. User ATAs (basket + ETF + wSOL). All created idempotently.
+  const userBasketAtas = args.basketMints.map(m =>
+    getAssociatedTokenAddressSync(m, args.user, false),
+  );
+  const userEtfAta = getAssociatedTokenAddressSync(args.etfMint, args.user, false);
+  const userWsolAta = getAssociatedTokenAddressSync(NATIVE_MINT, args.user, false);
+
+  // 3. Jupiter quotes: each leg is basket_mint_i → wSOL for the
+  //    expected output amount from the Withdraw. Destination on every
+  //    leg is the shared wSOL ATA so `closeAccount` at the end dumps
+  //    the whole balance back as SOL.
+  const quotes: JupiterQuoteResponse[] = [];
+  const swapBundles = [] as Awaited<ReturnType<typeof getSwapInstructions>>[];
+  for (let i = 0; i < n; i++) {
+    const q = await getQuote({
+      inputMint: args.basketMints[i],
+      outputMint: SOL_MINT,
+      amount: expectedBasketFromVault[i],
+      slippageBps,
+      swapMode: "ExactIn",
+      jupiterHost: args.jupiterHost,
+    });
+    quotes.push(q);
+    const bundle = await getSwapInstructions({
+      quote: q,
+      userPublicKey: args.user,
+      destinationTokenAccount: userWsolAta,
+      // We explicitly manage the wSOL ATA — don't let Jupiter
+      // auto-unwrap mid-flight (it would close the ATA between legs).
+      wrapAndUnwrapSol: false,
+      jupiterHost: args.jupiterHost,
+    });
+    swapBundles.push(bundle);
+  }
+
+  // 4. Assemble the tx.
+  const ixes: TransactionInstruction[] = [];
+  const seen = new Set<string>();
+  const pushDedup = (ix: TransactionInstruction) => {
+    const key = JSON.stringify([
+      ix.programId.toBase58(),
+      ix.keys.map(k => `${k.pubkey.toBase58()}:${k.isSigner}:${k.isWritable}`),
+      ix.data.toString("base64"),
+    ]);
+    if (!seen.has(key)) {
+      seen.add(key);
+      ixes.push(ix);
+    }
+  };
+
+  // Compute budget from the first Jupiter response.
+  for (const raw of swapBundles[0].computeBudgetInstructions) {
+    pushDedup(deserializeIx(raw));
+  }
+
+  // Create user basket ATAs + wSOL ATA idempotently. Note: user ETF
+  // ATA is the *source* of the burn, so the caller must already have
+  // ETF tokens (we don't create it here — burning from a non-existent
+  // account would fail).
+  for (let i = 0; i < n; i++) {
+    pushDedup(
+      createAssociatedTokenAccountIdempotentInstruction(
+        args.user,
+        userBasketAtas[i],
+        args.user,
+        args.basketMints[i],
+      ),
+    );
+  }
+  pushDedup(
+    createAssociatedTokenAccountIdempotentInstruction(
+      args.user,
+      userWsolAta,
+      args.user,
+      NATIVE_MINT,
+    ),
+  );
+
+  // Withdraw first: burns the ETF tokens, transfers basket tokens to
+  // userBasketAtas. `min_tokens_out = 0` at the axis-vault layer so we
+  // don't duplicate the slippage check that Jupiter is already doing.
+  // If the caller wanted on-chain enforcement they'd use the (future)
+  // native WithdrawSol instruction.
+  ixes.push(
+    buildAxisWithdrawIx(
+      args.programId,
+      args.user,
+      args.etfState,
+      args.etfMint,
+      userEtfAta,
+      args.treasuryEtfAta,
+      args.vaults,
+      userBasketAtas,
+      args.etfName,
+      args.burnAmount,
+      0n,
+    ),
+  );
+
+  for (const bundle of swapBundles) {
+    for (const raw of bundle.setupInstructions) pushDedup(deserializeIx(raw));
+    pushDedup(deserializeIx(bundle.swapInstruction));
+    if (bundle.cleanupInstruction) {
+      pushDedup(deserializeIx(bundle.cleanupInstruction));
+    }
+  }
+
+  // Close the wSOL ATA to return all wrapped lamports as native SOL to
+  // the user. Rent-exempt minimum also returns.
+  ixes.push(
+    createCloseAccountInstruction(userWsolAta, args.user, args.user),
+  );
+
+  // 5. Size / slippage checks before returning.
+  const expectedSolOut = quotes.reduce((s, q) => s + BigInt(q.outAmount), 0n);
+  const minSolOutGuaranteed = quotes.reduce(
+    (s, q) => s + BigInt(q.otherAmountThreshold),
+    0n,
+  );
+  if (args.minSolOut !== undefined && minSolOutGuaranteed < args.minSolOut) {
+    throw new Error(
+      `Quoted SOL out ${minSolOutGuaranteed} < minSolOut ${args.minSolOut}. ` +
+      `Bump slippageBps or reduce burnAmount.`,
+    );
+  }
+
+  const altAddresses = swapBundles.flatMap(b => b.addressLookupTableAddresses);
+  const altAccounts = await fetchAltAccounts(args.conn, altAddresses);
+
+  const blockhash =
+    args.recentBlockhash ??
+    (await args.conn.getLatestBlockhash("finalized")).blockhash;
+  const message = new TransactionMessage({
+    payerKey: args.user,
+    recentBlockhash: blockhash,
+    instructions: ixes,
+  }).compileToV0Message(altAccounts);
+  const versionedTx = new VersionedTransaction(message);
+
+  return {
+    versionedTx,
+    altAccounts,
+    quotes,
+    expectedBasketFromVault,
+    expectedSolOut,
+    minSolOutGuaranteed,
+    ixCount: ixes.length,
+  };
+}

--- a/scripts/package.json
+++ b/scripts/package.json
@@ -3,6 +3,7 @@
   "version": "0.1.0",
   "private": true,
   "scripts": {
-    "setup-feeds": "bun setup-switchboard-feeds.ts"
+    "setup-feeds": "bun setup-switchboard-feeds.ts",
+    "axis-vault:demo": "bun axis-vault/demo.ts"
   }
 }


### PR DESCRIPTION
## Summary

Closes the UX part of #36 (pump-style: pay in SOL, receive SOL on exit).

Ships **client-bundled** Jupiter integration — a single versioned transaction containing `[ComputeBudget][Jupiter × N][axis-vault Deposit]` (or the reverse for Withdraw). This is how production basket / ETF protocols on Solana integrate Jupiter (Kamino, Drift, Marginfi vaults) and it's what Jupiter themselves recommend.

## Why client-bundled, not on-chain CPI

An on-chain Jupiter CPI inside axis-vault would have hit three structural walls:

1. **Account-list blow-up** — one Jupiter route carries 20–40 accounts. A 5-leg basket ≈ 150 accounts, well past the ALT-expanded tx envelope once axis-vault's own accounts are added.
2. **CU budget** — a Jupiter swap is 200–400k CU; five legs alone overrun the 1.4M CU cap before Deposit logic runs.
3. **Testability** — Jupiter V6 is mainnet-only, so on-chain CPI forces every e2e into a mainnet-fork. Client-bundled tests run against any RPC.

Atomicity is preserved: a versioned tx is all-or-nothing, so if any Jupiter leg or the final `Deposit` reverts, the whole thing reverts.

## Files

Under `scripts/axis-vault/`:

| File | What |
|------|------|
| `jupiter.ts` | Typed wrapper over Jupiter V6 `/quote` + `/swap-instructions`, ALT loader. |
| `deposit-sol.ts` | Builds `[ComputeBudget][Jupiter × N][axis-vault Deposit]` versioned tx with layered slippage guards. |
| `withdraw-sol.ts` | Builds `[ComputeBudget][Withdraw][Jupiter × N][Close wSOL]`; estimates per-leg Withdraw output off-chain to pre-quote Jupiter. |
| `demo.ts` | Manual runbook against real Jupiter. |
| `demo.stub.test.ts` | Stub-fetch regression test (no network) validating tx structure — IX count, size, correct final IX, safe `depositAmount` floor. |
| `README.md` | Design rationale + mainnet-fork test instructions. |

## Slippage layering

Three independent guards, conservative by design:

| Layer | Where | Catches |
|-------|-------|---------|
| `slippageBps` per leg | Jupiter `otherAmountThreshold` | Price move between quote and exec. |
| `minEtfOut` / `minSolOut` | axis-vault `min_mint_out` / client | Rounding drift, partial fill. |
| `MAX_NAV_DEVIATION_BPS = 300` | axis-vault Deposit (on-chain) | Vault ratio drift (from #18). |

## Scope vs the 6-subtask breakdown

Shipped here:
- [x] Jupiter route construction (client-side)
- [x] Versioned tx + ALT support
- [x] Deposit SOL-in path
- [x] Withdraw SOL-out path
- [x] Layered slippage (user + Jupiter + NAV)

Explicitly deferred (follow-up PRs):
- [ ] Native on-chain `DepositSol` / `WithdrawSol` for callers that need strict on-chain `minSolOut` enforcement (today it's client-checked).
- [ ] Scripted mainnet-fork CI invocation with the full DEX `--clone` list (the template is already in `test/e2e/axis-g3m/axis-g3m.jupiter-fork.e2e.ts`).

## Test plan

- [x] `bash ci/ts-typecheck.sh` — all 7 TS projects clean.
- [x] `bash ci/rust-tests.sh` — no regressions (no Rust changes in this PR).
- [x] `bun scripts/axis-vault/demo.stub.test.ts` — stub-fetch structure test passes:
  - 13 IXes assembled (2 compute + 4 ATA creates + 3 legs × 2 + 1 Deposit)
  - 1088 bytes serialized (fits the 1232-byte versioned-tx cap)
  - `depositAmount = 990_000_000` exactly matches `(0.99 × 1 SOL) × 10_000 / 5_000_weight` — the safe per-leg floor under the 100 bps stub slippage.
  - Final IX is axis-vault Deposit (disc = 1).
- [ ] Manual fork run: `JUPITER_HOST=https://quote-api.jup.ag bun scripts/axis-vault/demo.ts` against a mainnet-fork validator.
- [ ] Review by @sidneywakala.

## Notes for reviewer

- **Dust**: Jupiter's per-leg outputs don't land on exact weight ratios, so the helper computes a safe `depositAmount` floor from `otherAmountThreshold`; leftover basket tokens stay in user ATAs as dust. Standard trade-off for client-bundled ETF deposits. An on-chain `DepositSol` variant (fee-aware, per-leg amounts) can eliminate the dust and is tracked as a follow-up.
- **wSOL handling**: The deposit helper lets Jupiter wrap/unwrap on the first and last legs only (shared wSOL ATA); the withdraw helper manages the wSOL ATA itself and closes it at the end to return native SOL.
- **No program changes** in this PR — the existing `Deposit` / `Withdraw` instructions are used as-is.
- Independent of #35 / #37 / #38. Rebases cleanly on current main.