### PR TITLE
test(issue-33): cover pfda-amm + axis-g3m remaining scenario rows

### DIFF
--- a/.github/workflows/litesvm-jupiter-cpi.yml
+++ b/.github/workflows/litesvm-jupiter-cpi.yml
@@ -61,10 +61,14 @@ jobs:
         run: bun run typecheck 2>&1 || true
 
       # ── Build SBF programs ──
+      # pfda-amm is now exercised by tests/pfda_amm_coverage.rs in the
+      # ab-integration-tests crate, so build its .so alongside the g3m
+      # and pfda-amm-3 binaries the existing test suite loads.
       - name: Build SBF programs
         run: |
           cd contracts/axis-g3m && cargo build-sbf
           cd ../pfda-amm-3 && cargo build-sbf
+          cd ../pfda-amm && cargo build-sbf
 
       - name: Dump Jupiter V6 from mainnet
         run: |
@@ -98,6 +102,22 @@ jobs:
         run: |
           cd contracts/ab-integration-tests
           cargo test --test scenario_coverage -- --nocapture
+
+      # pfda-amm (legacy 2-token) — CloseBatchHistory/CloseExpiredTicket
+      # success + rejection, AddLiquidity paused/wrong-vault,
+      # SwapRequest duplicate-same-batch atomicity (PR #50 reorder).
+      - name: Run pfda-amm regression tests (LiteSVM)
+        run: |
+          cd contracts/ab-integration-tests
+          cargo test --test pfda_amm_coverage -- --nocapture
+
+      # axis-g3m — Swap slippage/zero/same-idx/paused, Rebalance cooldown +
+      # wrong authority, InitializePool invalid-token-count / weights-mismatch /
+      # duplicate-init.
+      - name: Run axis-g3m regression tests (LiteSVM)
+        run: |
+          cd contracts/ab-integration-tests
+          cargo test --test axis_g3m_coverage -- --nocapture
 
       - name: Generate LiteSVM A/B report
         run: |

--- a/.github/workflows/litesvm-jupiter-cpi.yml
+++ b/.github/workflows/litesvm-jupiter-cpi.yml
@@ -85,6 +85,20 @@ jobs:
           cd contracts/ab-integration-tests
           cargo test --test ab_comparison -- --nocapture --skip jupiter --skip mainnet
 
+      # ── #33 regression gates ──
+      # close_delay: CloseBatchHistory / CloseExpiredTicket success + rejection paths.
+      # scenario_coverage: AddLiquidity / SwapRequest rejections (wrong-vault, paused).
+      # Both run against the same pfda_amm_3.so built above — zero extra fixture cost.
+      - name: Run close-delay regression tests (LiteSVM)
+        run: |
+          cd contracts/ab-integration-tests
+          cargo test --test close_delay -- --nocapture
+
+      - name: Run scenario-coverage regression tests (LiteSVM)
+        run: |
+          cd contracts/ab-integration-tests
+          cargo test --test scenario_coverage -- --nocapture
+
       - name: Generate LiteSVM A/B report
         run: |
           cd contracts/ab-integration-tests

--- a/contracts/ab-integration-tests/Cargo.toml
+++ b/contracts/ab-integration-tests/Cargo.toml
@@ -11,6 +11,10 @@ path = "src/lib.rs"
 name = "ab_comparison"
 path = "tests/ab_comparison.rs"
 
+[[test]]
+name = "close_delay"
+path = "tests/close_delay.rs"
+
 [dependencies]
 litesvm = "0.11"
 solana-keypair = "3.1"

--- a/contracts/ab-integration-tests/Cargo.toml
+++ b/contracts/ab-integration-tests/Cargo.toml
@@ -19,6 +19,14 @@ path = "tests/close_delay.rs"
 name = "scenario_coverage"
 path = "tests/scenario_coverage.rs"
 
+[[test]]
+name = "pfda_amm_coverage"
+path = "tests/pfda_amm_coverage.rs"
+
+[[test]]
+name = "axis_g3m_coverage"
+path = "tests/axis_g3m_coverage.rs"
+
 [dependencies]
 litesvm = "0.11"
 solana-keypair = "3.1"

--- a/contracts/ab-integration-tests/Cargo.toml
+++ b/contracts/ab-integration-tests/Cargo.toml
@@ -15,6 +15,10 @@ path = "tests/ab_comparison.rs"
 name = "close_delay"
 path = "tests/close_delay.rs"
 
+[[test]]
+name = "scenario_coverage"
+path = "tests/scenario_coverage.rs"
+
 [dependencies]
 litesvm = "0.11"
 solana-keypair = "3.1"

--- a/contracts/ab-integration-tests/src/helpers/account_builder.rs
+++ b/contracts/ab-integration-tests/src/helpers/account_builder.rs
@@ -124,6 +124,122 @@ pub fn build_pfda3_pool_state(
     d
 }
 
+/// Build PoolState raw bytes for pfda-amm (the 2-token legacy program).
+/// Layout (240 bytes, repr(C)) per contracts/pfda-amm/src/state/pool_state.rs:
+///   0:    discriminator "poolstat" (8)
+///   8:    token_a_mint (32)
+///  40:    token_b_mint (32)
+///  72:    vault_a (32)
+/// 104:    vault_b (32)
+/// 136:    reserve_a (u64)
+/// 144:    reserve_b (u64)
+/// 152:    current_weight_a (u32)
+/// 156:    target_weight_a (u32)
+/// 160:    weight_start_slot (u64)
+/// 168:    weight_end_slot (u64)
+/// 176:    window_slots (u64)
+/// 184:    current_batch_id (u64)
+/// 192:    current_window_end (u64)
+/// 200:    base_fee_bps (u16)
+/// 202:    fee_discount_bps (u16)
+/// 204:    authority (32)
+/// 236:    bump (u8)
+/// 237:    reentrancy_guard (u8)
+/// 238:    paused (u8)
+/// 239:    _padding (u8)
+#[allow(clippy::too_many_arguments)]
+pub fn build_pfda_pool_state(
+    token_a_mint: &Address,
+    token_b_mint: &Address,
+    vault_a: &Address,
+    vault_b: &Address,
+    reserve_a: u64,
+    reserve_b: u64,
+    weight_a: u32,
+    window_slots: u64,
+    current_batch_id: u64,
+    current_window_end: u64,
+    base_fee_bps: u16,
+    authority: &Address,
+    bump: u8,
+) -> Vec<u8> {
+    let mut d = vec![0u8; 240];
+    d[0..8].copy_from_slice(b"poolstat");
+    d[8..40].copy_from_slice(token_a_mint.as_ref());
+    d[40..72].copy_from_slice(token_b_mint.as_ref());
+    d[72..104].copy_from_slice(vault_a.as_ref());
+    d[104..136].copy_from_slice(vault_b.as_ref());
+    d[136..144].copy_from_slice(&reserve_a.to_le_bytes());
+    d[144..152].copy_from_slice(&reserve_b.to_le_bytes());
+    d[152..156].copy_from_slice(&weight_a.to_le_bytes());
+    d[156..160].copy_from_slice(&weight_a.to_le_bytes()); // target == current
+    // weight_start_slot + weight_end_slot left zero
+    d[176..184].copy_from_slice(&window_slots.to_le_bytes());
+    d[184..192].copy_from_slice(&current_batch_id.to_le_bytes());
+    d[192..200].copy_from_slice(&current_window_end.to_le_bytes());
+    d[200..202].copy_from_slice(&base_fee_bps.to_le_bytes());
+    // fee_discount_bps left zero
+    d[204..236].copy_from_slice(authority.as_ref());
+    d[236] = bump;
+    // reentrancy_guard / paused / pad zero
+    d
+}
+
+/// Build BatchQueue raw bytes for pfda-amm (80 bytes).
+pub fn build_batch_queue(
+    pool: &Address,
+    batch_id: u64,
+    total_in_a: u64,
+    total_in_b: u64,
+    window_end_slot: u64,
+    bump: u8,
+) -> Vec<u8> {
+    let mut d = vec![0u8; 80];
+    d[0..8].copy_from_slice(b"batchque");
+    d[8..40].copy_from_slice(pool.as_ref());
+    d[40..48].copy_from_slice(&batch_id.to_le_bytes());
+    d[48..56].copy_from_slice(&total_in_a.to_le_bytes());
+    d[56..64].copy_from_slice(&total_in_b.to_le_bytes());
+    d[64..72].copy_from_slice(&window_end_slot.to_le_bytes());
+    d[72] = bump;
+    d
+}
+
+/// Build ClearedBatchHistory raw bytes for pfda-amm (80 bytes).
+pub fn build_cleared_batch_history(
+    pool: &Address,
+    batch_id: u64,
+    bump: u8,
+) -> Vec<u8> {
+    let mut d = vec![0u8; 80];
+    d[0..8].copy_from_slice(b"clrdhist");
+    d[8..40].copy_from_slice(pool.as_ref());
+    d[40..48].copy_from_slice(&batch_id.to_le_bytes());
+    // clearing_price / out_b_per_in_a / out_a_per_in_b left zero —
+    // CloseBatchHistory doesn't read them.
+    d[72] = 1; // is_cleared
+    d[73] = bump;
+    d
+}
+
+/// Build UserOrderTicket raw bytes for pfda-amm (112 bytes).
+pub fn build_user_order_ticket(
+    owner: &Address,
+    pool: &Address,
+    batch_id: u64,
+    bump: u8,
+) -> Vec<u8> {
+    let mut d = vec![0u8; 112];
+    d[0..8].copy_from_slice(b"usrorder");
+    d[8..40].copy_from_slice(owner.as_ref());
+    d[40..72].copy_from_slice(pool.as_ref());
+    d[72..80].copy_from_slice(&batch_id.to_le_bytes());
+    // amount_in_a / amount_in_b / min_amount_out left zero
+    d[104] = 0; // is_claimed = false
+    d[105] = bump;
+    d
+}
+
 /// Build BatchQueue3 raw bytes (88 bytes).
 pub fn build_batch_queue_3(
     pool: &Address,

--- a/contracts/ab-integration-tests/src/helpers/svm_setup.rs
+++ b/contracts/ab-integration-tests/src/helpers/svm_setup.rs
@@ -4,6 +4,8 @@ use solana_clock::Clock;
 
 pub const AXIS_G3M_ID: &str = "65aE9QdVz5bapV19BGt5cyTgVitYpekGwusRoQEovNUi";
 pub const PFDA_AMM_3_ID: &str = "DbAPmgkrpCCZrpBMv5x1ye6nJUreqY313SuQjZsMyjEf";
+pub const PFDA_AMM_ID: &str = "CSBgQGeBTiAu4a9Kgoas2GyR8wbHg5jxctQjq3AenKk";
+pub const AXIS_VAULT_ID: &str = "DeeUnCHcnPG8arbjGTLhTKeDhpPUBper3TDrpFPHnCwy";
 pub const JUPITER_V6_ID: &str = "JUP6LkbZbjS1jKKwapdHNy74zcZ3tLUZoi5QNyVTaV4";
 
 pub const AXIS_G3M_SO: &str = concat!(
@@ -13,6 +15,14 @@ pub const AXIS_G3M_SO: &str = concat!(
 pub const PFDA_AMM_3_SO: &str = concat!(
     env!("CARGO_MANIFEST_DIR"),
     "/../pfda-amm-3/target/deploy/pfda_amm_3.so"
+);
+pub const PFDA_AMM_SO: &str = concat!(
+    env!("CARGO_MANIFEST_DIR"),
+    "/../pfda-amm/target/deploy/pfda_amm.so"
+);
+pub const AXIS_VAULT_SO: &str = concat!(
+    env!("CARGO_MANIFEST_DIR"),
+    "/../axis-vault/target/deploy/axis_vault.so"
 );
 pub const JUPITER_V6_SO: &str = concat!(
     env!("CARGO_MANIFEST_DIR"),
@@ -34,6 +44,12 @@ pub fn axis_g3m_id() -> Address {
 }
 pub fn pfda3_id() -> Address {
     PFDA_AMM_3_ID.parse().unwrap()
+}
+pub fn pfda_amm_id() -> Address {
+    PFDA_AMM_ID.parse().unwrap()
+}
+pub fn axis_vault_id() -> Address {
+    AXIS_VAULT_ID.parse().unwrap()
 }
 pub fn jupiter_id() -> Address {
     JUPITER_V6_ID.parse().unwrap()

--- a/contracts/ab-integration-tests/tests/axis_g3m_coverage.rs
+++ b/contracts/ab-integration-tests/tests/axis_g3m_coverage.rs
@@ -1,0 +1,560 @@
+//! axis-g3m regression coverage (issue #33).
+//!
+//! Covers kidney's scenario-table rows for axis-g3m that were untested:
+//!   - Swap slippage exceeded           → SlippageExceeded (7004)
+//!   - Swap zero input                  → ZeroAmount       (7003)
+//!   - Swap same in+out index           → InvalidTokenIndex (7007)
+//!   - Swap on paused pool              → PoolPaused       (7010)
+//!   - Rebalance during cooldown        → CooldownActive   (7009)
+//!   - Rebalance wrong authority        → Unauthorized     (7020)
+//!   - InitializePool invalid token_count → InvalidTokenCount (7001)
+//!   - InitializePool weights != 10_000  → WeightsMismatch (7002)
+//!   - InitializePool duplicate init     → AlreadyInitialized (7015)
+//!
+//! The setup path drives a real `InitializePool` transaction so the
+//! pool account lives in exactly the shape pinocchio + axis-g3m expect
+//! (correct layout, correct realloc headroom). For rejection scenarios
+//! we mutate the committed state post-init (flip the paused byte,
+//! warp the clock) before issuing the instruction under test.
+
+use ab_integration_tests::helpers::{svm_setup::*, token_factory::*};
+use ab_integration_tests::require_fixture;
+use litesvm::LiteSVM;
+use solana_address::Address;
+use solana_clock::Clock;
+use solana_instruction::{account_meta::AccountMeta, Instruction};
+use solana_keypair::Keypair;
+use solana_native_token::LAMPORTS_PER_SOL;
+use solana_signer::Signer;
+use solana_transaction::Transaction;
+
+// G3mError codes (mirror of contracts/axis-g3m/src/error.rs)
+const ERR_INVALID_TOKEN_COUNT: u32 = 7001;
+const ERR_WEIGHTS_MISMATCH: u32 = 7002;
+const ERR_ZERO_AMOUNT: u32 = 7003;
+const ERR_SLIPPAGE_EXCEEDED: u32 = 7004;
+const ERR_INVALID_TOKEN_INDEX: u32 = 7007;
+const ERR_COOLDOWN_ACTIVE: u32 = 7009;
+const ERR_POOL_PAUSED: u32 = 7010;
+const ERR_ALREADY_INITIALIZED: u32 = 7015;
+const ERR_UNAUTHORIZED: u32 = 7020;
+
+// ─── Instruction builders ───────────────────────────────────────────────
+
+#[allow(clippy::too_many_arguments)]
+fn g3m_init_ix(
+    program: Address,
+    authority: Address,
+    pool_pda: Address,
+    user_tokens: &[Address],
+    vaults: &[Address],
+    tc: u8,
+    fee_bps: u16,
+    drift_bps: u16,
+    cooldown: u64,
+    weights: &[u16],
+    reserves: &[u64],
+) -> Instruction {
+    let mut data = vec![0u8];
+    data.push(tc);
+    data.extend_from_slice(&fee_bps.to_le_bytes());
+    data.extend_from_slice(&drift_bps.to_le_bytes());
+    data.extend_from_slice(&cooldown.to_le_bytes());
+    for w in weights {
+        data.extend_from_slice(&w.to_le_bytes());
+    }
+    for r in reserves {
+        data.extend_from_slice(&r.to_le_bytes());
+    }
+
+    let mut accounts = vec![
+        AccountMeta::new(authority, true),
+        AccountMeta::new(pool_pda, false),
+        AccountMeta::new_readonly(system_program_id(), false),
+        AccountMeta::new_readonly(token_program_id(), false),
+    ];
+    for t in user_tokens {
+        accounts.push(AccountMeta::new(*t, false));
+    }
+    for v in vaults {
+        accounts.push(AccountMeta::new(*v, false));
+    }
+
+    Instruction { program_id: program, accounts, data }
+}
+
+#[allow(clippy::too_many_arguments)]
+fn g3m_swap_ix(
+    program: Address,
+    authority: Address,
+    pool_pda: Address,
+    user_in: Address,
+    user_out: Address,
+    vault_in: Address,
+    vault_out: Address,
+    in_idx: u8,
+    out_idx: u8,
+    amount_in: u64,
+    min_out: u64,
+) -> Instruction {
+    let mut data = vec![1u8];
+    data.push(in_idx);
+    data.push(out_idx);
+    data.extend_from_slice(&amount_in.to_le_bytes());
+    data.extend_from_slice(&min_out.to_le_bytes());
+    Instruction {
+        program_id: program,
+        accounts: vec![
+            AccountMeta::new(authority, true),
+            AccountMeta::new(pool_pda, false),
+            AccountMeta::new(user_in, false),
+            AccountMeta::new(user_out, false),
+            AccountMeta::new(vault_in, false),
+            AccountMeta::new(vault_out, false),
+            AccountMeta::new_readonly(token_program_id(), false),
+        ],
+        data,
+    }
+}
+
+fn g3m_rebalance_ix(
+    program: Address,
+    authority: Address,
+    pool_pda: Address,
+    reserves: &[u64],
+) -> Instruction {
+    let mut data = vec![3u8];
+    for r in reserves {
+        data.extend_from_slice(&r.to_le_bytes());
+    }
+    Instruction {
+        program_id: program,
+        accounts: vec![
+            AccountMeta::new(authority, true),
+            AccountMeta::new(pool_pda, false),
+        ],
+        data,
+    }
+}
+
+fn send(svm: &mut LiteSVM, ix: Instruction, payer: &Keypair) -> Result<u64, String> {
+    let tx = Transaction::new_signed_with_payer(
+        &[ix],
+        Some(&payer.pubkey()),
+        &[payer],
+        svm.latest_blockhash(),
+    );
+    match svm.send_transaction(tx) {
+        Ok(meta) => Ok(meta.compute_units_consumed),
+        Err(e) => {
+            let mut msg = format!("{:?}", e.err);
+            for log in &e.meta.logs {
+                msg.push_str(&format!("\n  {}", log));
+            }
+            Err(msg)
+        }
+    }
+}
+
+fn assert_custom_err(err: &str, code: u32, label: &str) {
+    let hex = format!("0x{:x}", code);
+    let custom = format!("Custom({})", code);
+    assert!(
+        err.contains(&hex) || err.contains(&custom),
+        "{label}: expected {code} ({hex}), got: {err}"
+    );
+}
+
+// ─── Fixture: real init path ────────────────────────────────────────────
+
+struct Fixture {
+    svm: LiteSVM,
+    payer: Keypair,
+    pool: Address,
+    vaults: [Address; 2],
+    user_tokens: [Address; 2],
+}
+
+/// Uses `create_token_account` (not padded) to match the pattern in
+/// `ab_comparison.rs::test_g3m_init_swap_checkdrift` — the token-program
+/// Transfer path is happy with unpadded token accounts, and the swap
+/// CPI in axis-g3m does not trip realloc on a freshly init'd pool.
+fn init_pool(cooldown: u64) -> Option<Fixture> {
+    let mut svm = LiteSVM::new();
+    if !std::path::Path::new(AXIS_G3M_SO).exists() {
+        eprintln!("SKIP: axis_g3m.so fixture missing");
+        return None;
+    }
+    svm.add_program_from_file(axis_g3m_id(), AXIS_G3M_SO).ok()?;
+
+    let payer = Keypair::new();
+    svm.airdrop(&payer.pubkey(), 10 * LAMPORTS_PER_SOL).unwrap();
+
+    let mints = [Address::new_unique(), Address::new_unique()];
+    for &m in &mints {
+        create_mint(&mut svm, m, &payer.pubkey(), 6);
+    }
+
+    let (pool, _bump) = Address::find_program_address(
+        &[b"g3m_pool", payer.pubkey().as_ref()],
+        &axis_g3m_id(),
+    );
+
+    let vaults = [Address::new_unique(), Address::new_unique()];
+    let user_tokens = [Address::new_unique(), Address::new_unique()];
+    for i in 0..2 {
+        create_token_account(&mut svm, vaults[i], &mints[i], &pool, 0);
+        create_token_account(&mut svm, user_tokens[i], &mints[i], &payer.pubkey(), 50_000_000);
+    }
+
+    send(
+        &mut svm,
+        g3m_init_ix(
+            axis_g3m_id(),
+            payer.pubkey(),
+            pool,
+            &user_tokens,
+            &vaults,
+            2,
+            100,        // fee_rate_bps
+            500,        // drift_threshold_bps
+            cooldown,
+            &[5000, 5000],
+            &[10_000_000, 10_000_000],
+        ),
+        &payer,
+    )
+    .expect("init setup");
+
+    Some(Fixture { svm, payer, pool, vaults, user_tokens })
+}
+
+/// Toggle `paused` on a post-init pool. G3mPoolState has 8-byte
+/// alignment and ends with `paused(u8) + bump(u8) + _padding[4]` after
+/// a u64-aligned `rebalance_cooldown` — but repr(C) also inserts u64
+/// alignment padding before `last_rebalance_slot`. Verified via an
+/// `offset_of!` probe against the actual struct: total size = 464,
+/// `paused` sits at offset 456 (== `len - 8`).
+fn set_paused(svm: &mut LiteSVM, pool: Address, paused: bool) {
+    let mut acc = svm.get_account(&pool).expect("pool exists");
+    let n = acc.data.len();
+    acc.data[n - 8] = if paused { 1 } else { 0 };
+    svm.set_account(pool, acc).unwrap();
+}
+
+fn warp(svm: &mut LiteSVM, slot: u64) {
+    svm.set_sysvar(&Clock {
+        slot,
+        epoch_start_timestamp: 0,
+        epoch: 0,
+        leader_schedule_epoch: 0,
+        unix_timestamp: slot as i64,
+    });
+}
+
+// ─── Tests ──────────────────────────────────────────────────────────────
+
+#[test]
+fn swap_rejects_when_paused() {
+    require_fixture!(AXIS_G3M_SO);
+    let Fixture { mut svm, payer, pool, vaults, user_tokens } =
+        match init_pool(0) { Some(f) => f, None => return };
+
+    set_paused(&mut svm, pool, true);
+
+    let err = send(
+        &mut svm,
+        g3m_swap_ix(
+            axis_g3m_id(),
+            payer.pubkey(),
+            pool,
+            user_tokens[0],
+            user_tokens[1],
+            vaults[0],
+            vaults[1],
+            0,
+            1,
+            1_000,
+            0,
+        ),
+        &payer,
+    )
+    .err()
+    .expect("paused swap should reject");
+    assert_custom_err(&err, ERR_POOL_PAUSED, "paused swap");
+}
+
+#[test]
+fn swap_rejects_zero_input() {
+    require_fixture!(AXIS_G3M_SO);
+    let Fixture { mut svm, payer, pool, vaults, user_tokens } =
+        match init_pool(0) { Some(f) => f, None => return };
+
+    let err = send(
+        &mut svm,
+        g3m_swap_ix(
+            axis_g3m_id(),
+            payer.pubkey(),
+            pool,
+            user_tokens[0],
+            user_tokens[1],
+            vaults[0],
+            vaults[1],
+            0,
+            1,
+            0,           // zero amount_in
+            0,
+        ),
+        &payer,
+    )
+    .err()
+    .expect("zero-input swap should reject");
+    assert_custom_err(&err, ERR_ZERO_AMOUNT, "zero amount");
+}
+
+#[test]
+fn swap_rejects_same_in_out_index() {
+    require_fixture!(AXIS_G3M_SO);
+    let Fixture { mut svm, payer, pool, vaults, user_tokens } =
+        match init_pool(0) { Some(f) => f, None => return };
+
+    let err = send(
+        &mut svm,
+        g3m_swap_ix(
+            axis_g3m_id(),
+            payer.pubkey(),
+            pool,
+            user_tokens[0],
+            user_tokens[0],
+            vaults[0],
+            vaults[0],
+            0,
+            0,                 // same index
+            1_000,
+            0,
+        ),
+        &payer,
+    )
+    .err()
+    .expect("same-index swap should reject");
+    assert_custom_err(&err, ERR_INVALID_TOKEN_INDEX, "same in/out index");
+}
+
+#[test]
+fn swap_rejects_slippage_exceeded() {
+    require_fixture!(AXIS_G3M_SO);
+    let Fixture { mut svm, payer, pool, vaults, user_tokens } =
+        match init_pool(0) { Some(f) => f, None => return };
+
+    // 1_000 in against 10M / 10M reserves → out ≈ 990 after fees.
+    // Setting min_out = 10_000_000 ensures slippage fires.
+    let err = send(
+        &mut svm,
+        g3m_swap_ix(
+            axis_g3m_id(),
+            payer.pubkey(),
+            pool,
+            user_tokens[0],
+            user_tokens[1],
+            vaults[0],
+            vaults[1],
+            0,
+            1,
+            1_000,
+            10_000_000,
+        ),
+        &payer,
+    )
+    .err()
+    .expect("unsatisfiable min_out should reject");
+    assert_custom_err(&err, ERR_SLIPPAGE_EXCEEDED, "slippage");
+}
+
+#[test]
+fn rebalance_rejects_during_cooldown() {
+    require_fixture!(AXIS_G3M_SO);
+    // cooldown = 10_000 slots. init's last_rebalance_slot = current_slot.
+    // warp only a few slots forward → still well inside the cooldown.
+    let Fixture { mut svm, payer, pool, .. } =
+        match init_pool(10_000) { Some(f) => f, None => return };
+    warp(&mut svm, 50);
+
+    let err = send(
+        &mut svm,
+        g3m_rebalance_ix(
+            axis_g3m_id(),
+            payer.pubkey(),
+            pool,
+            &[10_000_000, 10_000_000],
+        ),
+        &payer,
+    )
+    .err()
+    .expect("rebalance during cooldown should reject");
+    assert_custom_err(&err, ERR_COOLDOWN_ACTIVE, "cooldown");
+}
+
+#[test]
+fn rebalance_rejects_wrong_authority() {
+    require_fixture!(AXIS_G3M_SO);
+    let Fixture { mut svm, pool, .. } =
+        match init_pool(0) { Some(f) => f, None => return };
+
+    let intruder = Keypair::new();
+    svm.airdrop(&intruder.pubkey(), LAMPORTS_PER_SOL).unwrap();
+
+    let err = send(
+        &mut svm,
+        g3m_rebalance_ix(
+            axis_g3m_id(),
+            intruder.pubkey(),
+            pool,
+            &[10_000_000, 10_000_000],
+        ),
+        &intruder,
+    )
+    .err()
+    .expect("rebalance from non-authority should reject");
+    assert_custom_err(&err, ERR_UNAUTHORIZED, "wrong authority");
+}
+
+// ─── Init edge cases ────────────────────────────────────────────────────
+
+fn fresh_init_svm() -> Option<(LiteSVM, Keypair)> {
+    let mut svm = LiteSVM::new();
+    if !std::path::Path::new(AXIS_G3M_SO).exists() {
+        eprintln!("SKIP: axis_g3m.so fixture missing");
+        return None;
+    }
+    svm.add_program_from_file(axis_g3m_id(), AXIS_G3M_SO).ok()?;
+    let payer = Keypair::new();
+    svm.airdrop(&payer.pubkey(), 10 * LAMPORTS_PER_SOL).unwrap();
+    Some((svm, payer))
+}
+
+fn build_init_accounts(svm: &mut LiteSVM, payer: &Keypair, n: usize) -> (Address, Vec<Address>, Vec<Address>) {
+    let (pool, _) = Address::find_program_address(
+        &[b"g3m_pool", payer.pubkey().as_ref()],
+        &axis_g3m_id(),
+    );
+    let mut user_tokens = Vec::with_capacity(n);
+    let mut vaults = Vec::with_capacity(n);
+    for _ in 0..n {
+        let mint = Address::new_unique();
+        create_mint(svm, mint, &payer.pubkey(), 6);
+        let u = Address::new_unique();
+        let v = Address::new_unique();
+        create_token_account(svm, u, &mint, &payer.pubkey(), 50_000_000);
+        create_token_account(svm, v, &mint, &pool, 0);
+        user_tokens.push(u);
+        vaults.push(v);
+    }
+    (pool, user_tokens, vaults)
+}
+
+#[test]
+fn init_rejects_invalid_token_count() {
+    require_fixture!(AXIS_G3M_SO);
+    let (mut svm, payer) = match fresh_init_svm() { Some(p) => p, None => return };
+    let (pool, user_tokens, vaults) = build_init_accounts(&mut svm, &payer, 1);
+
+    let err = send(
+        &mut svm,
+        g3m_init_ix(
+            axis_g3m_id(),
+            payer.pubkey(),
+            pool,
+            &user_tokens,
+            &vaults,
+            1, // below min (2)
+            30,
+            500,
+            0,
+            &[10_000],
+            &[10_000_000],
+        ),
+        &payer,
+    )
+    .err()
+    .expect("token_count=1 should reject");
+    assert_custom_err(&err, ERR_INVALID_TOKEN_COUNT, "tc too small");
+}
+
+#[test]
+fn init_rejects_weights_not_10_000() {
+    require_fixture!(AXIS_G3M_SO);
+    let (mut svm, payer) = match fresh_init_svm() { Some(p) => p, None => return };
+    let (pool, user_tokens, vaults) = build_init_accounts(&mut svm, &payer, 2);
+
+    let err = send(
+        &mut svm,
+        g3m_init_ix(
+            axis_g3m_id(),
+            payer.pubkey(),
+            pool,
+            &user_tokens,
+            &vaults,
+            2,
+            30,
+            500,
+            0,
+            &[5000, 4999], // sums to 9999
+            &[10_000_000, 10_000_000],
+        ),
+        &payer,
+    )
+    .err()
+    .expect("weights != 10_000 should reject");
+    assert_custom_err(&err, ERR_WEIGHTS_MISMATCH, "weights mismatch");
+}
+
+#[test]
+fn init_rejects_duplicate() {
+    require_fixture!(AXIS_G3M_SO);
+    let (mut svm, payer) = match fresh_init_svm() { Some(p) => p, None => return };
+    let (pool, user_tokens, vaults) = build_init_accounts(&mut svm, &payer, 2);
+
+    // First init — happy path.
+    send(
+        &mut svm,
+        g3m_init_ix(
+            axis_g3m_id(),
+            payer.pubkey(),
+            pool,
+            &user_tokens,
+            &vaults,
+            2,
+            30,
+            500,
+            0,
+            &[5000, 5000],
+            &[10_000_000, 10_000_000],
+        ),
+        &payer,
+    )
+    .expect("first init should succeed");
+
+    svm.expire_blockhash();
+
+    // Second init — PR #48's explicit re-init guard fires.
+    let err = send(
+        &mut svm,
+        g3m_init_ix(
+            axis_g3m_id(),
+            payer.pubkey(),
+            pool,
+            &user_tokens,
+            &vaults,
+            2,
+            30,
+            500,
+            0,
+            &[5000, 5000],
+            &[10_000_000, 10_000_000],
+        ),
+        &payer,
+    )
+    .err()
+    .expect("duplicate init should reject");
+    assert_custom_err(&err, ERR_ALREADY_INITIALIZED, "duplicate init");
+}

--- a/contracts/ab-integration-tests/tests/close_delay.rs
+++ b/contracts/ab-integration-tests/tests/close_delay.rs
@@ -1,0 +1,436 @@
+//! Close-delay success paths (issue #33).
+//!
+//! Kidney flagged that `CloseBatchHistory` and `CloseExpiredTicket` in
+//! both pfda-amm and pfda-amm-3 had never had their success path
+//! exercised — the 100-batch / 200-batch delays made it impractical to
+//! drive through a real flow in unit tests.
+//!
+//! LiteSVM lets us sidestep that by pre-seeding account state via
+//! `set_account`: fabricate a ClearedBatchHistory3 / UserOrderTicket3
+//! at the canonical PDA, advance pool.current_batch_id past the delay,
+//! and invoke the close instruction. The on-chain program logic is
+//! exercised in full — only the intermediate ClearBatch / time-waiting
+//! scaffolding is skipped.
+//!
+//! Covered here (pfda-amm-3):
+//!   1. CloseBatchHistory success once 100 batches have elapsed.
+//!   2. CloseBatchHistory rejection before the delay elapses.
+//!   3. CloseExpiredTicket success once 200 batches have elapsed.
+//!   4. CloseExpiredTicket rejection before the delay elapses.
+//!
+//! pfda-amm has the same instruction shape and delay constants; a
+//! follow-up PR can clone this file against that program's account
+//! layout.
+
+use ab_integration_tests::helpers::{account_builder::*, svm_setup::*, token_factory::*};
+use ab_integration_tests::require_fixture;
+use litesvm::LiteSVM;
+use solana_account::Account;
+use solana_address::Address;
+use solana_instruction::{account_meta::AccountMeta, Instruction};
+use solana_keypair::Keypair;
+use solana_native_token::LAMPORTS_PER_SOL;
+use solana_signer::Signer;
+use solana_transaction::Transaction;
+
+// ─── Account fabrication ────────────────────────────────────────────────
+// Sizes confirmed via `cargo test print_sizes -- --nocapture` in
+// contracts/pfda-amm-3/src/lib.rs (both structs are 128 bytes).
+
+fn build_cleared_batch_history_3(
+    pool: &Address,
+    batch_id: u64,
+    fee_bps: u16,
+    bump: u8,
+) -> Vec<u8> {
+    let mut d = vec![0u8; 128];
+    // Layout (repr(C), total 128 bytes):
+    //   0:   discriminator [8]        = b"clrd3h\0\0"
+    //   8:   pool          [32]
+    //  40:   batch_id      u64
+    //  48:   clearing_prices [u64; 3]  (Q32.32)
+    //  72:   total_out     [u64; 3]
+    //  96:   total_in      [u64; 3]
+    // 120:   fee_bps       u16
+    // 122:   is_cleared    bool
+    // 123:   bump          u8
+    // 124:   _padding      [u8; 4]
+    d[0..8].copy_from_slice(b"clrd3h\0\0");
+    d[8..40].copy_from_slice(pool.as_ref());
+    d[40..48].copy_from_slice(&batch_id.to_le_bytes());
+    // clearing_prices / total_out / total_in stay zero — CloseBatchHistory
+    // doesn't read them.
+    d[120..122].copy_from_slice(&fee_bps.to_le_bytes());
+    d[122] = 1; // is_cleared
+    d[123] = bump;
+    d
+}
+
+fn build_user_order_ticket_3(
+    owner: &Address,
+    pool: &Address,
+    batch_id: u64,
+    bump: u8,
+) -> Vec<u8> {
+    let mut d = vec![0u8; 128];
+    // Layout (repr(C), total 128 bytes):
+    //   0:   discriminator [8] = b"usrord3\0"
+    //   8:   owner         [32]
+    //  40:   pool          [32]
+    //  72:   batch_id      u64
+    //  80:   amounts_in    [u64; 3]
+    // 104:   out_token_idx u8
+    // 105:   padding to u64 align (7)  ← verified via print_sizes
+    // 112:   min_amount_out u64
+    // 120:   is_claimed    bool
+    // 121:   bump          u8
+    // 122:   _padding      [u8; 5]  + trailing alignment pad = 6 bytes → 128
+    d[0..8].copy_from_slice(b"usrord3\0");
+    d[8..40].copy_from_slice(owner.as_ref());
+    d[40..72].copy_from_slice(pool.as_ref());
+    d[72..80].copy_from_slice(&batch_id.to_le_bytes());
+    // amounts_in / out_token_idx / min_amount_out stay zero — CloseExpiredTicket
+    // only reads owner + batch_id off the ticket.
+    d[120] = 0; // is_claimed = false (so it's eligible to close)
+    d[121] = bump;
+    d
+}
+
+// ─── Instruction builders ───────────────────────────────────────────────
+
+fn pfda3_close_batch_history_ix(
+    program: Address,
+    rent_recipient: Address,
+    pool: Address,
+    history: Address,
+) -> Instruction {
+    Instruction {
+        program_id: program,
+        accounts: vec![
+            AccountMeta::new(rent_recipient, true),
+            AccountMeta::new_readonly(pool, false),
+            AccountMeta::new(history, false),
+        ],
+        data: vec![7u8], // disc = CloseBatchHistory
+    }
+}
+
+fn pfda3_close_expired_ticket_ix(
+    program: Address,
+    caller: Address,
+    pool: Address,
+    ticket: Address,
+    rent_recipient: Address,
+) -> Instruction {
+    Instruction {
+        program_id: program,
+        accounts: vec![
+            AccountMeta::new(caller, true),
+            AccountMeta::new_readonly(pool, false),
+            AccountMeta::new(ticket, false),
+            AccountMeta::new(rent_recipient, false),
+        ],
+        data: vec![8u8], // disc = CloseExpiredTicket
+    }
+}
+
+fn send(svm: &mut LiteSVM, ix: Instruction, payer: &Keypair) -> Result<u64, String> {
+    let tx = Transaction::new_signed_with_payer(
+        &[ix],
+        Some(&payer.pubkey()),
+        &[payer],
+        svm.latest_blockhash(),
+    );
+    match svm.send_transaction(tx) {
+        Ok(meta) => Ok(meta.compute_units_consumed),
+        Err(e) => {
+            let mut msg = format!("{:?}", e.err);
+            for log in &e.meta.logs {
+                msg.push_str(&format!("\n  {}", log));
+            }
+            Err(msg)
+        }
+    }
+}
+
+// ─── Test scaffolding ───────────────────────────────────────────────────
+
+struct Seed {
+    svm: LiteSVM,
+    payer: Keypair,
+    pool: Address,
+}
+
+/// Build a LiteSVM with pfda-amm-3 loaded, pre-seed a pool and its three
+/// vault token accounts, and return handles.
+///
+/// `current_batch_id` is written straight onto the pool so individual
+/// tests can pick where in the batch timeline they want to land (e.g.
+/// 150 for a history-eligible pool, 50 for a rejection case).
+fn seed_pool(current_batch_id: u64) -> Option<Seed> {
+    let mut svm = LiteSVM::new();
+    if !std::path::Path::new(PFDA_AMM_3_SO).exists() {
+        eprintln!("SKIP: pfda_amm_3.so fixture missing");
+        return None;
+    }
+    svm.add_program_from_file(pfda3_id(), PFDA_AMM_3_SO).ok()?;
+
+    let payer = Keypair::new();
+    svm.airdrop(&payer.pubkey(), 100 * LAMPORTS_PER_SOL).unwrap();
+
+    let mints = [
+        Address::new_unique(),
+        Address::new_unique(),
+        Address::new_unique(),
+    ];
+    for &m in &mints {
+        create_mint(&mut svm, m, &payer.pubkey(), 6);
+    }
+
+    let (pool, bump) = Address::find_program_address(
+        &[
+            b"pool3",
+            mints[0].as_ref(),
+            mints[1].as_ref(),
+            mints[2].as_ref(),
+        ],
+        &pfda3_id(),
+    );
+    let vaults = [
+        Address::new_unique(),
+        Address::new_unique(),
+        Address::new_unique(),
+    ];
+    for i in 0..3 {
+        create_token_account(&mut svm, vaults[i], &mints[i], &pool, 1_000_000);
+    }
+
+    // Treasury distinct from authority so we can also catch TreasuryMismatch
+    // regressions if close_batch_history ever gains that gate.
+    let treasury = Address::new_unique();
+
+    let pd = build_pfda3_pool_state(
+        &mints,
+        &vaults,
+        &[1_000_000; 3],
+        &[333_333, 333_333, 333_334],
+        1,                       // window_slots
+        current_batch_id,        // current_batch_id
+        10,                      // current_window_end (doesn't matter for close)
+        &treasury,
+        &payer.pubkey(),         // authority — required for PR #50 rent_recipient gate
+        30,                      // base_fee_bps
+        bump,
+    );
+    svm.set_account(
+        pool,
+        Account {
+            lamports: LAMPORTS_PER_SOL,
+            data: pd,
+            owner: pfda3_id(),
+            executable: false,
+            rent_epoch: 0,
+        },
+    )
+    .unwrap();
+
+    Some(Seed { svm, payer, pool })
+}
+
+// ─── Tests ──────────────────────────────────────────────────────────────
+
+#[test]
+fn close_batch_history_success_after_delay() {
+    require_fixture!(PFDA_AMM_3_SO);
+    let Seed { mut svm, payer, pool } = match seed_pool(/*current_batch_id=*/ 150) {
+        Some(s) => s,
+        None => return,
+    };
+
+    let old_batch_id: u64 = 0;
+    let (history, hbump) = Address::find_program_address(
+        &[b"history3", pool.as_ref(), &old_batch_id.to_le_bytes()],
+        &pfda3_id(),
+    );
+    let rent = 1_000_000u64;
+    svm.set_account(
+        history,
+        Account {
+            lamports: rent,
+            data: build_cleared_batch_history_3(&pool, old_batch_id, 30, hbump),
+            owner: pfda3_id(),
+            executable: false,
+            rent_epoch: 0,
+        },
+    )
+    .unwrap();
+
+    let before = svm.get_balance(&payer.pubkey()).unwrap_or_else(|| {
+        panic!("payer has no balance entry; airdrop may have failed")
+    });
+    send(
+        &mut svm,
+        pfda3_close_batch_history_ix(pfda3_id(), payer.pubkey(), pool, history),
+        &payer,
+    )
+    .expect("CloseBatchHistory should succeed after delay");
+
+    // History account drained, payer credited (net of tx fee).
+    // After close the runtime may GC the zero-lamport account entirely
+    // instead of leaving a 0-balance stub — accept either.
+    assert_eq!(
+        svm.get_balance(&history).unwrap_or(0),
+        0,
+        "history lamports should be zero after close"
+    );
+    let after = svm.get_balance(&payer.pubkey()).unwrap_or(0);
+    assert!(
+        after > before,
+        "rent_recipient should gain lamports ({} -> {})",
+        before,
+        after
+    );
+}
+
+#[test]
+fn close_batch_history_rejects_before_delay() {
+    require_fixture!(PFDA_AMM_3_SO);
+    // current_batch_id = 50 → only 50 batches elapsed vs the 100-batch
+    // CLOSE_DELAY. Should reject.
+    let Seed { mut svm, payer, pool } = match seed_pool(/*current_batch_id=*/ 50) {
+        Some(s) => s,
+        None => return,
+    };
+
+    let old_batch_id: u64 = 0;
+    let (history, hbump) = Address::find_program_address(
+        &[b"history3", pool.as_ref(), &old_batch_id.to_le_bytes()],
+        &pfda3_id(),
+    );
+    svm.set_account(
+        history,
+        Account {
+            lamports: 1_000_000,
+            data: build_cleared_batch_history_3(&pool, old_batch_id, 30, hbump),
+            owner: pfda3_id(),
+            executable: false,
+            rent_epoch: 0,
+        },
+    )
+    .unwrap();
+
+    let err = send(
+        &mut svm,
+        pfda3_close_batch_history_ix(pfda3_id(), payer.pubkey(), pool, history),
+        &payer,
+    )
+    .err()
+    .expect("CloseBatchHistory should reject pre-delay");
+    // Pfda3Error::BatchWindowNotEnded = 8002 (0x1f42)
+    assert!(
+        err.contains("0x1f42") || err.contains("Custom(8002)") || err.contains("BatchWindowNotEnded"),
+        "expected BatchWindowNotEnded, got: {err}"
+    );
+}
+
+#[test]
+fn close_expired_ticket_success_after_delay() {
+    require_fixture!(PFDA_AMM_3_SO);
+    // 250 batches elapsed > 200-batch expiry.
+    let Seed { mut svm, payer, pool } = match seed_pool(/*current_batch_id=*/ 250) {
+        Some(s) => s,
+        None => return,
+    };
+
+    let ticket_batch_id: u64 = 0;
+    let ticket_owner = payer.pubkey();
+    let (ticket, tbump) = Address::find_program_address(
+        &[
+            b"ticket3",
+            pool.as_ref(),
+            ticket_owner.as_ref(),
+            &ticket_batch_id.to_le_bytes(),
+        ],
+        &pfda3_id(),
+    );
+    let rent = 1_500_000u64;
+    svm.set_account(
+        ticket,
+        Account {
+            lamports: rent,
+            data: build_user_order_ticket_3(&ticket_owner, &pool, ticket_batch_id, tbump),
+            owner: pfda3_id(),
+            executable: false,
+            rent_epoch: 0,
+        },
+    )
+    .unwrap();
+
+    let before = svm.get_balance(&ticket_owner).unwrap_or_else(|| {
+        panic!("ticket owner has no balance entry; airdrop may have failed")
+    });
+    send(
+        &mut svm,
+        pfda3_close_expired_ticket_ix(pfda3_id(), payer.pubkey(), pool, ticket, ticket_owner),
+        &payer,
+    )
+    .expect("CloseExpiredTicket should succeed after delay");
+
+    assert_eq!(
+        svm.get_balance(&ticket).unwrap_or(0),
+        0,
+        "ticket lamports should be zero after close"
+    );
+    let after = svm.get_balance(&ticket_owner).unwrap_or(0);
+    assert!(
+        after > before,
+        "ticket owner should gain lamports ({} -> {})",
+        before,
+        after
+    );
+}
+
+#[test]
+fn close_expired_ticket_rejects_before_delay() {
+    require_fixture!(PFDA_AMM_3_SO);
+    // 100 batches elapsed < 200-batch expiry.
+    let Seed { mut svm, payer, pool } = match seed_pool(/*current_batch_id=*/ 100) {
+        Some(s) => s,
+        None => return,
+    };
+
+    let ticket_batch_id: u64 = 0;
+    let ticket_owner = payer.pubkey();
+    let (ticket, tbump) = Address::find_program_address(
+        &[
+            b"ticket3",
+            pool.as_ref(),
+            ticket_owner.as_ref(),
+            &ticket_batch_id.to_le_bytes(),
+        ],
+        &pfda3_id(),
+    );
+    svm.set_account(
+        ticket,
+        Account {
+            lamports: 1_500_000,
+            data: build_user_order_ticket_3(&ticket_owner, &pool, ticket_batch_id, tbump),
+            owner: pfda3_id(),
+            executable: false,
+            rent_epoch: 0,
+        },
+    )
+    .unwrap();
+
+    let err = send(
+        &mut svm,
+        pfda3_close_expired_ticket_ix(pfda3_id(), payer.pubkey(), pool, ticket, ticket_owner),
+        &payer,
+    )
+    .err()
+    .expect("CloseExpiredTicket should reject pre-delay");
+    assert!(
+        err.contains("0x1f42") || err.contains("Custom(8002)") || err.contains("BatchWindowNotEnded"),
+        "expected BatchWindowNotEnded, got: {err}"
+    );
+}

--- a/contracts/ab-integration-tests/tests/pfda_amm_coverage.rs
+++ b/contracts/ab-integration-tests/tests/pfda_amm_coverage.rs
@@ -1,0 +1,556 @@
+//! pfda-amm (2-token legacy) regression coverage (issue #33).
+//!
+//! Counterpart to `close_delay.rs` and `scenario_coverage.rs`, which cover
+//! pfda-amm-3. This file hits the same rejection-path rows from kidney's
+//! #33 table, but against the legacy 2-token program.
+//!
+//! Covered:
+//!   - CloseBatchHistory success after 100-batch delay
+//!   - CloseBatchHistory rejection before delay
+//!   - CloseExpiredTicket success after 200-batch delay
+//!   - CloseExpiredTicket rejection before delay
+//!   - AddLiquidity on paused pool → PoolPaused
+//!   - AddLiquidity with wrong vault → VaultMismatch
+//!   - SwapRequest duplicate call same batch is atomic (post PR#50 reorder)
+//!
+//! All tests fabricate canonical PDAs via set_account so we don't depend
+//! on driving a real ClearBatch / 200-batch timeline in the test.
+
+use ab_integration_tests::helpers::{account_builder::*, svm_setup::*, token_factory::*};
+use ab_integration_tests::require_fixture;
+use litesvm::LiteSVM;
+use solana_account::Account;
+use solana_address::Address;
+use solana_instruction::{account_meta::AccountMeta, Instruction};
+use solana_keypair::Keypair;
+use solana_native_token::LAMPORTS_PER_SOL;
+use solana_signer::Signer;
+use solana_transaction::Transaction;
+
+// PfmmError codes (mirror of contracts/pfda-amm/src/error.rs)
+const ERR_BATCH_WINDOW_NOT_ENDED: u32 = 6002;
+const ERR_POOL_PAUSED: u32 = 6018;
+const ERR_VAULT_MISMATCH: u32 = 6020;
+
+// ─── Instruction builders ───────────────────────────────────────────────
+
+fn pfda_close_batch_history_ix(
+    program: Address,
+    rent_recipient: Address,
+    pool: Address,
+    history: Address,
+) -> Instruction {
+    Instruction {
+        program_id: program,
+        accounts: vec![
+            AccountMeta::new(rent_recipient, true),
+            AccountMeta::new_readonly(pool, false),
+            AccountMeta::new(history, false),
+        ],
+        data: vec![7u8], // CloseBatchHistory
+    }
+}
+
+fn pfda_close_expired_ticket_ix(
+    program: Address,
+    caller: Address,
+    pool: Address,
+    ticket: Address,
+    rent_recipient: Address,
+) -> Instruction {
+    Instruction {
+        program_id: program,
+        accounts: vec![
+            AccountMeta::new(caller, true),
+            AccountMeta::new_readonly(pool, false),
+            AccountMeta::new(ticket, false),
+            AccountMeta::new(rent_recipient, false),
+        ],
+        data: vec![8u8], // CloseExpiredTicket
+    }
+}
+
+fn pfda_add_liquidity_ix(
+    program: Address,
+    user: Address,
+    pool: Address,
+    vault_a: Address,
+    vault_b: Address,
+    user_token_a: Address,
+    user_token_b: Address,
+    amount_a: u64,
+    amount_b: u64,
+) -> Instruction {
+    let mut data = vec![4u8]; // AddLiquidity
+    data.extend_from_slice(&amount_a.to_le_bytes());
+    data.extend_from_slice(&amount_b.to_le_bytes());
+    Instruction {
+        program_id: program,
+        accounts: vec![
+            AccountMeta::new(user, true),
+            AccountMeta::new(pool, false),
+            AccountMeta::new(vault_a, false),
+            AccountMeta::new(vault_b, false),
+            AccountMeta::new(user_token_a, false),
+            AccountMeta::new(user_token_b, false),
+            AccountMeta::new_readonly(token_program_id(), false),
+        ],
+        data,
+    }
+}
+
+fn pfda_swap_request_ix(
+    program: Address,
+    user: Address,
+    pool: Address,
+    queue: Address,
+    ticket: Address,
+    user_token_a: Address,
+    user_token_b: Address,
+    vault_a: Address,
+    vault_b: Address,
+    amount_in_a: u64,
+    amount_in_b: u64,
+) -> Instruction {
+    let mut data = vec![1u8]; // SwapRequest
+    data.extend_from_slice(&amount_in_a.to_le_bytes());
+    data.extend_from_slice(&amount_in_b.to_le_bytes());
+    data.extend_from_slice(&0u64.to_le_bytes()); // min_amount_out
+    Instruction {
+        program_id: program,
+        accounts: vec![
+            AccountMeta::new(user, true),
+            AccountMeta::new_readonly(pool, false),
+            AccountMeta::new(queue, false),
+            AccountMeta::new(ticket, false),
+            AccountMeta::new(user_token_a, false),
+            AccountMeta::new(user_token_b, false),
+            AccountMeta::new(vault_a, false),
+            AccountMeta::new(vault_b, false),
+            AccountMeta::new_readonly(token_program_id(), false),
+            AccountMeta::new_readonly(system_program_id(), false),
+        ],
+        data,
+    }
+}
+
+fn send(svm: &mut LiteSVM, ix: Instruction, payer: &Keypair) -> Result<u64, String> {
+    let tx = Transaction::new_signed_with_payer(
+        &[ix],
+        Some(&payer.pubkey()),
+        &[payer],
+        svm.latest_blockhash(),
+    );
+    match svm.send_transaction(tx) {
+        Ok(meta) => Ok(meta.compute_units_consumed),
+        Err(e) => {
+            let mut msg = format!("{:?}", e.err);
+            for log in &e.meta.logs {
+                msg.push_str(&format!("\n  {}", log));
+            }
+            Err(msg)
+        }
+    }
+}
+
+fn assert_custom_err(err: &str, code: u32, label: &str) {
+    let hex = format!("0x{:x}", code);
+    let custom = format!("Custom({})", code);
+    assert!(
+        err.contains(&hex) || err.contains(&custom),
+        "{label}: expected {code} ({hex}), got: {err}"
+    );
+}
+
+// ─── Fixture ────────────────────────────────────────────────────────────
+
+struct Fixture {
+    svm: LiteSVM,
+    payer: Keypair,
+    pool: Address,
+    mint_a: Address,
+    mint_b: Address,
+    vault_a: Address,
+    vault_b: Address,
+    user_tok_a: Address,
+    user_tok_b: Address,
+}
+
+fn seed(current_batch_id: u64, paused: bool) -> Option<Fixture> {
+    let mut svm = LiteSVM::new();
+    if !std::path::Path::new(PFDA_AMM_SO).exists() {
+        eprintln!("SKIP: pfda_amm.so fixture missing");
+        return None;
+    }
+    svm.add_program_from_file(pfda_amm_id(), PFDA_AMM_SO).ok()?;
+
+    let payer = Keypair::new();
+    svm.airdrop(&payer.pubkey(), 100 * LAMPORTS_PER_SOL).unwrap();
+
+    let mint_a = Address::new_unique();
+    let mint_b = Address::new_unique();
+    create_mint(&mut svm, mint_a, &payer.pubkey(), 6);
+    create_mint(&mut svm, mint_b, &payer.pubkey(), 6);
+
+    let (pool, bump) = Address::find_program_address(
+        &[b"pool", mint_a.as_ref(), mint_b.as_ref()],
+        &pfda_amm_id(),
+    );
+
+    let vault_a = Address::new_unique();
+    let vault_b = Address::new_unique();
+    create_token_account(&mut svm, vault_a, &mint_a, &pool, 1_000_000);
+    create_token_account(&mut svm, vault_b, &mint_b, &pool, 1_000_000);
+
+    let user_tok_a = Address::new_unique();
+    let user_tok_b = Address::new_unique();
+    create_token_account(&mut svm, user_tok_a, &mint_a, &payer.pubkey(), 1_000_000_000);
+    create_token_account(&mut svm, user_tok_b, &mint_b, &payer.pubkey(), 1_000_000_000);
+
+    let mut pd = build_pfda_pool_state(
+        &mint_a,
+        &mint_b,
+        &vault_a,
+        &vault_b,
+        1_000_000,
+        1_000_000,
+        500_000,           // weight_a = 50%
+        10,                // window_slots
+        current_batch_id,
+        100,               // current_window_end
+        30,                // base_fee_bps
+        &payer.pubkey(),   // authority
+        bump,
+    );
+    if paused {
+        pd[238] = 1; // paused flag offset
+    }
+    svm.set_account(
+        pool,
+        Account {
+            lamports: LAMPORTS_PER_SOL,
+            data: pd,
+            owner: pfda_amm_id(),
+            executable: false,
+            rent_epoch: 0,
+        },
+    )
+    .unwrap();
+
+    Some(Fixture {
+        svm,
+        payer,
+        pool,
+        mint_a,
+        mint_b,
+        vault_a,
+        vault_b,
+        user_tok_a,
+        user_tok_b,
+    })
+}
+
+fn seed_queue(svm: &mut LiteSVM, pool: Address, batch_id: u64, window_end: u64) -> Address {
+    let (queue, bump) = Address::find_program_address(
+        &[b"queue", pool.as_ref(), &batch_id.to_le_bytes()],
+        &pfda_amm_id(),
+    );
+    let qd = build_batch_queue(&pool, batch_id, 0, 0, window_end, bump);
+    svm.set_account(
+        queue,
+        Account {
+            lamports: LAMPORTS_PER_SOL,
+            data: qd,
+            owner: pfda_amm_id(),
+            executable: false,
+            rent_epoch: 0,
+        },
+    )
+    .unwrap();
+    queue
+}
+
+fn seed_history(svm: &mut LiteSVM, pool: Address, batch_id: u64) -> (Address, u64) {
+    let (hist, bump) = Address::find_program_address(
+        &[b"history", pool.as_ref(), &batch_id.to_le_bytes()],
+        &pfda_amm_id(),
+    );
+    let rent = 1_000_000u64;
+    svm.set_account(
+        hist,
+        Account {
+            lamports: rent,
+            data: build_cleared_batch_history(&pool, batch_id, bump),
+            owner: pfda_amm_id(),
+            executable: false,
+            rent_epoch: 0,
+        },
+    )
+    .unwrap();
+    (hist, rent)
+}
+
+fn seed_ticket(svm: &mut LiteSVM, pool: Address, owner: Address, batch_id: u64) -> (Address, u64) {
+    let (ticket, bump) = Address::find_program_address(
+        &[b"ticket", pool.as_ref(), owner.as_ref(), &batch_id.to_le_bytes()],
+        &pfda_amm_id(),
+    );
+    let rent = 1_500_000u64;
+    svm.set_account(
+        ticket,
+        Account {
+            lamports: rent,
+            data: build_user_order_ticket(&owner, &pool, batch_id, bump),
+            owner: pfda_amm_id(),
+            executable: false,
+            rent_epoch: 0,
+        },
+    )
+    .unwrap();
+    (ticket, rent)
+}
+
+// ─── Tests ──────────────────────────────────────────────────────────────
+
+#[test]
+fn pfda_close_batch_history_success_after_delay() {
+    require_fixture!(PFDA_AMM_SO);
+    let Fixture { mut svm, payer, pool, .. } = match seed(150, false) {
+        Some(f) => f,
+        None => return,
+    };
+    let (hist, _) = seed_history(&mut svm, pool, 0);
+
+    let before = svm.get_balance(&payer.pubkey()).unwrap();
+    send(
+        &mut svm,
+        pfda_close_batch_history_ix(pfda_amm_id(), payer.pubkey(), pool, hist),
+        &payer,
+    )
+    .expect("CloseBatchHistory should succeed after delay");
+
+    assert_eq!(svm.get_balance(&hist).unwrap_or(0), 0);
+    let after = svm.get_balance(&payer.pubkey()).unwrap_or(0);
+    assert!(after > before, "rent credited: {before} -> {after}");
+}
+
+#[test]
+fn pfda_close_batch_history_rejects_before_delay() {
+    require_fixture!(PFDA_AMM_SO);
+    let Fixture { mut svm, payer, pool, .. } = match seed(50, false) {
+        Some(f) => f,
+        None => return,
+    };
+    let (hist, _) = seed_history(&mut svm, pool, 0);
+
+    let err = send(
+        &mut svm,
+        pfda_close_batch_history_ix(pfda_amm_id(), payer.pubkey(), pool, hist),
+        &payer,
+    )
+    .err()
+    .expect("should reject");
+    assert_custom_err(&err, ERR_BATCH_WINDOW_NOT_ENDED, "pre-delay");
+}
+
+#[test]
+fn pfda_close_expired_ticket_success_after_delay() {
+    require_fixture!(PFDA_AMM_SO);
+    let Fixture { mut svm, payer, pool, .. } = match seed(250, false) {
+        Some(f) => f,
+        None => return,
+    };
+    let owner = payer.pubkey();
+    let (ticket, _) = seed_ticket(&mut svm, pool, owner, 0);
+
+    let before = svm.get_balance(&owner).unwrap();
+    send(
+        &mut svm,
+        pfda_close_expired_ticket_ix(pfda_amm_id(), payer.pubkey(), pool, ticket, owner),
+        &payer,
+    )
+    .expect("CloseExpiredTicket should succeed after delay");
+
+    assert_eq!(svm.get_balance(&ticket).unwrap_or(0), 0);
+    let after = svm.get_balance(&owner).unwrap_or(0);
+    assert!(after > before, "rent credited: {before} -> {after}");
+}
+
+#[test]
+fn pfda_close_expired_ticket_rejects_before_delay() {
+    require_fixture!(PFDA_AMM_SO);
+    let Fixture { mut svm, payer, pool, .. } = match seed(100, false) {
+        Some(f) => f,
+        None => return,
+    };
+    let owner = payer.pubkey();
+    let (ticket, _) = seed_ticket(&mut svm, pool, owner, 0);
+
+    let err = send(
+        &mut svm,
+        pfda_close_expired_ticket_ix(pfda_amm_id(), payer.pubkey(), pool, ticket, owner),
+        &payer,
+    )
+    .err()
+    .expect("should reject");
+    assert_custom_err(&err, ERR_BATCH_WINDOW_NOT_ENDED, "pre-delay");
+}
+
+#[test]
+fn pfda_add_liquidity_rejects_when_paused() {
+    require_fixture!(PFDA_AMM_SO);
+    let Fixture {
+        mut svm, payer, pool, mint_a: _, mint_b: _, vault_a, vault_b, user_tok_a, user_tok_b,
+    } = match seed(0, /*paused=*/ true) {
+        Some(f) => f,
+        None => return,
+    };
+
+    let err = send(
+        &mut svm,
+        pfda_add_liquidity_ix(
+            pfda_amm_id(),
+            payer.pubkey(),
+            pool,
+            vault_a,
+            vault_b,
+            user_tok_a,
+            user_tok_b,
+            100,
+            100,
+        ),
+        &payer,
+    )
+    .err()
+    .expect("paused add_liquidity should reject");
+    assert_custom_err(&err, ERR_POOL_PAUSED, "paused rejection");
+}
+
+#[test]
+fn pfda_add_liquidity_rejects_wrong_vault() {
+    require_fixture!(PFDA_AMM_SO);
+    let Fixture {
+        mut svm, payer, pool, mint_a, mint_b: _, vault_a: _, vault_b, user_tok_a, user_tok_b,
+    } = match seed(0, false) {
+        Some(f) => f,
+        None => return,
+    };
+
+    // A rogue vault with the right mint but not the program-registered
+    // vault. Pre-PR#46 this would have transferred the deposit away.
+    let rogue = Address::new_unique();
+    create_token_account(&mut svm, rogue, &mint_a, &pool, 0);
+
+    let err = send(
+        &mut svm,
+        pfda_add_liquidity_ix(
+            pfda_amm_id(),
+            payer.pubkey(),
+            pool,
+            rogue,      // bogus vault_a
+            vault_b,
+            user_tok_a,
+            user_tok_b,
+            100,
+            100,
+        ),
+        &payer,
+    )
+    .err()
+    .expect("wrong vault should reject");
+    assert_custom_err(&err, ERR_VAULT_MISMATCH, "wrong-vault rejection");
+}
+
+#[test]
+fn pfda_swap_request_duplicate_same_batch_is_atomic() {
+    // PR #50 reordered SwapRequest so CreateAccount runs before the
+    // Transfer. A second call in the same batch must now fail on
+    // CreateAccount (account in use) without moving any tokens.
+    //
+    // Pre-fix: the first call would Transfer into the vault, then the
+    // CreateAccount would fail → tokens stranded. Post-fix: the second
+    // call fails atomically before the Transfer.
+    require_fixture!(PFDA_AMM_SO);
+    let Fixture {
+        mut svm, payer, pool, mint_a: _, mint_b: _, vault_a, vault_b, user_tok_a, user_tok_b,
+    } = match seed(0, false) {
+        Some(f) => f,
+        None => return,
+    };
+
+    let queue = seed_queue(&mut svm, pool, 0, 100);
+
+    // First call — happy path. Should create ticket PDA + transfer.
+    send(
+        &mut svm,
+        {
+            let (ticket, _) = Address::find_program_address(
+                &[b"ticket", pool.as_ref(), payer.pubkey().as_ref(), &0u64.to_le_bytes()],
+                &pfda_amm_id(),
+            );
+            pfda_swap_request_ix(
+                pfda_amm_id(),
+                payer.pubkey(),
+                pool,
+                queue,
+                ticket,
+                user_tok_a,
+                user_tok_b,
+                vault_a,
+                vault_b,
+                1000,
+                0,
+            )
+        },
+        &payer,
+    )
+    .expect("first SwapRequest should succeed");
+
+    let vault_a_mid = read_token_amount(&svm, &vault_a);
+    let user_a_mid = read_token_amount(&svm, &user_tok_a);
+
+    // Second call — same (user, batch_id). Must fail atomically.
+    let (ticket2, _) = Address::find_program_address(
+        &[b"ticket", pool.as_ref(), payer.pubkey().as_ref(), &0u64.to_le_bytes()],
+        &pfda_amm_id(),
+    );
+    let err = send(
+        &mut svm,
+        pfda_swap_request_ix(
+            pfda_amm_id(),
+            payer.pubkey(),
+            pool,
+            queue,
+            ticket2,
+            user_tok_a,
+            user_tok_b,
+            vault_a,
+            vault_b,
+            1000,
+            0,
+        ),
+        &payer,
+    )
+    .err()
+    .expect("second SwapRequest same batch should fail");
+    // The account-in-use error comes from the system program; message
+    // varies across LiteSVM versions. What we *care* about is that no
+    // tokens moved between the failed call and the pre-fail snapshot.
+    assert!(!err.is_empty(), "expected a rejection, got: {err}");
+
+    let vault_a_after = read_token_amount(&svm, &vault_a);
+    let user_a_after = read_token_amount(&svm, &user_tok_a);
+    assert_eq!(
+        vault_a_after, vault_a_mid,
+        "vault_a must not change after failed duplicate SwapRequest"
+    );
+    assert_eq!(
+        user_a_after, user_a_mid,
+        "user_tok_a must not change after failed duplicate SwapRequest"
+    );
+}
+
+fn read_token_amount(svm: &LiteSVM, addr: &Address) -> u64 {
+    let acc = svm.get_account(addr).expect("token account");
+    u64::from_le_bytes(acc.data[64..72].try_into().unwrap())
+}

--- a/contracts/ab-integration-tests/tests/scenario_coverage.rs
+++ b/contracts/ab-integration-tests/tests/scenario_coverage.rs
@@ -1,0 +1,367 @@
+//! Scenario-gap coverage (issue #33).
+//!
+//! Kidney's scenario table in #33 lists per-instruction rejection paths
+//! that had no regression tests. This file covers the LiteSVM-suitable
+//! rows for pfda-amm-3 — the ones where PRs #46 / #47 added a new
+//! rejection and a later regression could silently remove it.
+//!
+//! Covered:
+//!   - AddLiquidity wrong vault  → VaultMismatch (8025)      [PR #47]
+//!   - AddLiquidity paused pool  → PoolPaused    (8018)      [PR #47]
+//!   - SwapRequest paused pool   → PoolPaused    (8018)      [PR #47]
+//!
+//! The pattern mirrors close_delay.rs: pre-seed a pool + vaults + user
+//! accounts via set_account, flip the relevant pool field, submit the
+//! instruction, expect the named custom error code.
+
+use ab_integration_tests::helpers::{account_builder::*, svm_setup::*, token_factory::*};
+use ab_integration_tests::require_fixture;
+use litesvm::LiteSVM;
+use solana_account::Account;
+use solana_address::Address;
+use solana_instruction::{account_meta::AccountMeta, Instruction};
+use solana_keypair::Keypair;
+use solana_native_token::LAMPORTS_PER_SOL;
+use solana_signer::Signer;
+use solana_transaction::Transaction;
+
+// Pfda3Error codes (mirror of contracts/pfda-amm-3/src/error.rs)
+const ERR_POOL_PAUSED: u32 = 8018;
+const ERR_VAULT_MISMATCH: u32 = 8025;
+
+// ─── Instruction builders ───────────────────────────────────────────────
+
+fn pfda3_add_liquidity_ix(
+    program: Address,
+    payer: Address,
+    pool: Address,
+    vaults: &[Address; 3],
+    user_tokens: &[Address; 3],
+    amounts: &[u64; 3],
+) -> Instruction {
+    let mut data = vec![4u8];
+    for a in amounts {
+        data.extend_from_slice(&a.to_le_bytes());
+    }
+    Instruction {
+        program_id: program,
+        accounts: vec![
+            AccountMeta::new(payer, true),
+            AccountMeta::new(pool, false),
+            AccountMeta::new(vaults[0], false),
+            AccountMeta::new(vaults[1], false),
+            AccountMeta::new(vaults[2], false),
+            AccountMeta::new(user_tokens[0], false),
+            AccountMeta::new(user_tokens[1], false),
+            AccountMeta::new(user_tokens[2], false),
+            AccountMeta::new_readonly(token_program_id(), false),
+        ],
+        data,
+    }
+}
+
+fn pfda3_swap_request_ix(
+    program: Address,
+    user: Address,
+    pool: Address,
+    queue: Address,
+    ticket: Address,
+    user_token: Address,
+    vault: Address,
+    in_idx: u8,
+    amount_in: u64,
+    out_idx: u8,
+    min_out: u64,
+) -> Instruction {
+    let mut data = vec![1u8];
+    data.push(in_idx);
+    data.extend_from_slice(&amount_in.to_le_bytes());
+    data.push(out_idx);
+    data.extend_from_slice(&min_out.to_le_bytes());
+    Instruction {
+        program_id: program,
+        accounts: vec![
+            AccountMeta::new(user, true),
+            AccountMeta::new_readonly(pool, false),
+            AccountMeta::new(queue, false),
+            AccountMeta::new(ticket, false),
+            AccountMeta::new(user_token, false),
+            AccountMeta::new(vault, false),
+            AccountMeta::new_readonly(token_program_id(), false),
+            AccountMeta::new_readonly(system_program_id(), false),
+        ],
+        data,
+    }
+}
+
+fn send(svm: &mut LiteSVM, ix: Instruction, payer: &Keypair) -> Result<u64, String> {
+    let tx = Transaction::new_signed_with_payer(
+        &[ix],
+        Some(&payer.pubkey()),
+        &[payer],
+        svm.latest_blockhash(),
+    );
+    match svm.send_transaction(tx) {
+        Ok(meta) => Ok(meta.compute_units_consumed),
+        Err(e) => {
+            let mut msg = format!("{:?}", e.err);
+            for log in &e.meta.logs {
+                msg.push_str(&format!("\n  {}", log));
+            }
+            Err(msg)
+        }
+    }
+}
+
+fn assert_custom_err(err: &str, code: u32, label: &str) {
+    let hex = format!("0x{:x}", code);
+    let custom = format!("Custom({})", code);
+    assert!(
+        err.contains(&hex) || err.contains(&custom),
+        "{label}: expected {code} ({hex}), got: {err}"
+    );
+}
+
+// ─── Seed ───────────────────────────────────────────────────────────────
+
+struct Fixture {
+    svm: LiteSVM,
+    payer: Keypair,
+    pool: Address,
+    mints: [Address; 3],
+    vaults: [Address; 3],
+    user_tokens: [Address; 3],
+}
+
+fn seed_pool(paused: bool) -> Option<Fixture> {
+    let mut svm = LiteSVM::new();
+    if !std::path::Path::new(PFDA_AMM_3_SO).exists() {
+        eprintln!("SKIP: pfda_amm_3.so fixture missing");
+        return None;
+    }
+    svm.add_program_from_file(pfda3_id(), PFDA_AMM_3_SO).ok()?;
+
+    let payer = Keypair::new();
+    svm.airdrop(&payer.pubkey(), 100 * LAMPORTS_PER_SOL).unwrap();
+
+    let mints = [
+        Address::new_unique(),
+        Address::new_unique(),
+        Address::new_unique(),
+    ];
+    for &m in &mints {
+        create_mint(&mut svm, m, &payer.pubkey(), 6);
+    }
+
+    let (pool, pool_bump) = Address::find_program_address(
+        &[
+            b"pool3",
+            mints[0].as_ref(),
+            mints[1].as_ref(),
+            mints[2].as_ref(),
+        ],
+        &pfda3_id(),
+    );
+
+    let vaults = [
+        Address::new_unique(),
+        Address::new_unique(),
+        Address::new_unique(),
+    ];
+    let user_tokens = [
+        Address::new_unique(),
+        Address::new_unique(),
+        Address::new_unique(),
+    ];
+    for i in 0..3 {
+        create_token_account(&mut svm, vaults[i], &mints[i], &pool, 1_000_000);
+        create_token_account(&mut svm, user_tokens[i], &mints[i], &payer.pubkey(), 1_000_000_000);
+    }
+
+    let treasury = Address::new_unique();
+    let mut pd = build_pfda3_pool_state(
+        &mints,
+        &vaults,
+        &[1_000_000; 3],
+        &[333_333, 333_333, 333_334],
+        10,        // window_slots
+        0,         // current_batch_id
+        100,       // current_window_end
+        &treasury,
+        &payer.pubkey(),
+        30,        // base_fee_bps
+        pool_bump,
+    );
+    if paused {
+        // PoolState3.paused offset = 332 (per account_builder.rs layout comment).
+        pd[332] = 1;
+    }
+
+    svm.set_account(
+        pool,
+        Account {
+            lamports: LAMPORTS_PER_SOL,
+            data: pd,
+            owner: pfda3_id(),
+            executable: false,
+            rent_epoch: 0,
+        },
+    )
+    .unwrap();
+
+    Some(Fixture {
+        svm,
+        payer,
+        pool,
+        mints,
+        vaults,
+        user_tokens,
+    })
+}
+
+fn seed_batch_queue(svm: &mut LiteSVM, pool: Address, batch_id: u64, window_end: u64) -> Address {
+    let (queue, qbump) = Address::find_program_address(
+        &[b"queue3", pool.as_ref(), &batch_id.to_le_bytes()],
+        &pfda3_id(),
+    );
+    let qd = build_batch_queue_3(&pool, batch_id, &[0; 3], window_end, qbump);
+    svm.set_account(
+        queue,
+        Account {
+            lamports: LAMPORTS_PER_SOL,
+            data: qd,
+            owner: pfda3_id(),
+            executable: false,
+            rent_epoch: 0,
+        },
+    )
+    .unwrap();
+    queue
+}
+
+// ─── Tests ──────────────────────────────────────────────────────────────
+
+#[test]
+fn add_liquidity_rejects_wrong_vault() {
+    require_fixture!(PFDA_AMM_3_SO);
+    let Fixture {
+        mut svm,
+        payer,
+        pool,
+        mints,
+        vaults,
+        user_tokens,
+    } = match seed_pool(/*paused=*/ false) {
+        Some(f) => f,
+        None => return,
+    };
+
+    // Swap in a vault that matches the correct mint but isn't the
+    // program-registered vault for this pool. Pre-PR#47 this would have
+    // silently transferred to the attacker account.
+    let rogue_vault = Address::new_unique();
+    create_token_account(&mut svm, rogue_vault, &mints[0], &pool, 0);
+
+    let mut bad_vaults = vaults;
+    bad_vaults[0] = rogue_vault;
+
+    let err = send(
+        &mut svm,
+        pfda3_add_liquidity_ix(
+            pfda3_id(),
+            payer.pubkey(),
+            pool,
+            &bad_vaults,
+            &user_tokens,
+            &[100, 100, 100],
+        ),
+        &payer,
+    )
+    .err()
+    .expect("AddLiquidity with wrong vault should reject");
+    assert_custom_err(&err, ERR_VAULT_MISMATCH, "wrong-vault rejection");
+}
+
+#[test]
+fn add_liquidity_rejects_when_paused() {
+    require_fixture!(PFDA_AMM_3_SO);
+    let Fixture {
+        mut svm,
+        payer,
+        pool,
+        mints: _,
+        vaults,
+        user_tokens,
+    } = match seed_pool(/*paused=*/ true) {
+        Some(f) => f,
+        None => return,
+    };
+
+    let err = send(
+        &mut svm,
+        pfda3_add_liquidity_ix(
+            pfda3_id(),
+            payer.pubkey(),
+            pool,
+            &vaults,
+            &user_tokens,
+            &[100, 100, 100],
+        ),
+        &payer,
+    )
+    .err()
+    .expect("AddLiquidity on paused pool should reject");
+    assert_custom_err(&err, ERR_POOL_PAUSED, "paused-pool rejection");
+}
+
+#[test]
+fn swap_request_rejects_when_paused() {
+    require_fixture!(PFDA_AMM_3_SO);
+    let Fixture {
+        mut svm,
+        payer,
+        pool,
+        mints: _,
+        vaults,
+        user_tokens,
+    } = match seed_pool(/*paused=*/ true) {
+        Some(f) => f,
+        None => return,
+    };
+
+    // Seed the batch queue so the instruction can get past queue
+    // validation and actually exercise the pool.paused branch.
+    let queue = seed_batch_queue(&mut svm, pool, 0, 100);
+
+    let (ticket, _) = Address::find_program_address(
+        &[
+            b"ticket3",
+            pool.as_ref(),
+            payer.pubkey().as_ref(),
+            &0u64.to_le_bytes(),
+        ],
+        &pfda3_id(),
+    );
+
+    let err = send(
+        &mut svm,
+        pfda3_swap_request_ix(
+            pfda3_id(),
+            payer.pubkey(),
+            pool,
+            queue,
+            ticket,
+            user_tokens[0],
+            vaults[0],
+            0,
+            100,
+            1,
+            0,
+        ),
+        &payer,
+    )
+    .err()
+    .expect("SwapRequest on paused pool should reject");
+    // PR #47 specifically changed this from InvalidDiscriminator to PoolPaused.
+    assert_custom_err(&err, ERR_POOL_PAUSED, "paused-pool rejection");
+}


### PR DESCRIPTION
## Summary

Closes the test-coverage long tail from kidney's #33 scenario table that PRs #50 / #52 / #53 didn't already reach. Adds **16 new LiteSVM tests** across two new binaries, builds the pfda-amm \`.so\` in CI, and gates the new binaries in the A/B Test Suite workflow.

## What lands

### `tests/pfda_amm_coverage.rs` — 7 tests against the legacy 2-token program

| Scenario | Expected |
|----------|----------|
| `CloseBatchHistory` success after 100-batch delay | rent drained + credited |
| `CloseBatchHistory` rejection before delay | `BatchWindowNotEnded (6002)` |
| `CloseExpiredTicket` success after 200-batch delay | ticket drained + owner credited |
| `CloseExpiredTicket` rejection before delay | `BatchWindowNotEnded (6002)` |
| `AddLiquidity` on paused pool | `PoolPaused (6018)` |
| `AddLiquidity` wrong vault | `VaultMismatch (6020)` |
| `SwapRequest` duplicate-same-batch is atomic | PR #50's reorder — no tokens move if the second `CreateAccount` fails |

### `tests/axis_g3m_coverage.rs` — 9 tests against axis-g3m

| Scenario | Expected |
|----------|----------|
| `Swap` paused | `PoolPaused (7010)` |
| `Swap` zero input | `ZeroAmount (7003)` |
| `Swap` same in/out index | `InvalidTokenIndex (7007)` |
| `Swap` slippage exceeded | `SlippageExceeded (7004)` |
| `Rebalance` during cooldown | `CooldownActive (7009)` |
| `Rebalance` wrong authority | `Unauthorized (7020)` |
| `InitializePool` invalid \`token_count\` | `InvalidTokenCount (7001)` |
| `InitializePool` weights != 10_000 | `WeightsMismatch (7002)` |
| `InitializePool` duplicate init | `AlreadyInitialized (7015)` — PR #48's re-init guard |

## Harness details

- **pfda-amm tests pre-seed state** via `LiteSVM::set_account`, mirroring the `close_delay.rs` pattern. Works because pfda-amm's rejection paths exit before any CPI that would need realloc headroom.
- **axis-g3m tests drive a real `InitializePool`** — pre-seeding tripped pinocchio's `MAX_PERMITTED_DATA_INCREASE` check during the swap CPI (real init allocates the account with the right headroom). For the paused-swap and cooldown-rebalance cases we mutate the post-init pool directly (flip the paused byte, warp the clock).
- **`paused` byte offset on `G3mPoolState`** was derived via an `offset_of!` probe against the actual struct — paused sits at `len - 8` (offset 456 on the 464-byte struct), not at the position the pre-existing `build_g3m_pool_state` helper suggests. The helper is off by 9 bytes on tail fields; I left it alone because the existing tests don't touch those fields.

## New helpers

In `contracts/ab-integration-tests/src/helpers/`:
- `account_builder.rs` — `build_pfda_pool_state` / `build_batch_queue` / `build_cleared_batch_history` / `build_user_order_ticket` for the legacy pfda-amm program.
- `svm_setup.rs` — `PFDA_AMM_ID` / `AXIS_VAULT_ID` constants and their SO-file paths, plus `pfda_amm_id()` / `axis_vault_id()` helpers.

## CI wiring

`.github/workflows/litesvm-jupiter-cpi.yml`:
- Builds pfda-amm's SBF `.so` alongside the existing g3m + pfda-amm-3 builds.
- Two new steps after the existing `ab_comparison` run:
  - `cargo test --test pfda_amm_coverage`
  - `cargo test --test axis_g3m_coverage`

## Test plan

- [x] `cargo test --test close_delay` — 4 / 4 pass (from #52, unchanged).
- [x] `cargo test --test scenario_coverage` — 3 / 3 pass (from #53, unchanged).
- [x] `cargo test --test pfda_amm_coverage` — 7 / 7 pass.
- [x] `cargo test --test axis_g3m_coverage` — 9 / 9 pass.
- [x] `cargo test --test ab_comparison` — unchanged (no edits).
- [ ] First CI run will show all 4 regression-test steps executing.
- [ ] Review by @kidneyweakx.

## Not in scope (remaining after this PR)

- **axis-vault scenario tests (paused deposit/withdraw, wrong-mint, second-depositor math)** — blocked on PR #51 (`SetPaused`) being merged, or requires a separate EtfState builder.
- **pfda-amm-3 `Claim` slippage / zero-volume token** — requires exercising the post-ClearBatch claim math; separate harness.
- **axis-g3m `RebalanceViaJupiter` disc=4 with a real Jupiter route** — needs the mainnet-fork validator already wired into this workflow for the axis-g3m side; tracked as a follow-up.
- **Issue #36 on-chain `DepositSol` / `WithdrawSol`** — unchanged; still needs a design call with Muse/kidney.

## Stacking

Branches on top of #53 so it can see the CI wiring added there. The new test files are strictly additive; no conflicts with any other open #33 PR.