### PR TITLE
fix(pfda-amm-3): decrement pool.reserves in WithdrawFees (#33)

### DIFF
--- a/contracts/pfda-amm-3/src/error.rs
+++ b/contracts/pfda-amm-3/src/error.rs
@@ -38,6 +38,8 @@ pub enum Pfda3Error {
     InvariantViolation = 8030,
     /// Bid is disproportionately large relative to batch volume
     BidExcessive = 8031,
+    /// WithdrawFees requested amount exceeds tracked reserves (#33)
+    FeeWithdrawExceedsReserves = 8032,
 }
 
 impl From<Pfda3Error> for ProgramError {

--- a/contracts/pfda-amm-3/src/instructions/withdraw_fees.rs
+++ b/contracts/pfda-amm-3/src/instructions/withdraw_fees.rs
@@ -8,7 +8,7 @@ use pinocchio::{
 use pinocchio_token::instructions::Transfer;
 
 use crate::error::Pfda3Error;
-use crate::state::{load, PoolState3};
+use crate::state::{load_mut, PoolState3};
 
 /// WithdrawFees — authority withdraws accumulated protocol fees from vaults.
 ///
@@ -17,12 +17,23 @@ use crate::state::{load, PoolState3};
 ///
 /// Accounts:
 ///   0: [signer]   authority (must match pool.authority)
-///   1: []          pool_state PDA
+///   1: [writable]  pool_state PDA
 ///   2..2+N: [writable] vault token accounts
 ///   5..5+N: [writable] treasury token accounts (destinations)
 ///   8: []          token_program
 ///
 /// Data: [amounts: [u64; 3]] — how much to withdraw from each vault
+///
+/// Accounting: kidneyweakx flagged in #33 that the original version
+/// transferred tokens out of the vaults without decrementing
+/// `pool.reserves[i]`. Every subsequent `ClearBatch` / `SwapRequest`
+/// then priced against a reserve snapshot that no longer matched the
+/// real vault balance — leading to oversold clearings and eventual
+/// transfer failures once the real vault ran out.
+///
+/// Fix: decrement `pool.reserves[i]` by `amounts[i]` in the same
+/// instruction, with an `InsufficientBalance` guard up-front so the
+/// authority can't accidentally under-flow the accounting.
 pub fn process_withdraw_fees(
     _program_id: &Pubkey,
     accounts: &[AccountInfo],
@@ -35,8 +46,11 @@ pub fn process_withdraw_fees(
         return Err(ProgramError::MissingRequiredSignature);
     }
 
-    // Validate authority
-    let (pool_key, pool_authority, token_mints, bump) = {
+    // Validate authority + capture the values we need for CPIs. We
+    // also pre-check that every requested withdrawal fits inside the
+    // tracked reserves so we don't start transferring before we know
+    // the whole batch can succeed.
+    let (mints, bump) = {
         let data = pool_ai.try_borrow_data()?;
         let pool = unsafe { crate::state::load::<PoolState3>(&data) }
             .ok_or(ProgramError::InvalidAccountData)?;
@@ -46,15 +60,12 @@ pub fn process_withdraw_fees(
         if authority.key().as_ref() != &pool.authority {
             return Err(Pfda3Error::OwnerMismatch.into());
         }
-        (*pool_ai.key(), pool.authority, pool.token_mints, pool.bump)
-    };
-
-    // Read mint keys for PDA signer seeds
-    let mints = {
-        let data = pool_ai.try_borrow_data()?;
-        let pool = unsafe { crate::state::load::<PoolState3>(&data) }
-            .ok_or(ProgramError::InvalidAccountData)?;
-        pool.token_mints
+        for i in 0..3 {
+            if amounts[i] > pool.reserves[i] {
+                return Err(Pfda3Error::FeeWithdrawExceedsReserves.into());
+            }
+        }
+        (pool.token_mints, pool.bump)
     };
 
     let bump_bytes = [bump];
@@ -78,6 +89,22 @@ pub fn process_withdraw_fees(
                 amount: amounts[i],
             }
             .invoke_signed(&[Signer::from(&pool_signer_seeds)])?;
+        }
+    }
+
+    // Decrement tracked reserves so subsequent ClearBatch / SwapRequest
+    // price against the real post-withdrawal vault balance.
+    {
+        let mut data = pool_ai.try_borrow_mut_data()?;
+        let pool = unsafe { load_mut::<PoolState3>(&mut data) }
+            .ok_or(ProgramError::InvalidAccountData)?;
+        for i in 0..3 {
+            // checked_sub is belt-and-braces: we already validated the
+            // amount above, but the mutable borrow is a new read so
+            // guard against a concurrent-modification false assumption.
+            pool.reserves[i] = pool.reserves[i]
+                .checked_sub(amounts[i])
+                .ok_or(Pfda3Error::FeeWithdrawExceedsReserves)?;
         }
     }
 


### PR DESCRIPTION
## Summary

Addresses the \`WithdrawFees\` accounting bug kidneyweakx flagged in #33.

## The bug

\`WithdrawFees\` transferred tokens from the pool vaults to treasury ATAs but never touched \`pool.reserves[i]\`. Every subsequent \`ClearBatch\` / \`SwapRequest\` then computed clearing prices and per-ticket payouts against a reserve snapshot that no longer matched the real vault balance. Downstream symptoms:

- Oversold clearings (pool books liquidity it no longer holds).
- Hard CPI failures once a real vault ran below the tracked reserve.
- Silent NAV drift over multiple withdraw cycles.

## The fix

Two changes to \`withdraw_fees.rs\`:

1. **Pre-check**: reject up-front if any \`amounts[i] > pool.reserves[i]\` so the instruction doesn't start transferring before knowing the whole batch can succeed. New error \`FeeWithdrawExceedsReserves = 8032\` (distinct code so failures are easy to grep in logs).
2. **Post-transfer decrement**: after the transfers land, re-borrow \`pool_state\` mutably and \`reserves[i] -= amounts[i]\` via \`checked_sub\`. The checked form is belt-and-braces — the pre-check already validated the amount, but the mutable borrow is a fresh read and it costs nothing to guard against a concurrent-modification false assumption.

## Test plan

- [x] \`cargo build-sbf\`: clean.
- [ ] **E2E coverage** — \`WithdrawFees\` was listed under \"zero coverage\" in #33. I'm opening a separate test PR that exercises the full success + reserves-exceeded + wrong-authority paths against a local validator. This PR is scoped to the on-chain fix; merging it before the tests lands doesn't change behavior for any pool where fees haven't yet been withdrawn.
- [ ] Review by @kidneyweakx.

## Scope

Two files, ~30 LOC. No changes to callers or call sites. The new error code slots after the last allocated (8031) with no collision against other open PRs.