### PR TITLE
fix(pfda-amm): stop collapsing oracle Q32.32 prices with >> 32 (#33)

### DIFF
--- a/contracts/pfda-amm/src/instructions/clear_batch.rs
+++ b/contracts/pfda-amm/src/instructions/clear_batch.rs
@@ -208,8 +208,16 @@ pub fn process_clear_batch(program_id: &Pubkey, accounts: &[AccountInfo], bid_la
                 // The clearing price is bounded by the oracle price to prevent
                 // manipulation: |clearing - oracle| <= max_deviation.
                 let effective_cp = if let Some((price_a, price_b)) = oracle_prices {
-                    // Oracle-derived market price: B per A = price_a / price_b
-                    let oracle_price = fp_div(fp_from_int(price_a >> 32), fp_from_int((price_b >> 32).max(1)));
+                    // Oracle-derived market price: B per A = price_a / price_b.
+                    // price_a / price_b are already Q32.32 (see oracle::read_switchboard_price);
+                    // dividing them with fp_div yields a Q32.32 ratio directly.
+                    //
+                    // The previous version applied `>> 32` to both sides before the
+                    // divide, which collapsed the integer part of each price and
+                    // (for sub-dollar tokens) rounded the price to 0, causing the
+                    // numerator or denominator to degenerate. Kidney flagged this
+                    // in #33.
+                    let oracle_price = fp_div(price_a, price_b.max(1));
                     // Use the G3M price but clamp to within 5% of oracle
                     let max_dev_bps: u64 = 500; // 5%
                     let lower = oracle_price.saturating_sub(oracle_price * max_dev_bps / 10_000);

--- a/contracts/pfda-amm/src/math/fp64.rs
+++ b/contracts/pfda-amm/src/math/fp64.rs
@@ -731,6 +731,71 @@ mod tests {
         assert_eq!(interp2, 400_000, "Weight at end should be target");
     }
 
+    // ───────── #33 regression: oracle Q32.32 ratio ─────────
+
+    /// Switchboard prices come in as Q32.32. ClearBatch previously applied
+    /// `>> 32` to each before computing a ratio, which collapsed the
+    /// integer part of each price and — for sub-unit prices — rounded to
+    /// zero, degenerating the oracle guard to 0.
+    ///
+    /// The fix uses `fp_div(price_a, price_b.max(1))` directly on the
+    /// Q32.32 values. Verify the ratio comes out correct for both
+    /// sub-unit and multi-unit prices.
+    #[test]
+    fn oracle_price_ratio_preserves_sub_unit_values() {
+        // price_a = $0.50, price_b = $1.00 — realistic memecoin vs USDC
+        let price_a = FP_ONE / 2; // 0.5 in Q32.32
+        let price_b = FP_ONE;      // 1.0 in Q32.32
+
+        // New code path
+        let ratio = fp_div(price_a, price_b.max(1));
+        // Expect 0.5 in Q32.32 = FP_ONE / 2
+        let tol = FP_ONE / 1_000_000;
+        assert!(
+            ratio.abs_diff(FP_ONE / 2) <= tol,
+            "sub-unit ratio: got {}, expected {}",
+            ratio,
+            FP_ONE / 2
+        );
+
+        // Demonstrate the old bug: price_a >> 32 == 0, fp_from_int(0) == 0,
+        // so the old formula would have produced oracle_price == 0.
+        let old_price_a_shifted = price_a >> 32;
+        assert_eq!(old_price_a_shifted, 0, "old bug would feed 0 to fp_from_int");
+    }
+
+    #[test]
+    fn oracle_price_ratio_for_dollar_magnitudes() {
+        // price_a = $100 (SOL-ish), price_b = $1 (USDC)
+        let price_a = fp_from_int(100);
+        let price_b = fp_from_int(1);
+
+        let ratio = fp_div(price_a, price_b.max(1));
+        // Expect 100.0 in Q32.32
+        let tol = FP_ONE / 1_000;
+        assert!(
+            ratio.abs_diff(fp_from_int(100)) <= tol,
+            "dollar-magnitude ratio: got {}, expected {}",
+            ratio,
+            fp_from_int(100)
+        );
+    }
+
+    #[test]
+    fn oracle_price_ratio_handles_zero_denominator_via_max1() {
+        // If the oracle returned 0 for price_b (degenerate), the .max(1)
+        // guard in clear_batch.rs prevents a u64::MAX fallback from
+        // fp_div. The resulting ratio is huge (price_a << 32) but no
+        // panic and no u64::MAX sentinel.
+        let price_a = FP_ONE; // 1.0 in Q32.32
+        let price_b = 0u64;
+        let ratio = fp_div(price_a, price_b.max(1));
+        // 1.0 / (1/2^32) = 2^32 in Q32.32 = 2^64 which overflows; u64::MAX
+        // would imply clamp-to-inf behavior, which the oracle clamp
+        // would then ignore — acceptable degenerate handling.
+        let _ = ratio; // we only care that it didn't panic
+    }
+
     #[test]
     fn test_clearing_price_general_weight() {
         // 60/40 pool


### PR DESCRIPTION
## Summary

Addresses the Switchboard-oracle Q32.32 bug kidneyweakx flagged in #33.

## The bug

`ClearBatch`'s oracle-bounded clearing path built the oracle-derived price as:

\`\`\`rust
let oracle_price = fp_div(
    fp_from_int(price_a >> 32),
    fp_from_int((price_b >> 32).max(1)),
);
\`\`\`

Switchboard prices are already Q32.32. `price >> 32` strips the fractional bits and keeps the integer; `fp_from_int` shifts left by 32 again — so the round-trip rounds every oracle price to the nearest whole dollar. For any sub-unit price (memecoins, or any token quoted under \$1) `price >> 32 == 0`, the numerator collapses to 0, and `fp_div(0, ...)` returns 0. The clamp bounds `(lower, upper)` become `(0, 0)`, and `cp.max(0).min(0)` forces the clearing price itself to 0.

## The fix

`fp_div` accepts Q32.32 operands and returns a Q32.32 ratio directly. Drop the `>> 32` / `fp_from_int` round-trip:

\`\`\`rust
let oracle_price = fp_div(price_a, price_b.max(1));
\`\`\`

The `.max(1)` on the denominator is preserved so a degenerate zero-price feed doesn't trip `fp_div`'s zero-denominator sentinel.

## Tests

Three unit tests added to `math/fp64.rs`:

1. `oracle_price_ratio_preserves_sub_unit_values` — `\$0.50 / \$1.00` returns `0.5` in Q32.32 under the new formula, and explicitly asserts `price_a >> 32 == 0` to document the old bug.
2. `oracle_price_ratio_for_dollar_magnitudes` — `\$100 / \$1` returns `100.0` in Q32.32 within 0.1%.
3. `oracle_price_ratio_handles_zero_denominator_via_max1` — zero-price denominator doesn't panic.

## Test plan

- [x] \`cargo test --lib\` (pfda-amm): 19 pass
- [x] \`cargo build-sbf\`: clean
- [ ] Review by @kidneyweakx

## Scope

Two files: the one-liner in `instructions/clear_batch.rs` and the three new tests in `math/fp64.rs`. No behavior change for whole-dollar prices (those happened to work with the old code); sub-dollar tokens now get a real oracle clamp instead of a degenerate zero.