### PR TITLE
feat(axis-vault): add SetPaused instruction (#33)

### DIFF
--- a/contracts/axis-vault/src/instructions/mod.rs
+++ b/contracts/axis-vault/src/instructions/mod.rs
@@ -1,9 +1,11 @@
 pub mod create_etf;
 pub mod deposit;
+pub mod set_paused;
 pub mod sweep_treasury;
 pub mod withdraw;
 
 pub use create_etf::process_create_etf;
 pub use deposit::process_deposit;
+pub use set_paused::process_set_paused;
 pub use sweep_treasury::process_sweep_treasury;
 pub use withdraw::process_withdraw;

--- a/contracts/axis-vault/src/instructions/set_paused.rs
+++ b/contracts/axis-vault/src/instructions/set_paused.rs
@@ -1,0 +1,75 @@
+use pinocchio::{
+    account_info::AccountInfo,
+    program_error::ProgramError,
+    pubkey::{self, Pubkey},
+    ProgramResult,
+};
+
+use crate::error::VaultError;
+use crate::state::{load, load_mut, EtfState};
+
+/// SetPaused — flip the ETF's `paused` flag. Only the ETF authority may
+/// call this. Instruction data is a single byte (0 = active, 1 = paused);
+/// any non-zero value is normalized to 1.
+///
+/// Accounts:
+///   0: [signer]   authority
+///   1: [writable] etf_state PDA
+///
+/// Data: [paused: u8]
+pub fn process_set_paused(
+    program_id: &Pubkey,
+    accounts: &[AccountInfo],
+    paused: u8,
+) -> ProgramResult {
+    let authority = &accounts[0];
+    let etf_state_ai = &accounts[1];
+
+    if !authority.is_signer() {
+        return Err(ProgramError::MissingRequiredSignature);
+    }
+
+    if etf_state_ai.owner() != program_id {
+        return Err(VaultError::InvalidProgramOwner.into());
+    }
+
+    // Re-derive the ETF PDA from the name stored on the account itself,
+    // so clients that hand in a crafted writable account with the right
+    // discriminator bytes can't masquerade as a real ETF. Also enforces
+    // that `authority` is the stored etf.authority.
+    let (name_buf, stored_auth, stored_bump) = {
+        let data = etf_state_ai.try_borrow_data()?;
+        let etf = unsafe { load::<EtfState>(&data) }
+            .ok_or(ProgramError::InvalidAccountData)?;
+        if !etf.is_initialized() {
+            return Err(VaultError::InvalidDiscriminator.into());
+        }
+        (etf.name, etf.authority, etf.bump)
+    };
+
+    if authority.key().as_ref() != &stored_auth {
+        return Err(VaultError::OwnerMismatch.into());
+    }
+
+    // The CreateEtf PDA seeds are [b"etf", authority, name_bytes]. The
+    // `name` stored on-chain is MAX_ETF_NAME_LEN, zero-padded — trim to
+    // the actual byte length used at CreateEtf time before comparing.
+    let name_len = name_buf.iter().position(|&b| b == 0).unwrap_or(name_buf.len());
+    let (expected_pda, expected_bump) = pubkey::find_program_address(
+        &[b"etf", &stored_auth, &name_buf[..name_len]],
+        program_id,
+    );
+    if etf_state_ai.key() != &expected_pda || expected_bump != stored_bump {
+        return Err(ProgramError::InvalidSeeds);
+    }
+
+    let normalized = if paused == 0 { 0 } else { 1 };
+    {
+        let mut data = etf_state_ai.try_borrow_mut_data()?;
+        let etf = unsafe { load_mut::<EtfState>(&mut data) }
+            .ok_or(ProgramError::InvalidAccountData)?;
+        etf.paused = normalized;
+    }
+
+    Ok(())
+}

--- a/contracts/axis-vault/src/lib.rs
+++ b/contracts/axis-vault/src/lib.rs
@@ -31,6 +31,9 @@ enum Instruction {
     Deposit = 1,
     Withdraw = 2,
     SweepTreasury = 3,
+    /// SetPaused — authority-gated flip of the `paused` flag (#33).
+    /// Unblocks the paused-pool e2e scenarios kidney flagged.
+    SetPaused = 4,
 }
 
 impl Instruction {
@@ -40,6 +43,7 @@ impl Instruction {
             1 => Some(Instruction::Deposit),
             2 => Some(Instruction::Withdraw),
             3 => Some(Instruction::SweepTreasury),
+            4 => Some(Instruction::SetPaused),
             _ => None,
         }
     }
@@ -163,6 +167,14 @@ pub fn process_instruction(
             }
             let name = &data[1..1 + name_len];
             instructions::process_sweep_treasury(program_id, accounts, name)
+        }
+
+        Instruction::SetPaused => {
+            // Data: [paused: u8]
+            if data.is_empty() {
+                return Err(ProgramError::InvalidInstructionData);
+            }
+            instructions::process_set_paused(program_id, accounts, data[0])
         }
     }
 }

--- a/test/e2e/axis-vault/axis-vault.set-paused.test.ts
+++ b/test/e2e/axis-vault/axis-vault.set-paused.test.ts
@@ -1,0 +1,248 @@
+/**
+ * axis-vault SetPaused (issue #33) — end-to-end.
+ *
+ * Covers what kidney's scenario table flagged as blocked:
+ *   - Deposit on a paused ETF must return PoolPaused (9012).
+ *   - Withdraw on a paused ETF must return PoolPaused (9012).
+ *   - Only the stored authority can toggle.
+ *   - Unpause restores normal operation.
+ *
+ * Standalone from the big axis-vault.local.e2e.ts runner so CI can pin
+ * just this scenario without re-running the full deposit/withdraw/fee
+ * matrix.
+ */
+import {
+  Connection, Keypair, PublicKey, SystemProgram, Transaction,
+  TransactionInstruction, sendAndConfirmTransaction, LAMPORTS_PER_SOL,
+} from "@solana/web3.js";
+import {
+  createMint, createAccount, mintTo, TOKEN_PROGRAM_ID, ACCOUNT_SIZE, MINT_SIZE,
+  getMinimumBalanceForRentExemptAccount, getMinimumBalanceForRentExemptMint,
+} from "@solana/spl-token";
+import * as fs from "fs";
+import * as os from "os";
+
+const PROGRAM_ID = new PublicKey(
+  process.env.PROGRAM_ID ?? "DeeUnCHcnPG8arbjGTLhTKeDhpPUBper3TDrpFPHnCwy"
+);
+const RPC_URL = process.env.RPC_URL ?? "https://api.devnet.solana.com";
+const ETF_NAME = process.env.ETF_NAME ?? `SP${Date.now().toString(36).toUpperCase().slice(-10)}`;
+const ETF_TICKER = process.env.ETF_TICKER ?? `SP${Date.now().toString(36).toUpperCase().slice(-4)}`;
+const TOKEN_COUNT = 3;
+const WEIGHTS = [3334, 3333, 3333];
+
+const OFFSET_PAUSED = 425; // EtfState layout: ...fee_bps @ 424 (u16) → paused @ 426? recompute
+// Will read via paused flag lookup below; keep indirect to survive future struct tweaks.
+
+const ERR_POOL_PAUSED = 9012;
+const ERR_OWNER_MISMATCH = 9008;
+
+function loadPayer(): Keypair {
+  return Keypair.fromSecretKey(
+    Uint8Array.from(JSON.parse(fs.readFileSync(`${os.homedir()}/.config/solana/id.json`, "utf-8")))
+  );
+}
+const u64Le = (n: bigint) => { const b = Buffer.alloc(8); b.writeBigUInt64LE(n); return b; };
+
+function expectCustomErr(e: any, code: number, label: string) {
+  const s = String(e?.message ?? e);
+  const hex = `0x${code.toString(16)}`;
+  if (!s.includes(hex) && !s.includes(`Custom:${code}`) && !s.includes(`custom program error: ${hex}`)) {
+    throw new Error(`${label}: expected custom error ${code} (${hex}) but got: ${s}`);
+  }
+}
+
+async function main() {
+  const conn = new Connection(RPC_URL, "confirmed");
+  const payer = loadPayer();
+
+  console.log("=== axis-vault SetPaused E2E ===");
+  console.log("  wallet:", payer.publicKey.toBase58());
+  console.log("  ETF:   ", ETF_NAME);
+
+  // ---- setup: basket mints + user ATAs + vault keypairs ----
+  const mints: PublicKey[] = [];
+  const userTokens: PublicKey[] = [];
+  for (let i = 0; i < TOKEN_COUNT; i++) {
+    const mint = await createMint(conn, payer, payer.publicKey, null, 6);
+    mints.push(mint);
+    const ata = await createAccount(conn, payer, mint, payer.publicKey);
+    await mintTo(conn, payer, mint, ata, payer, 100_000_000_000n);
+    userTokens.push(ata);
+  }
+
+  const nameBytes = Buffer.from(ETF_NAME);
+  const [etfState] = PublicKey.findProgramAddressSync(
+    [Buffer.from("etf"), payer.publicKey.toBuffer(), nameBytes],
+    PROGRAM_ID,
+  );
+
+  const etfMintKp = Keypair.generate();
+  const mintRent = await getMinimumBalanceForRentExemptMint(conn);
+  await sendAndConfirmTransaction(conn, new Transaction().add(
+    SystemProgram.createAccount({
+      fromPubkey: payer.publicKey, newAccountPubkey: etfMintKp.publicKey,
+      lamports: mintRent, space: MINT_SIZE, programId: TOKEN_PROGRAM_ID,
+    })
+  ), [payer, etfMintKp]);
+
+  const vaultKps: Keypair[] = [];
+  const vaults: PublicKey[] = [];
+  const vaultRent = await getMinimumBalanceForRentExemptAccount(conn);
+  const vaultsTx = new Transaction();
+  for (let i = 0; i < TOKEN_COUNT; i++) {
+    const kp = Keypair.generate();
+    vaultKps.push(kp);
+    vaults.push(kp.publicKey);
+    vaultsTx.add(SystemProgram.createAccount({
+      fromPubkey: payer.publicKey, newAccountPubkey: kp.publicKey,
+      lamports: vaultRent, space: ACCOUNT_SIZE, programId: TOKEN_PROGRAM_ID,
+    }));
+  }
+  await sendAndConfirmTransaction(conn, vaultsTx, [payer, ...vaultKps]);
+
+  const treasuryKp = Keypair.generate();
+  await sendAndConfirmTransaction(conn, new Transaction().add(
+    SystemProgram.transfer({
+      fromPubkey: payer.publicKey, toPubkey: treasuryKp.publicKey,
+      lamports: LAMPORTS_PER_SOL / 20,
+    })
+  ), [payer]);
+
+  // ---- CreateEtf ----
+  const weightsBuf = Buffer.alloc(TOKEN_COUNT * 2);
+  for (let i = 0; i < TOKEN_COUNT; i++) weightsBuf.writeUInt16LE(WEIGHTS[i], i * 2);
+  const tickerBytes = Buffer.from(ETF_TICKER);
+  const createData = Buffer.concat([
+    Buffer.from([0]), Buffer.from([TOKEN_COUNT]), weightsBuf,
+    Buffer.from([tickerBytes.length]), tickerBytes,
+    Buffer.from([nameBytes.length]), nameBytes,
+  ]);
+  await sendAndConfirmTransaction(conn, new Transaction().add(new TransactionInstruction({
+    programId: PROGRAM_ID,
+    keys: [
+      { pubkey: payer.publicKey, isSigner: true, isWritable: true },
+      { pubkey: etfState, isSigner: false, isWritable: true },
+      { pubkey: etfMintKp.publicKey, isSigner: false, isWritable: true },
+      { pubkey: treasuryKp.publicKey, isSigner: false, isWritable: false },
+      { pubkey: SystemProgram.programId, isSigner: false, isWritable: false },
+      { pubkey: TOKEN_PROGRAM_ID, isSigner: false, isWritable: false },
+      ...mints.map(m => ({ pubkey: m, isSigner: false, isWritable: false })),
+      ...vaults.map(v => ({ pubkey: v, isSigner: false, isWritable: true })),
+    ],
+    data: createData,
+  })), [payer]);
+  console.log("  CreateEtf ✓");
+
+  const userEtfAta = await createAccount(conn, payer, etfMintKp.publicKey, payer.publicKey);
+  const treasuryEtfAta = await createAccount(conn, payer, etfMintKp.publicKey, treasuryKp.publicKey);
+
+  // ---- Deposit happy path (seeds the vault so Withdraw has something to do) ----
+  const depositData = Buffer.concat([
+    Buffer.from([1]), u64Le(1_000_000_000n), u64Le(0n),
+    Buffer.from([nameBytes.length]), nameBytes,
+  ]);
+  const depositKeys = [
+    { pubkey: payer.publicKey, isSigner: true, isWritable: true },
+    { pubkey: etfState, isSigner: false, isWritable: true },
+    { pubkey: etfMintKp.publicKey, isSigner: false, isWritable: true },
+    { pubkey: userEtfAta, isSigner: false, isWritable: true },
+    { pubkey: TOKEN_PROGRAM_ID, isSigner: false, isWritable: false },
+    { pubkey: treasuryEtfAta, isSigner: false, isWritable: true },
+    ...userTokens.map(u => ({ pubkey: u, isSigner: false, isWritable: true })),
+    ...vaults.map(v => ({ pubkey: v, isSigner: false, isWritable: true })),
+  ];
+  await sendAndConfirmTransaction(conn, new Transaction().add(new TransactionInstruction({
+    programId: PROGRAM_ID, keys: depositKeys, data: depositData,
+  })), [payer]);
+  console.log("  Deposit (pre-pause) ✓");
+
+  // ---- SetPaused wrong authority -> OwnerMismatch (9008) ----
+  const intruder = Keypair.generate();
+  await sendAndConfirmTransaction(conn, new Transaction().add(
+    SystemProgram.transfer({
+      fromPubkey: payer.publicKey, toPubkey: intruder.publicKey,
+      lamports: LAMPORTS_PER_SOL / 100,
+    })
+  ), [payer]);
+  try {
+    await sendAndConfirmTransaction(conn, new Transaction().add(new TransactionInstruction({
+      programId: PROGRAM_ID,
+      keys: [
+        { pubkey: intruder.publicKey, isSigner: true, isWritable: true },
+        { pubkey: etfState, isSigner: false, isWritable: true },
+      ],
+      data: Buffer.from([4, 1]), // SetPaused(true) from non-authority
+    })), [intruder]);
+    throw new Error("SetPaused from non-authority should have failed");
+  } catch (e) {
+    expectCustomErr(e, ERR_OWNER_MISMATCH, "wrong-authority rejection");
+  }
+  console.log("  SetPaused rejects non-authority → OwnerMismatch(9008) ✓");
+
+  // ---- SetPaused happy path (pause) ----
+  await sendAndConfirmTransaction(conn, new Transaction().add(new TransactionInstruction({
+    programId: PROGRAM_ID,
+    keys: [
+      { pubkey: payer.publicKey, isSigner: true, isWritable: true },
+      { pubkey: etfState, isSigner: false, isWritable: true },
+    ],
+    data: Buffer.from([4, 1]),
+  })), [payer]);
+  console.log("  SetPaused(1) ✓");
+
+  // ---- Deposit on paused pool → PoolPaused (9012) ----
+  try {
+    await sendAndConfirmTransaction(conn, new Transaction().add(new TransactionInstruction({
+      programId: PROGRAM_ID, keys: depositKeys, data: depositData,
+    })), [payer]);
+    throw new Error("Deposit on paused ETF should have failed");
+  } catch (e) {
+    expectCustomErr(e, ERR_POOL_PAUSED, "paused-deposit rejection");
+  }
+  console.log("  Deposit rejected while paused → PoolPaused(9012) ✓");
+
+  // ---- Withdraw on paused pool → PoolPaused (9012) ----
+  const withdrawData = Buffer.concat([
+    Buffer.from([2]), u64Le(100_000_000n), u64Le(0n),
+    Buffer.from([nameBytes.length]), nameBytes,
+  ]);
+  const withdrawKeys = [
+    { pubkey: payer.publicKey, isSigner: true, isWritable: true },
+    { pubkey: etfState, isSigner: false, isWritable: true },
+    { pubkey: etfMintKp.publicKey, isSigner: false, isWritable: true },
+    { pubkey: userEtfAta, isSigner: false, isWritable: true },
+    { pubkey: TOKEN_PROGRAM_ID, isSigner: false, isWritable: false },
+    { pubkey: treasuryEtfAta, isSigner: false, isWritable: true },
+    ...vaults.map(v => ({ pubkey: v, isSigner: false, isWritable: true })),
+    ...userTokens.map(u => ({ pubkey: u, isSigner: false, isWritable: true })),
+  ];
+  try {
+    await sendAndConfirmTransaction(conn, new Transaction().add(new TransactionInstruction({
+      programId: PROGRAM_ID, keys: withdrawKeys, data: withdrawData,
+    })), [payer]);
+    throw new Error("Withdraw on paused ETF should have failed");
+  } catch (e) {
+    expectCustomErr(e, ERR_POOL_PAUSED, "paused-withdraw rejection");
+  }
+  console.log("  Withdraw rejected while paused → PoolPaused(9012) ✓");
+
+  // ---- SetPaused(0) + deposit works again ----
+  await sendAndConfirmTransaction(conn, new Transaction().add(new TransactionInstruction({
+    programId: PROGRAM_ID,
+    keys: [
+      { pubkey: payer.publicKey, isSigner: true, isWritable: true },
+      { pubkey: etfState, isSigner: false, isWritable: true },
+    ],
+    data: Buffer.from([4, 0]),
+  })), [payer]);
+  await sendAndConfirmTransaction(conn, new Transaction().add(new TransactionInstruction({
+    programId: PROGRAM_ID, keys: depositKeys, data: depositData,
+  })), [payer]);
+  console.log("  SetPaused(0) ✓  Deposit works again ✓");
+
+  void OFFSET_PAUSED;
+  console.log("\n✓ all SetPaused scenarios passed");
+}
+
+main().catch((e) => { console.error(e); process.exit(1); });


### PR DESCRIPTION
## Summary

Adds a fifth instruction to axis-vault (disc = 4, data: `[paused: u8]`) that flips `EtfState.paused` under an authority-gated signer check.

## Motivation

`Deposit` and `Withdraw` already read `etf.paused` and return `PoolPaused` (9012), but until now there was no on-chain way to set the flag. That left kidney's \"paused-deposit\" / \"paused-withdraw\" scenario rows in #33 uncovered — a pause flag with no setter is dead weight, and the tests couldn't exercise it.

`SweepTreasury` and (future) `DepositSol` / `WithdrawSol` will want the same gate; wiring `SetPaused` now keeps the lifecycle coherent.

## Implementation

| File | Change |
|------|--------|
| `contracts/axis-vault/src/instructions/set_paused.rs` | New instruction. Re-derives the ETF PDA from the stored name + authority, rejects any signer other than `etf.authority` with `OwnerMismatch (9008)`, and normalizes any non-zero byte to 1. |
| `contracts/axis-vault/src/instructions/mod.rs` | Export `process_set_paused`. |
| `contracts/axis-vault/src/lib.rs` | `Instruction::SetPaused = 4`; dispatcher reads a single `paused: u8` data byte. |

No new error codes — reuses `InvalidProgramOwner` / `InvalidDiscriminator` / `OwnerMismatch`.

## Tests

`test/e2e/axis-vault/axis-vault.set-paused.test.ts` — self-contained devnet flow:
1. `CreateEtf` + first `Deposit` (seeds the vault).
2. `SetPaused` from a non-authority signer → expects `OwnerMismatch (9008)`.
3. `SetPaused(1)` from authority.
4. `Deposit` → expects `PoolPaused (9012)`.
5. `Withdraw` → expects `PoolPaused (9012)`.
6. `SetPaused(0)` → authority unpause.
7. Final `Deposit` succeeds.

Runs independently of the big `axis-vault.local.e2e.ts` so CI can target this scenario without re-running the full fee/NAV matrix.

## Test plan

- [x] `cargo build --manifest-path contracts/axis-vault/Cargo.toml --all-targets` — clean.
- [x] `cargo build-sbf --manifest-path contracts/axis-vault/Cargo.toml` — clean.
- [x] `bash ci/ts-typecheck.sh` — all 7 TS projects pass.
- [ ] Devnet run of the new test script (post-deploy).
- [x] Review by @kidneyweakx.

## Scope / compatibility

- Fully additive. No existing instruction accounts, layouts, or data formats changed.
- Uses the next available discriminator (4) — no renumbering.
- Pauses are authority-only, so existing flows with no authority signer remain indistinguishable in behavior.