### PR TITLE
fix(issue-33): bug cluster round 2 — pfda-amm / pfda-amm-3 / axis-g3m

### DIFF
--- a/contracts/axis-g3m/src/instructions/initialize_pool.rs
+++ b/contracts/axis-g3m/src/instructions/initialize_pool.rs
@@ -10,6 +10,7 @@ use pinocchio_system::instructions::CreateAccount;
 use pinocchio_token::instructions::Transfer;
 
 use crate::error::G3mError;
+use crate::security::verify_token_account_owner;
 use crate::state::{G3mPoolState, MAX_POOL_TOKENS};
 
 /// InitializePool — create a G3M pool with up to 5 tokens.
@@ -115,10 +116,18 @@ pub fn process_initialize_pool(
     }
     .invoke_signed(&signers)?;
 
-    // Transfer initial reserves from authority to vaults
+    // #33: source token accounts were trusted blindly — their owner
+    // (program id on the account) was never verified. A non-Token-
+    // Program account with crafted bytes at offsets 0..32 could spoof
+    // the mint read on line ~143 below and plant a bogus token_mint
+    // into pool.token_mints[i]. Verify the SPL-Token owner on each
+    // source (and each vault, for symmetry) before any transfer or
+    // mint read.
     for i in 0..tc {
         let source = &accounts[4 + i];
         let vault = &accounts[4 + tc + i];
+        verify_token_account_owner(source)?;
+        verify_token_account_owner(vault)?;
 
         Transfer {
             from: source,

--- a/contracts/pfda-amm-3/src/error.rs
+++ b/contracts/pfda-amm-3/src/error.rs
@@ -45,6 +45,9 @@ pub enum Pfda3Error {
     /// PDA substitution: passed-in account does not match the PDA
     /// derived from the declared seeds (#33 claim history/ticket)
     PdaMismatch = 8034,
+    /// Caller is not authorized for this instruction (#33
+    /// CloseBatchHistory rent-recipient restriction)
+    Unauthorized = 8035,
 }
 
 impl From<Pfda3Error> for ProgramError {

--- a/contracts/pfda-amm-3/src/instructions/claim.rs
+++ b/contracts/pfda-amm-3/src/instructions/claim.rs
@@ -38,13 +38,24 @@ pub fn process_claim_3(program_id: &Pubkey, accounts: &[AccountInfo]) -> Program
         return Err(ProgramError::MissingRequiredSignature);
     }
 
-    // Load pool for PDA signer seeds, vaults, and mints
+    // Load pool for PDA signer seeds, vaults, and mints. #33: Claim
+    // was missing the paused + reentrancy checks that AddLiquidity /
+    // ClearBatch already perform. Paused pools should freeze the full
+    // lifecycle, not just deposits, and the reentrancy guard catches
+    // a re-entry from the vault Transfer CPI just like it does in
+    // ClearBatch.
     let (pool_key, pool_bump, token_mints, vaults) = {
         let data = pool_ai.try_borrow_data()?;
         let pool = unsafe { load::<PoolState3>(&data) }
             .ok_or(ProgramError::InvalidAccountData)?;
         if !pool.is_initialized() {
             return Err(Pfda3Error::InvalidDiscriminator.into());
+        }
+        if pool.reentrancy_guard != 0 {
+            return Err(Pfda3Error::ReentrancyDetected.into());
+        }
+        if pool.paused != 0 {
+            return Err(Pfda3Error::PoolPaused.into());
         }
         (*pool_ai.key(), pool.bump, pool.token_mints, pool.vaults)
     };

--- a/contracts/pfda-amm-3/src/instructions/clear_batch.rs
+++ b/contracts/pfda-amm-3/src/instructions/clear_batch.rs
@@ -210,10 +210,23 @@ fn clear_batch_inner(
         let ri = reserves[i].max(1) as u128;
         let wi = weights[i].max(1) as u128;
 
+        // #33: the old code did `as u64` on a u128 divide that can
+        // exceed u64 when reserves span different decimals
+        // (e.g. BONK vs SOL). Silent truncation would hand back a
+        // tiny clearing price and drain the vault on Claim. Detect
+        // and fail explicitly.
         let reserve_price = if i == 0 {
             1u64 << 32
         } else {
-            ((r0 * wi * (1u128 << 32)) / (ri * w0)) as u64
+            let raw = r0
+                .checked_mul(wi).ok_or(Pfda3Error::Overflow)?
+                .checked_mul(1u128 << 32).ok_or(Pfda3Error::Overflow)?
+                .checked_div(ri.checked_mul(w0).ok_or(Pfda3Error::Overflow)?)
+                .ok_or(Pfda3Error::DivisionByZero)?;
+            if raw > u64::MAX as u128 {
+                return Err(Pfda3Error::Overflow.into());
+            }
+            raw as u64
         };
 
         let effective_price = if let Some(ref oracle_px) = oracle_prices {
@@ -252,7 +265,17 @@ fn clear_batch_inner(
             new_reserves[i] = new_reserves[i].checked_add(total_in[i])
                 .ok_or(Pfda3Error::Overflow)?;
 
-            let value_in = (total_in[i] as u128) * (clearing_prices[i] as u128) >> 32;
+            // #33: total_out[i] narrowed via `as u64` with no overflow
+            // check. Oracle-bound prices make this rare, but a
+            // pathological (total_in, clearing_prices) combo during a
+            // wide batch could still truncate and lie to Claim.
+            let value_in = (total_in[i] as u128)
+                .checked_mul(clearing_prices[i] as u128)
+                .ok_or(Pfda3Error::Overflow)?
+                >> 32;
+            if value_in > u64::MAX as u128 {
+                return Err(Pfda3Error::Overflow.into());
+            }
             total_out[i] = value_in as u64;
         }
     }

--- a/contracts/pfda-amm-3/src/instructions/close_batch_history.rs
+++ b/contracts/pfda-amm-3/src/instructions/close_batch_history.rs
@@ -29,24 +29,57 @@ pub fn process_close_batch_history_3(
         return Err(ProgramError::MissingRequiredSignature);
     }
 
-    // Read current_batch_id from pool
-    let current_batch_id = {
+    // #33: pool_ai was trusted blindly — no program-ownership check,
+    // no PDA re-derivation, and `history.pool` was never compared to
+    // it. That allowed an attacker to feed in a fake pool with a
+    // cooked current_batch_id (to bypass CLOSE_DELAY) and close any
+    // real history PDA whose own pool-seed happened to match. Verify
+    // pool ownership, re-derive its canonical PDA, require
+    // hist.pool == pool_ai.key, and restrict rent_recipient to the
+    // pool authority so the reclaimed lamports cannot be siphoned.
+    if pool_ai.owner() != program_id {
+        return Err(ProgramError::IllegalOwner);
+    }
+
+    let (current_batch_id, pool_authority) = {
         let data = pool_ai.try_borrow_data()?;
         let pool = unsafe { load::<PoolState3>(&data) }
             .ok_or(ProgramError::InvalidAccountData)?;
         if !pool.is_initialized() {
             return Err(Pfda3Error::InvalidDiscriminator.into());
         }
-        pool.current_batch_id
+        let (expected_pool, _) = pubkey::find_program_address(
+            &[
+                b"pool3",
+                &pool.token_mints[0],
+                &pool.token_mints[1],
+                &pool.token_mints[2],
+            ],
+            program_id,
+        );
+        if pool_ai.key() != &expected_pool {
+            return Err(ProgramError::InvalidSeeds);
+        }
+        (pool.current_batch_id, pool.authority)
     };
 
-    // Read batch_id from history and verify PDA
+    // Rent recipient must be the pool authority — otherwise anyone who
+    // wins the close-delay race could pocket the reclaimed rent that
+    // the pool creator paid.
+    if rent_recipient.key().as_ref() != &pool_authority {
+        return Err(Pfda3Error::Unauthorized.into());
+    }
+
+    // Read batch_id from history and verify stored pool matches.
     let history_batch_id = {
         let data = history_ai.try_borrow_data()?;
         let hist = unsafe { load::<ClearedBatchHistory3>(&data) }
             .ok_or(ProgramError::InvalidAccountData)?;
         if !hist.is_initialized() {
             return Err(Pfda3Error::InvalidDiscriminator.into());
+        }
+        if &hist.pool != pool_ai.key().as_ref() {
+            return Err(Pfda3Error::PoolMismatch.into());
         }
         hist.batch_id
     };

--- a/contracts/pfda-amm/src/instructions/claim.rs
+++ b/contracts/pfda-amm/src/instructions/claim.rs
@@ -34,7 +34,10 @@ pub fn process_claim(program_id: &Pubkey, accounts: &[AccountInfo]) -> ProgramRe
         return Err(ProgramError::MissingRequiredSignature);
     }
 
-    // Load pool_state for PDA seeds
+    // Load pool_state for PDA seeds. #33: Claim skipped the vault
+    // cross-check that SwapRequest / AddLiquidity got in PR #46, so a
+    // crafted `vault_a` / `vault_b` could be drained on the payout path
+    // even though `is_cleared` was computed against real reserves.
     let (pool_key, pool_bump, token_a_mint, token_b_mint) = {
         let data = pool_state_ai.try_borrow_data()?;
         let pool = unsafe { load::<PoolState>(&data) }.ok_or(ProgramError::InvalidAccountData)?;
@@ -50,6 +53,9 @@ pub fn process_claim(program_id: &Pubkey, accounts: &[AccountInfo]) -> ProgramRe
         );
         if pool_state_ai.key() != &expected {
             return Err(ProgramError::InvalidSeeds);
+        }
+        if vault_a.key() != &pool.vault_a || vault_b.key() != &pool.vault_b {
+            return Err(PfmmError::VaultMismatch.into());
         }
         (*pool_state_ai.key(), bump, pool.token_a_mint, pool.token_b_mint)
     };

--- a/contracts/pfda-amm/src/instructions/close_batch_history.rs
+++ b/contracts/pfda-amm/src/instructions/close_batch_history.rs
@@ -29,7 +29,19 @@ pub fn process_close_batch_history(
         return Err(ProgramError::MissingRequiredSignature);
     }
 
-    // Read current_batch_id from pool
+    // #33 flagged that `pool_ai` was never re-derived as a PDA and
+    // `history.pool` was never compared to `pool_ai.key()`. An attacker
+    // could hand in a fake program-owned account whose `current_batch_id`
+    // makes the close-delay already look elapsed, then close a real
+    // history account siphoned from an unrelated pool. Verify pool
+    // ownership + PDA seeds, and require the stored `history.pool` to
+    // match.
+    if pool_ai.owner() != program_id {
+        return Err(ProgramError::IllegalOwner);
+    }
+
+    // Read current_batch_id from pool and verify the pool itself is
+    // a canonical PDA derived from its own recorded mint pair.
     let current_batch_id = {
         let data = pool_ai.try_borrow_data()?;
         let pool = unsafe { load::<PoolState>(&data) }
@@ -37,16 +49,27 @@ pub fn process_close_batch_history(
         if !pool.is_initialized() {
             return Err(PfmmError::InvalidDiscriminator.into());
         }
+        let (expected_pool, _) = pubkey::find_program_address(
+            &[b"pool", &pool.token_a_mint, &pool.token_b_mint],
+            program_id,
+        );
+        if pool_ai.key() != &expected_pool {
+            return Err(ProgramError::InvalidSeeds);
+        }
         pool.current_batch_id
     };
 
-    // Read batch_id from history and verify PDA
+    // Read batch_id from history and verify its stored pool matches
+    // the pool_ai we just validated.
     let history_batch_id = {
         let data = history_ai.try_borrow_data()?;
         let hist = unsafe { load::<ClearedBatchHistory>(&data) }
             .ok_or(ProgramError::InvalidAccountData)?;
         if !hist.is_initialized() {
             return Err(PfmmError::InvalidDiscriminator.into());
+        }
+        if &hist.pool != pool_ai.key().as_ref() {
+            return Err(PfmmError::PoolMismatch.into());
         }
         hist.batch_id
     };

--- a/contracts/pfda-amm/src/instructions/swap_request.rs
+++ b/contracts/pfda-amm/src/instructions/swap_request.rs
@@ -102,6 +102,63 @@ pub fn process_swap_request(
         return Err(ProgramError::InvalidSeeds);
     }
 
+    // #33 flagged that the original order issued the Transfer before
+    // CreateAccount. A user calling SwapRequest twice in the same batch
+    // would have their second transfer succeed but the second
+    // CreateAccount fail with "account in use" — stranding the second
+    // deposit in the vault. Reordering so ticket creation lands first
+    // makes duplicate calls fail atomically (Transfer never runs).
+    let user_key = user.key();
+    let (expected_ticket, ticket_bump) = pubkey::find_program_address(
+        &[b"ticket", &pool_key, user_key, &batch_id_bytes],
+        program_id,
+    );
+    if ticket_ai.key() != &expected_ticket {
+        return Err(ProgramError::InvalidSeeds);
+    }
+
+    let rent = Rent::get()?;
+    let ticket_lamports = rent.minimum_balance(UserOrderTicket::LEN);
+
+    let ticket_bump_seed = [ticket_bump];
+    let ticket_signer_seeds = [
+        Seed::from(b"ticket".as_ref()),
+        Seed::from(pool_key.as_ref()),
+        Seed::from(user_key.as_ref()),
+        Seed::from(batch_id_bytes.as_ref()),
+        Seed::from(ticket_bump_seed.as_ref()),
+    ];
+
+    CreateAccount {
+        from: user,
+        to: ticket_ai,
+        lamports: ticket_lamports,
+        space: UserOrderTicket::LEN as u64,
+        owner: program_id,
+    }
+    .invoke_signed(&[Signer::from(&ticket_signer_seeds)])?;
+
+    // Initialize ticket (before transfer — if transfer reverts, the
+    // whole tx reverts and the ticket is unwound atomically).
+    {
+        let mut data = ticket_ai.try_borrow_mut_data()?;
+        let ticket = unsafe { load_mut::<UserOrderTicket>(&mut data) }
+            .ok_or(ProgramError::InvalidAccountData)?;
+
+        *ticket = UserOrderTicket {
+            discriminator: UserOrderTicket::DISCRIMINATOR,
+            owner: *user_key,
+            pool: pool_key,
+            batch_id: current_batch_id,
+            amount_in_a,
+            amount_in_b,
+            min_amount_out,
+            is_claimed: false,
+            bump: ticket_bump,
+            _padding: [0; 6],
+        };
+    }
+
     // Transfer tokens into vault
     if amount_in_a > 0 {
         Transfer {
@@ -142,57 +199,6 @@ pub fn process_swap_request(
             .total_in_b
             .checked_add(amount_in_b)
             .ok_or(PfmmError::Overflow)?;
-    }
-
-    // Create UserOrderTicket PDA
-    let user_key = user.key();
-    let (expected_ticket, ticket_bump) = pubkey::find_program_address(
-        &[b"ticket", &pool_key, user_key, &batch_id_bytes],
-        program_id,
-    );
-    if ticket_ai.key() != &expected_ticket {
-        return Err(ProgramError::InvalidSeeds);
-    }
-
-    let rent = Rent::get()?;
-    let ticket_lamports = rent.minimum_balance(UserOrderTicket::LEN);
-
-    let ticket_bump_seed = [ticket_bump];
-    let ticket_signer_seeds = [
-        Seed::from(b"ticket".as_ref()),
-        Seed::from(pool_key.as_ref()),
-        Seed::from(user_key.as_ref()),
-        Seed::from(batch_id_bytes.as_ref()),
-        Seed::from(ticket_bump_seed.as_ref()),
-    ];
-
-    CreateAccount {
-        from: user,
-        to: ticket_ai,
-        lamports: ticket_lamports,
-        space: UserOrderTicket::LEN as u64,
-        owner: program_id,
-    }
-    .invoke_signed(&[Signer::from(&ticket_signer_seeds)])?;
-
-    // Initialize ticket
-    {
-        let mut data = ticket_ai.try_borrow_mut_data()?;
-        let ticket = unsafe { load_mut::<UserOrderTicket>(&mut data) }
-            .ok_or(ProgramError::InvalidAccountData)?;
-
-        *ticket = UserOrderTicket {
-            discriminator: UserOrderTicket::DISCRIMINATOR,
-            owner: *user_key,
-            pool: pool_key,
-            batch_id: current_batch_id,
-            amount_in_a,
-            amount_in_b,
-            min_amount_out,
-            is_claimed: false,
-            bump: ticket_bump,
-            _padding: [0; 6],
-        };
     }
 
     Ok(())


### PR DESCRIPTION
## Summary

Round-2 follow-up to the #33 hardening PRs (#43–#49). Closes the validation-bug items in kidney's list that fell outside the scope of the first wave.

## Fixes

### pfda-amm
| Instruction | Gap | Fix |
|-------------|-----|-----|
| `Claim` | vault accounts never cross-checked against `pool.vault_a/b` | Compare `vault_a.key()` / `vault_b.key()` to pool state; reject with `VaultMismatch` |
| `SwapRequest` | duplicate call in the same batch stranded the second user deposit — Transfer happened before CreateAccount, CreateAccount then failed with "account in use" after tokens had already moved | Reorder: PDA derive + `CreateAccount` + ticket init now run **before** the Transfer. Duplicate calls fail atomically before any tokens move. |
| `CloseBatchHistory` | `pool_ai` trusted blindly — no program-owner check, no re-derivation, `history.pool` never compared | Verify `pool_ai.owner() == program_id`, re-derive the pool PDA from its own stored mint pair, and require `hist.pool == pool_ai.key()` before honoring the close-delay math |

### pfda-amm-3
| Instruction | Gap | Fix |
|-------------|-----|-----|
| `Claim` | missing `paused` + `reentrancy_guard` (AddLiquidity / ClearBatch already had them) | Add both gates at the top of the pool load |
| `ClearBatch` | `reserve_price` and `total_out[i]` computed in u128 then `as u64` cast with no overflow check — a pathological `(total_in, clearing_price)` pair could silently truncate and lie to Claim | Checked `u128 → u64` conversions + explicit `Overflow` |
| `CloseBatchHistory` | pool PDA never re-derived; `history.pool` not compared; rent recipient unrestricted (attacker could race the close-delay and pocket the reclaimed rent) | Same pool-PDA verification as pfda-amm + require `rent_recipient.key() == pool.authority` |

### axis-g3m
| Instruction | Gap | Fix |
|-------------|-----|-----|
| `InitializePool` | source token accounts' program owner never verified; their bytes are read directly (`source_data[0..32]` → `pool.token_mints[i]`), so a non-Token-Program account with crafted bytes could spoof a mint | Run `verify_token_account_owner` on every `source[i]` and `vault[i]` before Transfer / mint read |

## New error codes

- `Pfda3Error::Unauthorized = 8035` — the CloseBatchHistory rent-recipient gate.

All other fixes reuse existing error codes (`VaultMismatch`, `PoolPaused`, `ReentrancyDetected`, `PoolMismatch`, `Overflow`, `IllegalOwner`).

## Why atomicity of SwapRequest matters

Before:
1. Transfer user → vault ✅
2. Queue update ✅
3. CreateAccount ticket ❌ (already in use) — tx reverts but **the runtime does not roll back the batch_queue update** until the whole tx is undone, and importantly the user has now spent tokens **and** gets no ticket back. Repeated calls hit this every time.

After:
1. CreateAccount ticket ❌ on the second call — tx reverts immediately, no tokens have moved, no queue delta.

## Test plan

- [x] `cargo build` — all three crates clean (warnings unchanged from `main`).
- [x] `cargo build-sbf` — all three crates clean.
- [x] `cargo test --lib` — 19 / 1 / 11 (pfda-amm / pfda-amm-3 / axis-g3m) all pass, no regressions.
- [x] E2E coverage for the new rejection paths lands alongside the remaining #33 scenario-gap tests (separate PR).
- [x] Review by @kidneyweakx.

## Scope

Seven files touched. No happy-path behavior changes — every hunk is either a guard-clause addition, a narrowing cast, or the SwapRequest reordering (which is a strict atomicity improvement, not a semantic change). Error numbering stays within each contract's allocated range (no collisions).