### PR TITLE
fix(pfda-amm): harden init, swap, add-liquidity, clear-batch validation (#33)

### DIFF
--- a/contracts/pfda-amm/src/error.rs
+++ b/contracts/pfda-amm/src/error.rs
@@ -41,6 +41,14 @@ pub enum PfmmError {
     OracleOwnerMismatch = 6017,
     /// Pool is paused
     PoolPaused = 6018,
+    /// InitializePool base_fee_bps ≥ 10_000 (fee ≥ 100%)
+    InvalidFeeBps = 6019,
+    /// Vault account does not match pool.vault_a / pool.vault_b
+    VaultMismatch = 6020,
+    /// Jito bid is below MIN_BID_LAMPORTS
+    BidTooLow = 6021,
+    /// next_window_end would overflow u64
+    WindowEndOverflow = 6022,
 }
 
 impl From<PfmmError> for ProgramError {

--- a/contracts/pfda-amm/src/instructions/add_liquidity.rs
+++ b/contracts/pfda-amm/src/instructions/add_liquidity.rs
@@ -39,12 +39,18 @@ pub fn process_add_liquidity(
         return Err(ProgramError::MissingRequiredSignature);
     }
 
-    // Verify pool_state PDA and initialization
+    // Verify pool_state PDA and initialization. #33 flagged that the
+    // original version skipped the paused flag and never cross-checked
+    // the vault accounts passed in by the caller against the ones
+    // stored on the pool.
     {
         let data = pool_state_ai.try_borrow_data()?;
         let pool = unsafe { load::<PoolState>(&data) }.ok_or(ProgramError::InvalidAccountData)?;
         if !pool.is_initialized() {
             return Err(PfmmError::InvalidDiscriminator.into());
+        }
+        if pool.paused != 0 {
+            return Err(PfmmError::PoolPaused.into());
         }
         let (expected, _) = pubkey::find_program_address(
             &[b"pool", &pool.token_a_mint, &pool.token_b_mint],
@@ -52,6 +58,9 @@ pub fn process_add_liquidity(
         );
         if pool_state_ai.key() != &expected {
             return Err(ProgramError::InvalidSeeds);
+        }
+        if vault_a.key() != &pool.vault_a || vault_b.key() != &pool.vault_b {
+            return Err(PfmmError::VaultMismatch.into());
         }
     }
 

--- a/contracts/pfda-amm/src/instructions/clear_batch.rs
+++ b/contracts/pfda-amm/src/instructions/clear_batch.rs
@@ -46,22 +46,31 @@ pub fn process_clear_batch(program_id: &Pubkey, accounts: &[AccountInfo], bid_la
     // If bid_lamports > 0 and accounts[8] is a protocol treasury,
     // transfer SOL from cranker to treasury. This is the searcher's payment
     // for exclusive clearing rights in this batch window.
-    if bid_lamports > 0 && accounts.len() > 8 {
-        let treasury = &accounts[8];
-
-        // Transfer SOL from cranker to treasury via system program CPI
-        pinocchio_system::instructions::Transfer {
-            from: cranker,
-            to: treasury,
-            lamports: bid_lamports,
+    //
+    // #33: MIN_BID_LAMPORTS was never enforced on pfda-amm — pfda-amm-3's
+    // ClearBatch already has the check; mirror it here so anti-spam
+    // parity holds across both programs.
+    if bid_lamports > 0 {
+        if bid_lamports < crate::jito::MIN_BID_LAMPORTS {
+            return Err(PfmmError::BidTooLow.into());
         }
-        .invoke()?;
+        if accounts.len() > 8 {
+            let treasury = &accounts[8];
 
-        // Compute revenue split for accounting
-        let (_protocol_share, _lp_share) = crate::jito::compute_bid_split(
-            bid_lamports,
-            crate::jito::DEFAULT_ALPHA_BPS,
-        );
+            // Transfer SOL from cranker to treasury via system program CPI
+            pinocchio_system::instructions::Transfer {
+                from: cranker,
+                to: treasury,
+                lamports: bid_lamports,
+            }
+            .invoke()?;
+
+            // Compute revenue split for accounting
+            let (_protocol_share, _lp_share) = crate::jito::compute_bid_split(
+                bid_lamports,
+                crate::jito::DEFAULT_ALPHA_BPS,
+            );
+        }
     }
 
     if !cranker.is_signer() {
@@ -309,7 +318,11 @@ pub fn process_clear_batch(program_id: &Pubkey, accounts: &[AccountInfo], bid_la
         .checked_add(1)
         .ok_or(PfmmError::Overflow)?;
     let next_batch_id_bytes = next_batch_id.to_le_bytes();
-    let next_window_end = current_window_end + window_slots;
+    // #33: unchecked u64 addition. Pool would brick once current_window_end
+    // approaches u64::MAX (or on a malformed pool state).
+    let next_window_end = current_window_end
+        .checked_add(window_slots)
+        .ok_or(PfmmError::WindowEndOverflow)?;
 
     let (expected_new_queue, new_queue_bump) = pubkey::find_program_address(
         &[b"queue", &pool_key, &next_batch_id_bytes],

--- a/contracts/pfda-amm/src/instructions/initialize_pool.rs
+++ b/contracts/pfda-amm/src/instructions/initialize_pool.rs
@@ -38,6 +38,12 @@ pub fn process_initialize_pool(
     if initial_weight_a > 1_000_000 {
         return Err(PfmmError::InvalidWeight.into());
     }
+    // A fee ≥ 100% would consume every swap output; reject at init so
+    // a misconfigured pool can never be deployed. kidneyweakx flagged
+    // the missing bound in #33.
+    if base_fee_bps >= 10_000 {
+        return Err(PfmmError::InvalidFeeBps.into());
+    }
 
     let [payer, pool_state_ai, batch_queue_ai, token_a_mint, token_b_mint, vault_a, vault_b, system_program, token_program, ..] =
         accounts

--- a/contracts/pfda-amm/src/instructions/swap_request.rs
+++ b/contracts/pfda-amm/src/instructions/swap_request.rs
@@ -47,7 +47,10 @@ pub fn process_swap_request(
         return Err(ProgramError::MissingRequiredSignature);
     }
 
-    // Load and validate pool_state
+    // Load and validate pool_state. #33 flagged that the vault
+    // accounts passed in by the caller were never cross-checked
+    // against the ones stored on the pool — an attacker could redirect
+    // the incoming transfer to an arbitrary token account.
     let (pool_key, current_batch_id, current_window_end, window_slots) = {
         let data = pool_state_ai.try_borrow_data()?;
         let pool = unsafe { load::<PoolState>(&data) }.ok_or(ProgramError::InvalidAccountData)?;
@@ -69,6 +72,9 @@ pub fn process_swap_request(
         );
         if pool_state_ai.key() != &expected_pool {
             return Err(ProgramError::InvalidSeeds);
+        }
+        if vault_a.key() != &pool.vault_a || vault_b.key() != &pool.vault_b {
+            return Err(PfmmError::VaultMismatch.into());
         }
 
         (


### PR DESCRIPTION
## Summary

Bundle of five localized validation additions that kidneyweakx listed in #33 for pfda-amm. All are guard-clause changes with no cross-instruction dependencies.

## Fixes

| Instruction | Gap | Fix | New error |
|-------------|-----|-----|-----------|
| \`InitializePool\` | \`base_fee_bps >= 10_000\` (100% fee) wasn't rejected | Add bound check at top of function | \`InvalidFeeBps = 6019\` |
| \`AddLiquidity\` | No \`paused\` check | Gate on \`pool.paused\` | \`PoolPaused\` (existing) |
| \`AddLiquidity\` | vaults not cross-checked against pool.vault_a/b | Reject \`vault_a/b != pool.vault_a/b\` | \`VaultMismatch = 6020\` |
| \`SwapRequest\` | same vault cross-check missing | same | \`VaultMismatch\` |
| \`ClearBatch\` | \`MIN_BID_LAMPORTS\` never enforced (pfda-amm-3 had it, pfda-amm didn't) | Reject \`bid_lamports > 0 && bid_lamports < MIN_BID_LAMPORTS\` | \`BidTooLow = 6021\` |
| \`ClearBatch\` | \`next_window_end = current_window_end + window_slots\` unchecked u64 add | \`checked_add\` + error | \`WindowEndOverflow = 6022\` |

## Why each matters

- **Fee bound**: a misconfigured pool with 100% fee consumes every swap output. No reason to let it deploy.
- **Paused on AddLiquidity**: pauses don't mean anything if liquidity still flows in.
- **Vault cross-check**: without it, `SwapRequest` / `AddLiquidity` would send user tokens to any attacker-supplied ATA that shares the correct mint.
- **MIN_BID_LAMPORTS**: sub-threshold bids churn accounting without contributing real Jito auction value — parity with pfda-amm-3.
- **Window overflow**: `current_window_end + window_slots` wrapping silently bricks the pool for future clearings. Small-probability, cheap-to-fix.

## Test plan

- [x] \`cargo build-sbf\`: clean.
- [x] \`cargo test --lib\`: 16 pass (no regressions; existing math / weight-interpolation tests unchanged).
- [ ] E2E coverage for each rejection path tracked alongside the zero-coverage gaps in #33.
- [x] Review by @kidneyweakx.

## Scope

Five files. No logic changes — every hunk is a new guard clause. Error codes stay within pfda-amm's 6000 series and don't collide with the other open #33 PRs (#43-#45, which are in the 8000 / 9000 ranges).