### PR TITLE
fix(pfda-amm-3): harden init, add-liquidity, swap, claim validation (#33)

### DIFF
--- a/contracts/pfda-amm-3/src/error.rs
+++ b/contracts/pfda-amm-3/src/error.rs
@@ -40,6 +40,11 @@ pub enum Pfda3Error {
     BidExcessive = 8031,
     /// WithdrawFees requested amount exceeds tracked reserves (#33)
     FeeWithdrawExceedsReserves = 8032,
+    /// InitializePool base_fee_bps ≥ 10_000 (#33)
+    InvalidFeeBps = 8033,
+    /// PDA substitution: passed-in account does not match the PDA
+    /// derived from the declared seeds (#33 claim history/ticket)
+    PdaMismatch = 8034,
 }
 
 impl From<Pfda3Error> for ProgramError {

--- a/contracts/pfda-amm-3/src/instructions/add_liquidity.rs
+++ b/contracts/pfda-amm-3/src/instructions/add_liquidity.rs
@@ -37,17 +37,36 @@ pub fn process_add_liquidity_3(
         return Err(ProgramError::MissingRequiredSignature);
     }
 
-    {
+    // #33: the original version skipped paused / reentrancy / vault
+    // cross-checks. Gate on all three so AddLiquidity shares the same
+    // safety posture as SwapRequest.
+    let pool_vaults = {
         let data = pool_ai.try_borrow_data()?;
         let pool = unsafe { load::<PoolState3>(&data) }
             .ok_or(ProgramError::InvalidAccountData)?;
         if !pool.is_initialized() {
             return Err(Pfda3Error::InvalidDiscriminator.into());
         }
-    }
+        if pool.paused != 0 {
+            return Err(Pfda3Error::PoolPaused.into());
+        }
+        if pool.reentrancy_guard != 0 {
+            return Err(Pfda3Error::ReentrancyDetected.into());
+        }
+        pool.vaults
+    };
 
     let vaults = [vault0, vault1, vault2];
     let user_tokens = [ut0, ut1, ut2];
+
+    // Vault mismatch check: every passed-in vault account must equal
+    // the pool's stored vault for that index. Otherwise a user could
+    // deposit into an attacker-controlled ATA of the right mint.
+    for i in 0..3 {
+        if vaults[i].key() != &pool_vaults[i] {
+            return Err(Pfda3Error::VaultMismatch.into());
+        }
+    }
 
     for i in 0..3 {
         if amounts[i] > 0 {

--- a/contracts/pfda-amm-3/src/instructions/claim.rs
+++ b/contracts/pfda-amm-3/src/instructions/claim.rs
@@ -58,7 +58,12 @@ pub fn process_claim_3(program_id: &Pubkey, accounts: &[AccountInfo]) -> Program
         verify_vault(vault_accounts[i], &token_mints[i], pool_key.as_ref().try_into().unwrap())?;
     }
 
-    // Load history
+    // Load history. #33 flagged that history_ai was only validated by
+    // comparing its stored `pool` field against pool_key — that left
+    // room for a crafted account with the right bytes but the wrong
+    // PDA. Re-derive the PDA from the declared seeds and compare it
+    // to history_ai.key() so only the canonical on-chain history for
+    // (pool, batch_id) can be consumed.
     let (batch_id, clearing_prices, total_in, total_out, fee_bps) = {
         let data = history_ai.try_borrow_data()?;
         let hist = unsafe { load::<ClearedBatchHistory3>(&data) }
@@ -69,10 +74,19 @@ pub fn process_claim_3(program_id: &Pubkey, accounts: &[AccountInfo]) -> Program
         if &hist.pool != pool_key.as_ref() {
             return Err(Pfda3Error::PoolMismatch.into());
         }
+        let batch_id_bytes = hist.batch_id.to_le_bytes();
+        let (expected_history, _) = pubkey::find_program_address(
+            &[b"history3", pool_key.as_ref(), &batch_id_bytes],
+            program_id,
+        );
+        if history_ai.key() != &expected_history {
+            return Err(Pfda3Error::PdaMismatch.into());
+        }
         (hist.batch_id, hist.clearing_prices, hist.total_in, hist.total_out, hist.fee_bps)
     };
 
-    // Load ticket
+    // Load ticket — same PDA re-derivation. Ticket seeds are
+    // [b"ticket3", pool, user, batch_id].
     let (in_idx, amount_in, out_idx, min_out) = {
         let data = ticket_ai.try_borrow_data()?;
         let ticket = unsafe { load::<UserOrderTicket3>(&data) }
@@ -88,6 +102,14 @@ pub fn process_claim_3(program_id: &Pubkey, accounts: &[AccountInfo]) -> Program
         }
         if &ticket.owner != user.key().as_ref() {
             return Err(Pfda3Error::OwnerMismatch.into());
+        }
+        let ticket_batch_bytes = ticket.batch_id.to_le_bytes();
+        let (expected_ticket, _) = pubkey::find_program_address(
+            &[b"ticket3", pool_key.as_ref(), user.key().as_ref(), &ticket_batch_bytes],
+            program_id,
+        );
+        if ticket_ai.key() != &expected_ticket {
+            return Err(Pfda3Error::PdaMismatch.into());
         }
 
         // Find which token was deposited

--- a/contracts/pfda-amm-3/src/instructions/initialize_pool.rs
+++ b/contracts/pfda-amm-3/src/instructions/initialize_pool.rs
@@ -42,6 +42,12 @@ pub fn process_initialize_pool_3(
         return Err(Pfda3Error::InvalidWeight.into());
     }
 
+    // #33: reject a fee ≥ 100% up-front so a misconfigured pool can
+    // never deploy. Mirrors the guard added to pfda-amm.
+    if base_fee_bps >= 10_000 {
+        return Err(Pfda3Error::InvalidFeeBps.into());
+    }
+
     // Accounts: payer, pool, queue, mint0-2, vault0-2, treasury, system, token_program
     if accounts.len() < 12 {
         return Err(ProgramError::NotEnoughAccountKeys);

--- a/contracts/pfda-amm-3/src/instructions/swap_request.rs
+++ b/contracts/pfda-amm-3/src/instructions/swap_request.rs
@@ -59,7 +59,10 @@ pub fn process_swap_request_3(
             return Err(Pfda3Error::ReentrancyDetected.into());
         }
         if pool.paused != 0 {
-            return Err(Pfda3Error::InvalidDiscriminator.into()); // pool is paused
+            // #33: was InvalidDiscriminator — mis-surfacing a pause as a
+            // discriminator error confused operators in logs. Return
+            // the dedicated PoolPaused code instead.
+            return Err(Pfda3Error::PoolPaused.into());
         }
         // Security rule 7: verify vault mint matches pool token
         crate::security::verify_token_account_mint(vault, &pool.token_mints[in_token_idx as usize])?;


### PR DESCRIPTION
## Summary

Bundle of four validation fixes kidneyweakx listed in #33 for pfda-amm-3. All localized guard-clause additions with no cross-instruction dependencies.

## Fixes

| Instruction | Gap | Fix | Error |
|-------------|-----|-----|-------|
| \`InitializePool\` | \`base_fee_bps >= 10_000\` not rejected | Add bound check | \`InvalidFeeBps = 8033\` |
| \`SwapRequest\` | Paused pool returned \`InvalidDiscriminator\` instead of \`PoolPaused\` | Return dedicated code | \`PoolPaused\` (existing) |
| \`AddLiquidity\` | No \`paused\` / \`reentrancy_guard\` / vault cross-check | Gate on all three; verify \`vaults[i] == pool.vaults[i]\` | \`PoolPaused\`, \`ReentrancyDetected\`, \`VaultMismatch\` (all existing) |
| \`Claim\` | \`history_ai\` / \`ticket_ai\` not re-derived from PDA seeds | \`find_program_address\` + compare to passed key | \`PdaMismatch = 8034\` |

## Why Claim's PDA re-derivation matters

The original code only checked stored fields (\`hist.pool\`, \`ticket.owner\`, \`ticket.batch_id\`) on the loaded account data. A crafted account owned by this program with the right bytes at those offsets would pass — even if its PDA doesn't match \`[b\"history3\", pool, batch_id]\` / \`[b\"ticket3\", pool, user, batch_id]\`. Re-deriving the PDA is the canonical way to ensure the account is the one the program itself created.

## Test plan

- [x] \`cargo build-sbf\`: clean.
- [x] \`cargo test --lib\`: 1 pass (existing).
- [ ] E2E coverage for rejection paths tracked alongside the other #33 zero-coverage items.
- [ ] Review by @kidneyweakx.

## Error numbering

Skips 8032 — reserved on the sibling \`fix/issue-33-pfda3-withdrawfees-reserves\` branch (\`FeeWithdrawExceedsReserves\`). Both PRs can merge in any order.

## Scope

Five files. All additions are pre-transfer guard clauses — no behavior change on the happy path, only adds rejection for attack inputs.