### PR TITLE
test(issue-33): close the 7 remaining scenario rows (for real this time)

### DIFF
--- a/.github/workflows/litesvm-jupiter-cpi.yml
+++ b/.github/workflows/litesvm-jupiter-cpi.yml
@@ -61,10 +61,14 @@ jobs:
         run: bun run typecheck 2>&1 || true
 
       # ── Build SBF programs ──
+      # pfda-amm is now exercised by tests/pfda_amm_coverage.rs in the
+      # ab-integration-tests crate, so build its .so alongside the g3m
+      # and pfda-amm-3 binaries the existing test suite loads.
       - name: Build SBF programs
         run: |
           cd contracts/axis-g3m && cargo build-sbf
           cd ../pfda-amm-3 && cargo build-sbf
+          cd ../pfda-amm && cargo build-sbf
 
       - name: Dump Jupiter V6 from mainnet
         run: |
@@ -98,6 +102,22 @@ jobs:
         run: |
           cd contracts/ab-integration-tests
           cargo test --test scenario_coverage -- --nocapture
+
+      # pfda-amm (legacy 2-token) — CloseBatchHistory/CloseExpiredTicket
+      # success + rejection, AddLiquidity paused/wrong-vault,
+      # SwapRequest duplicate-same-batch atomicity (PR #50 reorder).
+      - name: Run pfda-amm regression tests (LiteSVM)
+        run: |
+          cd contracts/ab-integration-tests
+          cargo test --test pfda_amm_coverage -- --nocapture
+
+      # axis-g3m — Swap slippage/zero/same-idx/paused, Rebalance cooldown +
+      # wrong authority, InitializePool invalid-token-count / weights-mismatch /
+      # duplicate-init.
+      - name: Run axis-g3m regression tests (LiteSVM)
+        run: |
+          cd contracts/ab-integration-tests
+          cargo test --test axis_g3m_coverage -- --nocapture
 
       - name: Generate LiteSVM A/B report
         run: |

--- a/.github/workflows/litesvm-jupiter-cpi.yml
+++ b/.github/workflows/litesvm-jupiter-cpi.yml
@@ -69,6 +69,7 @@ jobs:
           cd contracts/axis-g3m && cargo build-sbf
           cd ../pfda-amm-3 && cargo build-sbf
           cd ../pfda-amm && cargo build-sbf
+          cd ../axis-vault && cargo build-sbf
 
       - name: Dump Jupiter V6 from mainnet
         run: |
@@ -119,6 +120,19 @@ jobs:
           cd contracts/ab-integration-tests
           cargo test --test axis_g3m_coverage -- --nocapture
 
+      # pfda-amm-3 Claim — slippage exceeded + zero-volume token short-circuit.
+      - name: Run pfda-amm-3 Claim regression tests (LiteSVM)
+        run: |
+          cd contracts/ab-integration-tests
+          cargo test --test pfda3_claim_coverage -- --nocapture
+
+      # axis-vault — CreateEtf data-validation branches (basket size, weights,
+      # ticker, name). All fire before any CPI so no SPL setup required.
+      - name: Run axis-vault regression tests (LiteSVM)
+        run: |
+          cd contracts/ab-integration-tests
+          cargo test --test axis_vault_coverage -- --nocapture
+
       - name: Generate LiteSVM A/B report
         run: |
           cd contracts/ab-integration-tests
@@ -151,6 +165,19 @@ jobs:
       - name: Run mainnet-fork E2E (solana-test-validator)
         run: |
           RPC_URL=http://localhost:8899 bun test/e2e/axis-g3m/axis-g3m.jupiter-fork.e2e.ts
+
+      # axis-vault mainnet-fork check (#36): PR #42 shipped the
+      # client-bundled SOL-in / SOL-out flow with stub tests only. This
+      # step exercises the real Jupiter quote API + ALT resolution against
+      # a live Jupiter program cloned into the forked validator. demo.ts
+      # builds the versioned tx but does not sign/send — it's a structural
+      # validator for the Jupiter path and tx size/layout.
+      - name: Run axis-vault Jupiter mainnet-fork check
+        run: |
+          RPC_URL=http://localhost:8899 \
+          JUPITER_HOST=https://quote-api.jup.ag \
+            bun scripts/axis-vault/demo.ts
+        continue-on-error: true  # external Jupiter API flakiness ≠ repo regression
 
       - name: Stop forked validator
         if: always()

--- a/.github/workflows/litesvm-jupiter-cpi.yml
+++ b/.github/workflows/litesvm-jupiter-cpi.yml
@@ -85,6 +85,20 @@ jobs:
           cd contracts/ab-integration-tests
           cargo test --test ab_comparison -- --nocapture --skip jupiter --skip mainnet
 
+      # ── #33 regression gates ──
+      # close_delay: CloseBatchHistory / CloseExpiredTicket success + rejection paths.
+      # scenario_coverage: AddLiquidity / SwapRequest rejections (wrong-vault, paused).
+      # Both run against the same pfda_amm_3.so built above — zero extra fixture cost.
+      - name: Run close-delay regression tests (LiteSVM)
+        run: |
+          cd contracts/ab-integration-tests
+          cargo test --test close_delay -- --nocapture
+
+      - name: Run scenario-coverage regression tests (LiteSVM)
+        run: |
+          cd contracts/ab-integration-tests
+          cargo test --test scenario_coverage -- --nocapture
+
       - name: Generate LiteSVM A/B report
         run: |
           cd contracts/ab-integration-tests

--- a/contracts/ab-integration-tests/Cargo.toml
+++ b/contracts/ab-integration-tests/Cargo.toml
@@ -11,6 +11,10 @@ path = "src/lib.rs"
 name = "ab_comparison"
 path = "tests/ab_comparison.rs"
 
+[[test]]
+name = "close_delay"
+path = "tests/close_delay.rs"
+
 [dependencies]
 litesvm = "0.11"
 solana-keypair = "3.1"

--- a/contracts/ab-integration-tests/Cargo.toml
+++ b/contracts/ab-integration-tests/Cargo.toml
@@ -27,6 +27,14 @@ path = "tests/pfda_amm_coverage.rs"
 name = "axis_g3m_coverage"
 path = "tests/axis_g3m_coverage.rs"
 
+[[test]]
+name = "pfda3_claim_coverage"
+path = "tests/pfda3_claim_coverage.rs"
+
+[[test]]
+name = "axis_vault_coverage"
+path = "tests/axis_vault_coverage.rs"
+
 [dependencies]
 litesvm = "0.11"
 solana-keypair = "3.1"

--- a/contracts/ab-integration-tests/Cargo.toml
+++ b/contracts/ab-integration-tests/Cargo.toml
@@ -19,6 +19,14 @@ path = "tests/close_delay.rs"
 name = "scenario_coverage"
 path = "tests/scenario_coverage.rs"
 
+[[test]]
+name = "pfda_amm_coverage"
+path = "tests/pfda_amm_coverage.rs"
+
+[[test]]
+name = "axis_g3m_coverage"
+path = "tests/axis_g3m_coverage.rs"
+
 [dependencies]
 litesvm = "0.11"
 solana-keypair = "3.1"

--- a/contracts/ab-integration-tests/Cargo.toml
+++ b/contracts/ab-integration-tests/Cargo.toml
@@ -15,6 +15,10 @@ path = "tests/ab_comparison.rs"
 name = "close_delay"
 path = "tests/close_delay.rs"
 
+[[test]]
+name = "scenario_coverage"
+path = "tests/scenario_coverage.rs"
+
 [dependencies]
 litesvm = "0.11"
 solana-keypair = "3.1"

--- a/contracts/ab-integration-tests/src/helpers/account_builder.rs
+++ b/contracts/ab-integration-tests/src/helpers/account_builder.rs
@@ -124,6 +124,122 @@ pub fn build_pfda3_pool_state(
     d
 }
 
+/// Build PoolState raw bytes for pfda-amm (the 2-token legacy program).
+/// Layout (240 bytes, repr(C)) per contracts/pfda-amm/src/state/pool_state.rs:
+///   0:    discriminator "poolstat" (8)
+///   8:    token_a_mint (32)
+///  40:    token_b_mint (32)
+///  72:    vault_a (32)
+/// 104:    vault_b (32)
+/// 136:    reserve_a (u64)
+/// 144:    reserve_b (u64)
+/// 152:    current_weight_a (u32)
+/// 156:    target_weight_a (u32)
+/// 160:    weight_start_slot (u64)
+/// 168:    weight_end_slot (u64)
+/// 176:    window_slots (u64)
+/// 184:    current_batch_id (u64)
+/// 192:    current_window_end (u64)
+/// 200:    base_fee_bps (u16)
+/// 202:    fee_discount_bps (u16)
+/// 204:    authority (32)
+/// 236:    bump (u8)
+/// 237:    reentrancy_guard (u8)
+/// 238:    paused (u8)
+/// 239:    _padding (u8)
+#[allow(clippy::too_many_arguments)]
+pub fn build_pfda_pool_state(
+    token_a_mint: &Address,
+    token_b_mint: &Address,
+    vault_a: &Address,
+    vault_b: &Address,
+    reserve_a: u64,
+    reserve_b: u64,
+    weight_a: u32,
+    window_slots: u64,
+    current_batch_id: u64,
+    current_window_end: u64,
+    base_fee_bps: u16,
+    authority: &Address,
+    bump: u8,
+) -> Vec<u8> {
+    let mut d = vec![0u8; 240];
+    d[0..8].copy_from_slice(b"poolstat");
+    d[8..40].copy_from_slice(token_a_mint.as_ref());
+    d[40..72].copy_from_slice(token_b_mint.as_ref());
+    d[72..104].copy_from_slice(vault_a.as_ref());
+    d[104..136].copy_from_slice(vault_b.as_ref());
+    d[136..144].copy_from_slice(&reserve_a.to_le_bytes());
+    d[144..152].copy_from_slice(&reserve_b.to_le_bytes());
+    d[152..156].copy_from_slice(&weight_a.to_le_bytes());
+    d[156..160].copy_from_slice(&weight_a.to_le_bytes()); // target == current
+    // weight_start_slot + weight_end_slot left zero
+    d[176..184].copy_from_slice(&window_slots.to_le_bytes());
+    d[184..192].copy_from_slice(&current_batch_id.to_le_bytes());
+    d[192..200].copy_from_slice(&current_window_end.to_le_bytes());
+    d[200..202].copy_from_slice(&base_fee_bps.to_le_bytes());
+    // fee_discount_bps left zero
+    d[204..236].copy_from_slice(authority.as_ref());
+    d[236] = bump;
+    // reentrancy_guard / paused / pad zero
+    d
+}
+
+/// Build BatchQueue raw bytes for pfda-amm (80 bytes).
+pub fn build_batch_queue(
+    pool: &Address,
+    batch_id: u64,
+    total_in_a: u64,
+    total_in_b: u64,
+    window_end_slot: u64,
+    bump: u8,
+) -> Vec<u8> {
+    let mut d = vec![0u8; 80];
+    d[0..8].copy_from_slice(b"batchque");
+    d[8..40].copy_from_slice(pool.as_ref());
+    d[40..48].copy_from_slice(&batch_id.to_le_bytes());
+    d[48..56].copy_from_slice(&total_in_a.to_le_bytes());
+    d[56..64].copy_from_slice(&total_in_b.to_le_bytes());
+    d[64..72].copy_from_slice(&window_end_slot.to_le_bytes());
+    d[72] = bump;
+    d
+}
+
+/// Build ClearedBatchHistory raw bytes for pfda-amm (80 bytes).
+pub fn build_cleared_batch_history(
+    pool: &Address,
+    batch_id: u64,
+    bump: u8,
+) -> Vec<u8> {
+    let mut d = vec![0u8; 80];
+    d[0..8].copy_from_slice(b"clrdhist");
+    d[8..40].copy_from_slice(pool.as_ref());
+    d[40..48].copy_from_slice(&batch_id.to_le_bytes());
+    // clearing_price / out_b_per_in_a / out_a_per_in_b left zero —
+    // CloseBatchHistory doesn't read them.
+    d[72] = 1; // is_cleared
+    d[73] = bump;
+    d
+}
+
+/// Build UserOrderTicket raw bytes for pfda-amm (112 bytes).
+pub fn build_user_order_ticket(
+    owner: &Address,
+    pool: &Address,
+    batch_id: u64,
+    bump: u8,
+) -> Vec<u8> {
+    let mut d = vec![0u8; 112];
+    d[0..8].copy_from_slice(b"usrorder");
+    d[8..40].copy_from_slice(owner.as_ref());
+    d[40..72].copy_from_slice(pool.as_ref());
+    d[72..80].copy_from_slice(&batch_id.to_le_bytes());
+    // amount_in_a / amount_in_b / min_amount_out left zero
+    d[104] = 0; // is_claimed = false
+    d[105] = bump;
+    d
+}
+
 /// Build BatchQueue3 raw bytes (88 bytes).
 pub fn build_batch_queue_3(
     pool: &Address,

--- a/contracts/ab-integration-tests/src/helpers/svm_setup.rs
+++ b/contracts/ab-integration-tests/src/helpers/svm_setup.rs
@@ -4,6 +4,8 @@ use solana_clock::Clock;
 
 pub const AXIS_G3M_ID: &str = "65aE9QdVz5bapV19BGt5cyTgVitYpekGwusRoQEovNUi";
 pub const PFDA_AMM_3_ID: &str = "DbAPmgkrpCCZrpBMv5x1ye6nJUreqY313SuQjZsMyjEf";
+pub const PFDA_AMM_ID: &str = "CSBgQGeBTiAu4a9Kgoas2GyR8wbHg5jxctQjq3AenKk";
+pub const AXIS_VAULT_ID: &str = "DeeUnCHcnPG8arbjGTLhTKeDhpPUBper3TDrpFPHnCwy";
 pub const JUPITER_V6_ID: &str = "JUP6LkbZbjS1jKKwapdHNy74zcZ3tLUZoi5QNyVTaV4";
 
 pub const AXIS_G3M_SO: &str = concat!(
@@ -13,6 +15,14 @@ pub const AXIS_G3M_SO: &str = concat!(
 pub const PFDA_AMM_3_SO: &str = concat!(
     env!("CARGO_MANIFEST_DIR"),
     "/../pfda-amm-3/target/deploy/pfda_amm_3.so"
+);
+pub const PFDA_AMM_SO: &str = concat!(
+    env!("CARGO_MANIFEST_DIR"),
+    "/../pfda-amm/target/deploy/pfda_amm.so"
+);
+pub const AXIS_VAULT_SO: &str = concat!(
+    env!("CARGO_MANIFEST_DIR"),
+    "/../axis-vault/target/deploy/axis_vault.so"
 );
 pub const JUPITER_V6_SO: &str = concat!(
     env!("CARGO_MANIFEST_DIR"),
@@ -34,6 +44,12 @@ pub fn axis_g3m_id() -> Address {
 }
 pub fn pfda3_id() -> Address {
     PFDA_AMM_3_ID.parse().unwrap()
+}
+pub fn pfda_amm_id() -> Address {
+    PFDA_AMM_ID.parse().unwrap()
+}
+pub fn axis_vault_id() -> Address {
+    AXIS_VAULT_ID.parse().unwrap()
 }
 pub fn jupiter_id() -> Address {
     JUPITER_V6_ID.parse().unwrap()

--- a/contracts/ab-integration-tests/src/helpers/token_factory.rs
+++ b/contracts/ab-integration-tests/src/helpers/token_factory.rs
@@ -84,6 +84,22 @@ pub fn create_uninit_token_account(svm: &mut LiteSVM, addr: Address) {
     .unwrap();
 }
 
+/// Create an uninitialized SPL mint account (82 bytes, Token-Program-owned,
+/// zero data). axis-vault's CreateEtf calls `InitializeMint2` on this.
+pub fn create_uninit_mint_account(svm: &mut LiteSVM, addr: Address) {
+    svm.set_account(
+        addr,
+        Account {
+            lamports: LAMPORTS_PER_SOL,
+            data: vec![0u8; 82],
+            owner: token_program_id(),
+            executable: false,
+            rent_epoch: 0,
+        },
+    )
+    .unwrap();
+}
+
 /// Create a token account with extra data padding for CPI realloc headroom.
 /// Used for vault accounts that Jupiter may need to resize during swaps.
 pub fn create_token_account_padded(

--- a/contracts/ab-integration-tests/tests/axis_g3m_coverage.rs
+++ b/contracts/ab-integration-tests/tests/axis_g3m_coverage.rs
@@ -1,0 +1,560 @@
+//! axis-g3m regression coverage (issue #33).
+//!
+//! Covers kidney's scenario-table rows for axis-g3m that were untested:
+//!   - Swap slippage exceeded           → SlippageExceeded (7004)
+//!   - Swap zero input                  → ZeroAmount       (7003)
+//!   - Swap same in+out index           → InvalidTokenIndex (7007)
+//!   - Swap on paused pool              → PoolPaused       (7010)
+//!   - Rebalance during cooldown        → CooldownActive   (7009)
+//!   - Rebalance wrong authority        → Unauthorized     (7020)
+//!   - InitializePool invalid token_count → InvalidTokenCount (7001)
+//!   - InitializePool weights != 10_000  → WeightsMismatch (7002)
+//!   - InitializePool duplicate init     → AlreadyInitialized (7015)
+//!
+//! The setup path drives a real `InitializePool` transaction so the
+//! pool account lives in exactly the shape pinocchio + axis-g3m expect
+//! (correct layout, correct realloc headroom). For rejection scenarios
+//! we mutate the committed state post-init (flip the paused byte,
+//! warp the clock) before issuing the instruction under test.
+
+use ab_integration_tests::helpers::{svm_setup::*, token_factory::*};
+use ab_integration_tests::require_fixture;
+use litesvm::LiteSVM;
+use solana_address::Address;
+use solana_clock::Clock;
+use solana_instruction::{account_meta::AccountMeta, Instruction};
+use solana_keypair::Keypair;
+use solana_native_token::LAMPORTS_PER_SOL;
+use solana_signer::Signer;
+use solana_transaction::Transaction;
+
+// G3mError codes (mirror of contracts/axis-g3m/src/error.rs)
+const ERR_INVALID_TOKEN_COUNT: u32 = 7001;
+const ERR_WEIGHTS_MISMATCH: u32 = 7002;
+const ERR_ZERO_AMOUNT: u32 = 7003;
+const ERR_SLIPPAGE_EXCEEDED: u32 = 7004;
+const ERR_INVALID_TOKEN_INDEX: u32 = 7007;
+const ERR_COOLDOWN_ACTIVE: u32 = 7009;
+const ERR_POOL_PAUSED: u32 = 7010;
+const ERR_ALREADY_INITIALIZED: u32 = 7015;
+const ERR_UNAUTHORIZED: u32 = 7020;
+
+// ─── Instruction builders ───────────────────────────────────────────────
+
+#[allow(clippy::too_many_arguments)]
+fn g3m_init_ix(
+    program: Address,
+    authority: Address,
+    pool_pda: Address,
+    user_tokens: &[Address],
+    vaults: &[Address],
+    tc: u8,
+    fee_bps: u16,
+    drift_bps: u16,
+    cooldown: u64,
+    weights: &[u16],
+    reserves: &[u64],
+) -> Instruction {
+    let mut data = vec![0u8];
+    data.push(tc);
+    data.extend_from_slice(&fee_bps.to_le_bytes());
+    data.extend_from_slice(&drift_bps.to_le_bytes());
+    data.extend_from_slice(&cooldown.to_le_bytes());
+    for w in weights {
+        data.extend_from_slice(&w.to_le_bytes());
+    }
+    for r in reserves {
+        data.extend_from_slice(&r.to_le_bytes());
+    }
+
+    let mut accounts = vec![
+        AccountMeta::new(authority, true),
+        AccountMeta::new(pool_pda, false),
+        AccountMeta::new_readonly(system_program_id(), false),
+        AccountMeta::new_readonly(token_program_id(), false),
+    ];
+    for t in user_tokens {
+        accounts.push(AccountMeta::new(*t, false));
+    }
+    for v in vaults {
+        accounts.push(AccountMeta::new(*v, false));
+    }
+
+    Instruction { program_id: program, accounts, data }
+}
+
+#[allow(clippy::too_many_arguments)]
+fn g3m_swap_ix(
+    program: Address,
+    authority: Address,
+    pool_pda: Address,
+    user_in: Address,
+    user_out: Address,
+    vault_in: Address,
+    vault_out: Address,
+    in_idx: u8,
+    out_idx: u8,
+    amount_in: u64,
+    min_out: u64,
+) -> Instruction {
+    let mut data = vec![1u8];
+    data.push(in_idx);
+    data.push(out_idx);
+    data.extend_from_slice(&amount_in.to_le_bytes());
+    data.extend_from_slice(&min_out.to_le_bytes());
+    Instruction {
+        program_id: program,
+        accounts: vec![
+            AccountMeta::new(authority, true),
+            AccountMeta::new(pool_pda, false),
+            AccountMeta::new(user_in, false),
+            AccountMeta::new(user_out, false),
+            AccountMeta::new(vault_in, false),
+            AccountMeta::new(vault_out, false),
+            AccountMeta::new_readonly(token_program_id(), false),
+        ],
+        data,
+    }
+}
+
+fn g3m_rebalance_ix(
+    program: Address,
+    authority: Address,
+    pool_pda: Address,
+    reserves: &[u64],
+) -> Instruction {
+    let mut data = vec![3u8];
+    for r in reserves {
+        data.extend_from_slice(&r.to_le_bytes());
+    }
+    Instruction {
+        program_id: program,
+        accounts: vec![
+            AccountMeta::new(authority, true),
+            AccountMeta::new(pool_pda, false),
+        ],
+        data,
+    }
+}
+
+fn send(svm: &mut LiteSVM, ix: Instruction, payer: &Keypair) -> Result<u64, String> {
+    let tx = Transaction::new_signed_with_payer(
+        &[ix],
+        Some(&payer.pubkey()),
+        &[payer],
+        svm.latest_blockhash(),
+    );
+    match svm.send_transaction(tx) {
+        Ok(meta) => Ok(meta.compute_units_consumed),
+        Err(e) => {
+            let mut msg = format!("{:?}", e.err);
+            for log in &e.meta.logs {
+                msg.push_str(&format!("\n  {}", log));
+            }
+            Err(msg)
+        }
+    }
+}
+
+fn assert_custom_err(err: &str, code: u32, label: &str) {
+    let hex = format!("0x{:x}", code);
+    let custom = format!("Custom({})", code);
+    assert!(
+        err.contains(&hex) || err.contains(&custom),
+        "{label}: expected {code} ({hex}), got: {err}"
+    );
+}
+
+// ─── Fixture: real init path ────────────────────────────────────────────
+
+struct Fixture {
+    svm: LiteSVM,
+    payer: Keypair,
+    pool: Address,
+    vaults: [Address; 2],
+    user_tokens: [Address; 2],
+}
+
+/// Uses `create_token_account` (not padded) to match the pattern in
+/// `ab_comparison.rs::test_g3m_init_swap_checkdrift` — the token-program
+/// Transfer path is happy with unpadded token accounts, and the swap
+/// CPI in axis-g3m does not trip realloc on a freshly init'd pool.
+fn init_pool(cooldown: u64) -> Option<Fixture> {
+    let mut svm = LiteSVM::new();
+    if !std::path::Path::new(AXIS_G3M_SO).exists() {
+        eprintln!("SKIP: axis_g3m.so fixture missing");
+        return None;
+    }
+    svm.add_program_from_file(axis_g3m_id(), AXIS_G3M_SO).ok()?;
+
+    let payer = Keypair::new();
+    svm.airdrop(&payer.pubkey(), 10 * LAMPORTS_PER_SOL).unwrap();
+
+    let mints = [Address::new_unique(), Address::new_unique()];
+    for &m in &mints {
+        create_mint(&mut svm, m, &payer.pubkey(), 6);
+    }
+
+    let (pool, _bump) = Address::find_program_address(
+        &[b"g3m_pool", payer.pubkey().as_ref()],
+        &axis_g3m_id(),
+    );
+
+    let vaults = [Address::new_unique(), Address::new_unique()];
+    let user_tokens = [Address::new_unique(), Address::new_unique()];
+    for i in 0..2 {
+        create_token_account(&mut svm, vaults[i], &mints[i], &pool, 0);
+        create_token_account(&mut svm, user_tokens[i], &mints[i], &payer.pubkey(), 50_000_000);
+    }
+
+    send(
+        &mut svm,
+        g3m_init_ix(
+            axis_g3m_id(),
+            payer.pubkey(),
+            pool,
+            &user_tokens,
+            &vaults,
+            2,
+            100,        // fee_rate_bps
+            500,        // drift_threshold_bps
+            cooldown,
+            &[5000, 5000],
+            &[10_000_000, 10_000_000],
+        ),
+        &payer,
+    )
+    .expect("init setup");
+
+    Some(Fixture { svm, payer, pool, vaults, user_tokens })
+}
+
+/// Toggle `paused` on a post-init pool. G3mPoolState has 8-byte
+/// alignment and ends with `paused(u8) + bump(u8) + _padding[4]` after
+/// a u64-aligned `rebalance_cooldown` — but repr(C) also inserts u64
+/// alignment padding before `last_rebalance_slot`. Verified via an
+/// `offset_of!` probe against the actual struct: total size = 464,
+/// `paused` sits at offset 456 (== `len - 8`).
+fn set_paused(svm: &mut LiteSVM, pool: Address, paused: bool) {
+    let mut acc = svm.get_account(&pool).expect("pool exists");
+    let n = acc.data.len();
+    acc.data[n - 8] = if paused { 1 } else { 0 };
+    svm.set_account(pool, acc).unwrap();
+}
+
+fn warp(svm: &mut LiteSVM, slot: u64) {
+    svm.set_sysvar(&Clock {
+        slot,
+        epoch_start_timestamp: 0,
+        epoch: 0,
+        leader_schedule_epoch: 0,
+        unix_timestamp: slot as i64,
+    });
+}
+
+// ─── Tests ──────────────────────────────────────────────────────────────
+
+#[test]
+fn swap_rejects_when_paused() {
+    require_fixture!(AXIS_G3M_SO);
+    let Fixture { mut svm, payer, pool, vaults, user_tokens } =
+        match init_pool(0) { Some(f) => f, None => return };
+
+    set_paused(&mut svm, pool, true);
+
+    let err = send(
+        &mut svm,
+        g3m_swap_ix(
+            axis_g3m_id(),
+            payer.pubkey(),
+            pool,
+            user_tokens[0],
+            user_tokens[1],
+            vaults[0],
+            vaults[1],
+            0,
+            1,
+            1_000,
+            0,
+        ),
+        &payer,
+    )
+    .err()
+    .expect("paused swap should reject");
+    assert_custom_err(&err, ERR_POOL_PAUSED, "paused swap");
+}
+
+#[test]
+fn swap_rejects_zero_input() {
+    require_fixture!(AXIS_G3M_SO);
+    let Fixture { mut svm, payer, pool, vaults, user_tokens } =
+        match init_pool(0) { Some(f) => f, None => return };
+
+    let err = send(
+        &mut svm,
+        g3m_swap_ix(
+            axis_g3m_id(),
+            payer.pubkey(),
+            pool,
+            user_tokens[0],
+            user_tokens[1],
+            vaults[0],
+            vaults[1],
+            0,
+            1,
+            0,           // zero amount_in
+            0,
+        ),
+        &payer,
+    )
+    .err()
+    .expect("zero-input swap should reject");
+    assert_custom_err(&err, ERR_ZERO_AMOUNT, "zero amount");
+}
+
+#[test]
+fn swap_rejects_same_in_out_index() {
+    require_fixture!(AXIS_G3M_SO);
+    let Fixture { mut svm, payer, pool, vaults, user_tokens } =
+        match init_pool(0) { Some(f) => f, None => return };
+
+    let err = send(
+        &mut svm,
+        g3m_swap_ix(
+            axis_g3m_id(),
+            payer.pubkey(),
+            pool,
+            user_tokens[0],
+            user_tokens[0],
+            vaults[0],
+            vaults[0],
+            0,
+            0,                 // same index
+            1_000,
+            0,
+        ),
+        &payer,
+    )
+    .err()
+    .expect("same-index swap should reject");
+    assert_custom_err(&err, ERR_INVALID_TOKEN_INDEX, "same in/out index");
+}
+
+#[test]
+fn swap_rejects_slippage_exceeded() {
+    require_fixture!(AXIS_G3M_SO);
+    let Fixture { mut svm, payer, pool, vaults, user_tokens } =
+        match init_pool(0) { Some(f) => f, None => return };
+
+    // 1_000 in against 10M / 10M reserves → out ≈ 990 after fees.
+    // Setting min_out = 10_000_000 ensures slippage fires.
+    let err = send(
+        &mut svm,
+        g3m_swap_ix(
+            axis_g3m_id(),
+            payer.pubkey(),
+            pool,
+            user_tokens[0],
+            user_tokens[1],
+            vaults[0],
+            vaults[1],
+            0,
+            1,
+            1_000,
+            10_000_000,
+        ),
+        &payer,
+    )
+    .err()
+    .expect("unsatisfiable min_out should reject");
+    assert_custom_err(&err, ERR_SLIPPAGE_EXCEEDED, "slippage");
+}
+
+#[test]
+fn rebalance_rejects_during_cooldown() {
+    require_fixture!(AXIS_G3M_SO);
+    // cooldown = 10_000 slots. init's last_rebalance_slot = current_slot.
+    // warp only a few slots forward → still well inside the cooldown.
+    let Fixture { mut svm, payer, pool, .. } =
+        match init_pool(10_000) { Some(f) => f, None => return };
+    warp(&mut svm, 50);
+
+    let err = send(
+        &mut svm,
+        g3m_rebalance_ix(
+            axis_g3m_id(),
+            payer.pubkey(),
+            pool,
+            &[10_000_000, 10_000_000],
+        ),
+        &payer,
+    )
+    .err()
+    .expect("rebalance during cooldown should reject");
+    assert_custom_err(&err, ERR_COOLDOWN_ACTIVE, "cooldown");
+}
+
+#[test]
+fn rebalance_rejects_wrong_authority() {
+    require_fixture!(AXIS_G3M_SO);
+    let Fixture { mut svm, pool, .. } =
+        match init_pool(0) { Some(f) => f, None => return };
+
+    let intruder = Keypair::new();
+    svm.airdrop(&intruder.pubkey(), LAMPORTS_PER_SOL).unwrap();
+
+    let err = send(
+        &mut svm,
+        g3m_rebalance_ix(
+            axis_g3m_id(),
+            intruder.pubkey(),
+            pool,
+            &[10_000_000, 10_000_000],
+        ),
+        &intruder,
+    )
+    .err()
+    .expect("rebalance from non-authority should reject");
+    assert_custom_err(&err, ERR_UNAUTHORIZED, "wrong authority");
+}
+
+// ─── Init edge cases ────────────────────────────────────────────────────
+
+fn fresh_init_svm() -> Option<(LiteSVM, Keypair)> {
+    let mut svm = LiteSVM::new();
+    if !std::path::Path::new(AXIS_G3M_SO).exists() {
+        eprintln!("SKIP: axis_g3m.so fixture missing");
+        return None;
+    }
+    svm.add_program_from_file(axis_g3m_id(), AXIS_G3M_SO).ok()?;
+    let payer = Keypair::new();
+    svm.airdrop(&payer.pubkey(), 10 * LAMPORTS_PER_SOL).unwrap();
+    Some((svm, payer))
+}
+
+fn build_init_accounts(svm: &mut LiteSVM, payer: &Keypair, n: usize) -> (Address, Vec<Address>, Vec<Address>) {
+    let (pool, _) = Address::find_program_address(
+        &[b"g3m_pool", payer.pubkey().as_ref()],
+        &axis_g3m_id(),
+    );
+    let mut user_tokens = Vec::with_capacity(n);
+    let mut vaults = Vec::with_capacity(n);
+    for _ in 0..n {
+        let mint = Address::new_unique();
+        create_mint(svm, mint, &payer.pubkey(), 6);
+        let u = Address::new_unique();
+        let v = Address::new_unique();
+        create_token_account(svm, u, &mint, &payer.pubkey(), 50_000_000);
+        create_token_account(svm, v, &mint, &pool, 0);
+        user_tokens.push(u);
+        vaults.push(v);
+    }
+    (pool, user_tokens, vaults)
+}
+
+#[test]
+fn init_rejects_invalid_token_count() {
+    require_fixture!(AXIS_G3M_SO);
+    let (mut svm, payer) = match fresh_init_svm() { Some(p) => p, None => return };
+    let (pool, user_tokens, vaults) = build_init_accounts(&mut svm, &payer, 1);
+
+    let err = send(
+        &mut svm,
+        g3m_init_ix(
+            axis_g3m_id(),
+            payer.pubkey(),
+            pool,
+            &user_tokens,
+            &vaults,
+            1, // below min (2)
+            30,
+            500,
+            0,
+            &[10_000],
+            &[10_000_000],
+        ),
+        &payer,
+    )
+    .err()
+    .expect("token_count=1 should reject");
+    assert_custom_err(&err, ERR_INVALID_TOKEN_COUNT, "tc too small");
+}
+
+#[test]
+fn init_rejects_weights_not_10_000() {
+    require_fixture!(AXIS_G3M_SO);
+    let (mut svm, payer) = match fresh_init_svm() { Some(p) => p, None => return };
+    let (pool, user_tokens, vaults) = build_init_accounts(&mut svm, &payer, 2);
+
+    let err = send(
+        &mut svm,
+        g3m_init_ix(
+            axis_g3m_id(),
+            payer.pubkey(),
+            pool,
+            &user_tokens,
+            &vaults,
+            2,
+            30,
+            500,
+            0,
+            &[5000, 4999], // sums to 9999
+            &[10_000_000, 10_000_000],
+        ),
+        &payer,
+    )
+    .err()
+    .expect("weights != 10_000 should reject");
+    assert_custom_err(&err, ERR_WEIGHTS_MISMATCH, "weights mismatch");
+}
+
+#[test]
+fn init_rejects_duplicate() {
+    require_fixture!(AXIS_G3M_SO);
+    let (mut svm, payer) = match fresh_init_svm() { Some(p) => p, None => return };
+    let (pool, user_tokens, vaults) = build_init_accounts(&mut svm, &payer, 2);
+
+    // First init — happy path.
+    send(
+        &mut svm,
+        g3m_init_ix(
+            axis_g3m_id(),
+            payer.pubkey(),
+            pool,
+            &user_tokens,
+            &vaults,
+            2,
+            30,
+            500,
+            0,
+            &[5000, 5000],
+            &[10_000_000, 10_000_000],
+        ),
+        &payer,
+    )
+    .expect("first init should succeed");
+
+    svm.expire_blockhash();
+
+    // Second init — PR #48's explicit re-init guard fires.
+    let err = send(
+        &mut svm,
+        g3m_init_ix(
+            axis_g3m_id(),
+            payer.pubkey(),
+            pool,
+            &user_tokens,
+            &vaults,
+            2,
+            30,
+            500,
+            0,
+            &[5000, 5000],
+            &[10_000_000, 10_000_000],
+        ),
+        &payer,
+    )
+    .err()
+    .expect("duplicate init should reject");
+    assert_custom_err(&err, ERR_ALREADY_INITIALIZED, "duplicate init");
+}

--- a/contracts/ab-integration-tests/tests/axis_g3m_coverage.rs
+++ b/contracts/ab-integration-tests/tests/axis_g3m_coverage.rs
@@ -558,3 +558,111 @@ fn init_rejects_duplicate() {
     .expect("duplicate init should reject");
     assert_custom_err(&err, ERR_ALREADY_INITIALIZED, "duplicate init");
 }
+
+// ─── Rebalance >50% attestation reserve-change cap ─────────────────────
+
+const ERR_RESERVE_CHANGE_EXCEEDED: u32 = 7019;
+const ERR_ATTESTATION_REQUIRES_JUPITER: u32 = 7022;
+
+#[test]
+fn rebalance_attestation_rejects_over_50pct_reserve_change() {
+    require_fixture!(AXIS_G3M_SO);
+    // Attestation mode requires Jupiter V6 loaded in the SVM — skip
+    // when the fork fixture isn't present.
+    if !std::path::Path::new(JUPITER_V6_SO).exists() {
+        eprintln!("SKIP: jupiter_v6.so fixture missing");
+        return;
+    }
+
+    let Fixture { mut svm, payer, pool, .. } =
+        match init_pool(0) { Some(f) => f, None => return };
+
+    svm.add_program_from_file(jupiter_id(), JUPITER_V6_SO).unwrap();
+
+    // Force the pool into a drifted state so `needs_rebalance()` fires,
+    // then drop the drift threshold to 1 bp so any drift qualifies.
+    // Layout offsets (verified via offset_of! probe):
+    //   reserves[0]             @ 376  (u64)
+    //   drift_threshold_bps     @ 434  (u16)
+    //   max_invariant_drift_bps @ 436  (u16)
+    {
+        let mut acc = svm.get_account(&pool).unwrap();
+        acc.data[376..384].copy_from_slice(&9_000_000u64.to_le_bytes()); // reserve_0 → 9M
+        acc.data[434..436].copy_from_slice(&1u16.to_le_bytes());         // drift_threshold = 1 bp
+        acc.data[436..438].copy_from_slice(&10_000u16.to_le_bytes());    // max invariant drift = 100%
+        svm.set_account(pool, acc).unwrap();
+    }
+
+    // Attestation-mode Rebalance: authority + pool + jupiter_program
+    // (exactly 3 accounts — no vault slots). Reserve 0 drops from 9M
+    // to 3M (~66.7% change), well past the 5000-bp (50%) cap.
+    let mut data = vec![3u8];
+    data.extend_from_slice(&3_000_000u64.to_le_bytes());
+    data.extend_from_slice(&10_000_000u64.to_le_bytes());
+
+    let err = send(
+        &mut svm,
+        Instruction {
+            program_id: axis_g3m_id(),
+            accounts: vec![
+                AccountMeta::new(payer.pubkey(), true),
+                AccountMeta::new(pool, false),
+                AccountMeta::new_readonly(jupiter_id(), false),
+            ],
+            data,
+        },
+        &payer,
+    )
+    .err()
+    .expect("over-50% attestation reserve change should reject");
+    assert_custom_err(&err, ERR_RESERVE_CHANGE_EXCEEDED, ">50% change");
+}
+
+#[test]
+fn rebalance_attestation_rejects_missing_jupiter() {
+    // PR #48's #33 hardening: attestation mode now requires the
+    // Jupiter V6 program account as an explicit opt-in. Sending
+    // attestation-mode accounts without Jupiter should return
+    // AttestationRequiresJupiter.
+    //
+    // The Jupiter check happens after `needs_rebalance()`, so the pool
+    // must first be in a drifted state; otherwise DriftBelowThreshold
+    // fires first.
+    require_fixture!(AXIS_G3M_SO);
+    let Fixture { mut svm, payer, pool, .. } =
+        match init_pool(0) { Some(f) => f, None => return };
+
+    // Force drift — same byte-level tweak as the >50% test.
+    {
+        let mut acc = svm.get_account(&pool).unwrap();
+        acc.data[376..384].copy_from_slice(&9_000_000u64.to_le_bytes());
+        acc.data[434..436].copy_from_slice(&1u16.to_le_bytes());
+        svm.set_account(pool, acc).unwrap();
+    }
+
+    let mut data = vec![3u8];
+    data.extend_from_slice(&10_000_000u64.to_le_bytes());
+    data.extend_from_slice(&10_000_000u64.to_le_bytes());
+
+    let err = send(
+        &mut svm,
+        Instruction {
+            program_id: axis_g3m_id(),
+            accounts: vec![
+                AccountMeta::new(payer.pubkey(), true),
+                AccountMeta::new(pool, false),
+                // no jupiter_program — attestation mode detected but
+                // Jupiter opt-in missing.
+            ],
+            data,
+        },
+        &payer,
+    )
+    .err()
+    .expect("missing jupiter should reject");
+    assert_custom_err(
+        &err,
+        ERR_ATTESTATION_REQUIRES_JUPITER,
+        "attestation requires jupiter",
+    );
+}

--- a/contracts/ab-integration-tests/tests/axis_g3m_coverage.rs
+++ b/contracts/ab-integration-tests/tests/axis_g3m_coverage.rs
@@ -666,3 +666,87 @@ fn rebalance_attestation_rejects_missing_jupiter() {
         "attestation requires jupiter",
     );
 }
+
+// ─── RebalanceViaJupiter rejection paths (#33) ─────────────────────────
+
+const ERR_DRIFT_BELOW_THRESHOLD: u32 = 7008;
+
+fn rebalance_via_jupiter_ix(
+    authority: Address,
+    pool: Address,
+    jupiter_program: Address,
+    vaults: &[Address],
+    jupiter_data: Vec<u8>,
+) -> Instruction {
+    let mut data = vec![4u8]; // RebalanceViaJupiter
+    let len = jupiter_data.len() as u32;
+    data.extend_from_slice(&len.to_le_bytes());
+    data.extend_from_slice(&jupiter_data);
+
+    let mut accts = vec![
+        AccountMeta::new(authority, true),
+        AccountMeta::new(pool, false),
+        AccountMeta::new_readonly(jupiter_program, false),
+    ];
+    for v in vaults {
+        accts.push(AccountMeta::new(*v, false));
+    }
+    Instruction { program_id: axis_g3m_id(), accounts: accts, data }
+}
+
+#[test]
+fn rebalance_via_jupiter_rejects_wrong_program_id() {
+    require_fixture!(AXIS_G3M_SO);
+    let Fixture { mut svm, payer, pool, vaults, .. } =
+        match init_pool(0) { Some(f) => f, None => return };
+
+    // Pass a wrong pubkey for the Jupiter program slot. The gate fires
+    // with `IncorrectProgramId` (builtin program error, code 0xF) —
+    // it's not a custom code, it's a ProgramError variant.
+    let wrong_program = Address::new_unique();
+
+    let err = send(
+        &mut svm,
+        rebalance_via_jupiter_ix(
+            payer.pubkey(), pool, wrong_program, &vaults,
+            // Dummy route bytes — we never reach the CPI.
+            vec![0u8; 16],
+        ),
+        &payer,
+    )
+    .err()
+    .expect("wrong Jupiter program should reject");
+    assert!(
+        err.contains("IncorrectProgramId") || err.contains("0xf"),
+        "expected IncorrectProgramId, got: {err}"
+    );
+}
+
+#[test]
+fn rebalance_via_jupiter_rejects_below_drift() {
+    require_fixture!(AXIS_G3M_SO);
+    // Pool is freshly init'd with matching reserves + weights — no
+    // drift. RebalanceViaJupiter should reject with DriftBelowThreshold
+    // before reaching the Jupiter CPI, since the hardened (PR #48) path
+    // explicitly validates drift first on both Rebalance and
+    // RebalanceViaJupiter.
+    let Fixture { mut svm, payer, pool, vaults, .. } =
+        match init_pool(0) { Some(f) => f, None => return };
+
+    // We don't have a real Jupiter fixture here — and we don't need
+    // one, because the drift check fires before the CPI. Pass the
+    // canonical Jupiter V6 program id; the program-id check only
+    // validates `program_account.key() == JUPITER_PROGRAM_ID`, not
+    // executability.
+    let err = send(
+        &mut svm,
+        rebalance_via_jupiter_ix(
+            payer.pubkey(), pool, jupiter_id(), &vaults,
+            vec![0u8; 16],
+        ),
+        &payer,
+    )
+    .err()
+    .expect("below-drift RebalanceViaJupiter should reject");
+    assert_custom_err(&err, ERR_DRIFT_BELOW_THRESHOLD, "below drift");
+}

--- a/contracts/ab-integration-tests/tests/axis_vault_coverage.rs
+++ b/contracts/ab-integration-tests/tests/axis_vault_coverage.rs
@@ -1,0 +1,317 @@
+//! axis-vault CreateEtf + Deposit validation coverage (issue #33).
+//!
+//! kidney's scenario table:
+//!   - CreateEtf invalid token_count          → InvalidBasketSize (9002)
+//!   - CreateEtf weights != 10_000            → WeightsMismatch   (9003)
+//!   - CreateEtf invalid ticker               → InvalidTicker     (9019)
+//!   - CreateEtf invalid name                 → InvalidName       (9020)
+//!   - Deposit wrong mint on basket ATA       → MintMismatch or similar
+//!
+//! These sit in the validation prefix of CreateEtf, before any account
+//! initialization CPIs run — we can hit every branch with a minimal
+//! account set (just enough to pass the length check) and a hand-rolled
+//! instruction-data buffer.
+
+use ab_integration_tests::helpers::{svm_setup::*, token_factory::*};
+use ab_integration_tests::require_fixture;
+use litesvm::LiteSVM;
+use solana_account::Account;
+use solana_address::Address;
+use solana_instruction::{account_meta::AccountMeta, Instruction};
+use solana_keypair::Keypair;
+use solana_native_token::LAMPORTS_PER_SOL;
+use solana_signer::Signer;
+use solana_transaction::Transaction;
+
+// VaultError codes
+const ERR_INVALID_BASKET_SIZE: u32 = 9002;
+const ERR_WEIGHTS_MISMATCH: u32 = 9003;
+const ERR_INVALID_TICKER: u32 = 9019;
+const ERR_INVALID_NAME: u32 = 9020;
+
+// ─── CreateEtf instruction data helpers ────────────────────────────────
+
+fn create_etf_data(
+    token_count: u8,
+    weights_bps: &[u16],
+    ticker: &[u8],
+    name: &[u8],
+) -> Vec<u8> {
+    let mut data = vec![0u8]; // disc = 0 (CreateEtf)
+    data.push(token_count);
+    for w in weights_bps {
+        data.extend_from_slice(&w.to_le_bytes());
+    }
+    data.push(ticker.len() as u8);
+    data.extend_from_slice(ticker);
+    data.push(name.len() as u8);
+    data.extend_from_slice(name);
+    data
+}
+
+/// Build the minimum account list CreateEtf expects (6 fixed + 2N).
+/// For validation-only tests we just need N fresh unique keys — the
+/// rejection fires on instruction-data validation before any account
+/// deserialization, so the accounts don't need real mint/vault bytes.
+fn create_etf_accounts(
+    authority: Address,
+    etf_state: Address,
+    etf_mint: Address,
+    treasury: Address,
+    basket_mints: &[Address],
+    basket_vaults: &[Address],
+) -> Vec<AccountMeta> {
+    let mut a = vec![
+        AccountMeta::new(authority, true),
+        AccountMeta::new(etf_state, false),
+        AccountMeta::new(etf_mint, false),
+        AccountMeta::new_readonly(treasury, false),
+        AccountMeta::new_readonly(system_program_id(), false),
+        AccountMeta::new_readonly(token_program_id(), false),
+    ];
+    for m in basket_mints {
+        a.push(AccountMeta::new_readonly(*m, false));
+    }
+    for v in basket_vaults {
+        a.push(AccountMeta::new(*v, false));
+    }
+    a
+}
+
+fn send(svm: &mut LiteSVM, ix: Instruction, payer: &Keypair) -> Result<u64, String> {
+    let tx = Transaction::new_signed_with_payer(
+        &[ix],
+        Some(&payer.pubkey()),
+        &[payer],
+        svm.latest_blockhash(),
+    );
+    match svm.send_transaction(tx) {
+        Ok(meta) => Ok(meta.compute_units_consumed),
+        Err(e) => {
+            let mut msg = format!("{:?}", e.err);
+            for log in &e.meta.logs {
+                msg.push_str(&format!("\n  {}", log));
+            }
+            Err(msg)
+        }
+    }
+}
+
+fn assert_custom_err(err: &str, code: u32, label: &str) {
+    let hex = format!("0x{:x}", code);
+    let custom = format!("Custom({})", code);
+    assert!(
+        err.contains(&hex) || err.contains(&custom),
+        "{label}: expected {code} ({hex}), got: {err}"
+    );
+}
+
+// ─── Fixture ────────────────────────────────────────────────────────────
+
+struct Fixture {
+    svm: LiteSVM,
+    payer: Keypair,
+    etf_state: Address,
+    etf_mint: Address,
+    treasury: Address,
+    basket_mints: Vec<Address>,
+    basket_vaults: Vec<Address>,
+}
+
+/// Minimal setup for CreateEtf validation tests. Doesn't pre-create
+/// any SPL state — these tests exercise instruction-data rejection
+/// which fires before any account reads.
+fn seed(n: usize, name: &[u8]) -> Option<Fixture> {
+    let mut svm = LiteSVM::new();
+    if !std::path::Path::new(AXIS_VAULT_SO).exists() {
+        eprintln!("SKIP: axis_vault.so fixture missing");
+        return None;
+    }
+    svm.add_program_from_file(axis_vault_id(), AXIS_VAULT_SO).ok()?;
+
+    let payer = Keypair::new();
+    svm.airdrop(&payer.pubkey(), 100 * LAMPORTS_PER_SOL).unwrap();
+
+    let etf_mint = Address::new_unique();
+    let treasury = Address::new_unique();
+
+    // Fund the etf_mint and vaults as empty System-owned accounts so
+    // the runtime accepts the tx; CreateEtf's validation will reject
+    // before it tries to CreateAccount / InitializeMint on them.
+    let basket_mints: Vec<Address> = (0..n).map(|_| Address::new_unique()).collect();
+    let basket_vaults: Vec<Address> = (0..n).map(|_| Address::new_unique()).collect();
+
+    let (etf_state, _bump) = Address::find_program_address(
+        &[b"etf", payer.pubkey().as_ref(), name],
+        &axis_vault_id(),
+    );
+
+    // Empty accounts: 0 data, system-owned, 0 lamports — enough for the
+    // runtime to serialize them into the tx. Program rejects before
+    // reading their data.
+    for k in basket_mints.iter().chain(basket_vaults.iter()).chain([etf_mint, treasury, etf_state].iter()) {
+        svm.set_account(
+            *k,
+            Account {
+                lamports: 0,
+                data: vec![],
+                owner: Address::from([0u8; 32]),
+                executable: false,
+                rent_epoch: 0,
+            },
+        )
+        .unwrap();
+    }
+
+    Some(Fixture {
+        svm, payer, etf_state, etf_mint, treasury,
+        basket_mints, basket_vaults,
+    })
+}
+
+// ─── Tests ──────────────────────────────────────────────────────────────
+
+#[test]
+fn create_etf_rejects_invalid_basket_size() {
+    require_fixture!(AXIS_VAULT_SO);
+    let Fixture { mut svm, payer, etf_state, etf_mint, treasury, basket_mints, basket_vaults } =
+        match seed(1, b"TEST") { Some(f) => f, None => return };
+
+    // token_count = 1 is below the MIN_BASKET_TOKENS (2).
+    let err = send(
+        &mut svm,
+        Instruction {
+            program_id: axis_vault_id(),
+            accounts: create_etf_accounts(
+                payer.pubkey(), etf_state, etf_mint, treasury,
+                &basket_mints, &basket_vaults,
+            ),
+            data: create_etf_data(1, &[10_000], b"AX", b"TEST"),
+        },
+        &payer,
+    )
+    .err()
+    .expect("tc=1 should reject");
+    assert_custom_err(&err, ERR_INVALID_BASKET_SIZE, "tc too small");
+}
+
+#[test]
+fn create_etf_rejects_weights_mismatch() {
+    require_fixture!(AXIS_VAULT_SO);
+    let Fixture { mut svm, payer, etf_state, etf_mint, treasury, basket_mints, basket_vaults } =
+        match seed(3, b"TEST") { Some(f) => f, None => return };
+
+    // Weights sum to 9_999 (off by 1), not 10_000.
+    let err = send(
+        &mut svm,
+        Instruction {
+            program_id: axis_vault_id(),
+            accounts: create_etf_accounts(
+                payer.pubkey(), etf_state, etf_mint, treasury,
+                &basket_mints, &basket_vaults,
+            ),
+            data: create_etf_data(3, &[3334, 3333, 3332], b"AX", b"TEST"),
+        },
+        &payer,
+    )
+    .err()
+    .expect("weight sum 9999 should reject");
+    assert_custom_err(&err, ERR_WEIGHTS_MISMATCH, "weights mismatch");
+}
+
+#[test]
+fn create_etf_rejects_invalid_ticker() {
+    require_fixture!(AXIS_VAULT_SO);
+    let Fixture { mut svm, payer, etf_state, etf_mint, treasury, basket_mints, basket_vaults } =
+        match seed(3, b"TEST") { Some(f) => f, None => return };
+
+    // Ticker contains lowercase — rejected (ASCII upper + digits only).
+    let err = send(
+        &mut svm,
+        Instruction {
+            program_id: axis_vault_id(),
+            accounts: create_etf_accounts(
+                payer.pubkey(), etf_state, etf_mint, treasury,
+                &basket_mints, &basket_vaults,
+            ),
+            data: create_etf_data(3, &[3334, 3333, 3333], b"ax", b"TEST"),
+        },
+        &payer,
+    )
+    .err()
+    .expect("lowercase ticker should reject");
+    assert_custom_err(&err, ERR_INVALID_TICKER, "ticker lowercase");
+}
+
+#[test]
+fn create_etf_rejects_invalid_ticker_too_short() {
+    require_fixture!(AXIS_VAULT_SO);
+    let Fixture { mut svm, payer, etf_state, etf_mint, treasury, basket_mints, basket_vaults } =
+        match seed(3, b"TEST") { Some(f) => f, None => return };
+
+    // Ticker is 1 char — below the 2..=16 bound.
+    let err = send(
+        &mut svm,
+        Instruction {
+            program_id: axis_vault_id(),
+            accounts: create_etf_accounts(
+                payer.pubkey(), etf_state, etf_mint, treasury,
+                &basket_mints, &basket_vaults,
+            ),
+            data: create_etf_data(3, &[3334, 3333, 3333], b"X", b"TEST"),
+        },
+        &payer,
+    )
+    .err()
+    .expect("1-char ticker should reject");
+    assert_custom_err(&err, ERR_INVALID_TICKER, "ticker too short");
+}
+
+#[test]
+fn create_etf_rejects_empty_name() {
+    require_fixture!(AXIS_VAULT_SO);
+    let Fixture { mut svm, payer, etf_state, etf_mint, treasury, basket_mints, basket_vaults } =
+        match seed(3, b"") { Some(f) => f, None => return };
+
+    // Name is empty — rejected (1..=32 bytes required).
+    let err = send(
+        &mut svm,
+        Instruction {
+            program_id: axis_vault_id(),
+            accounts: create_etf_accounts(
+                payer.pubkey(), etf_state, etf_mint, treasury,
+                &basket_mints, &basket_vaults,
+            ),
+            data: create_etf_data(3, &[3334, 3333, 3333], b"AX", b""),
+        },
+        &payer,
+    )
+    .err()
+    .expect("empty name should reject");
+    assert_custom_err(&err, ERR_INVALID_NAME, "empty name");
+}
+
+#[test]
+fn create_etf_rejects_invalid_utf8_name() {
+    require_fixture!(AXIS_VAULT_SO);
+    // Use a name that's not valid UTF-8 (stray 0xFF byte).
+    let bad_name = &[0xFFu8, 0xFE, 0xFD];
+    let Fixture { mut svm, payer, etf_state, etf_mint, treasury, basket_mints, basket_vaults } =
+        match seed(3, bad_name) { Some(f) => f, None => return };
+
+    let err = send(
+        &mut svm,
+        Instruction {
+            program_id: axis_vault_id(),
+            accounts: create_etf_accounts(
+                payer.pubkey(), etf_state, etf_mint, treasury,
+                &basket_mints, &basket_vaults,
+            ),
+            data: create_etf_data(3, &[3334, 3333, 3333], b"AX", bad_name),
+        },
+        &payer,
+    )
+    .err()
+    .expect("non-UTF-8 name should reject");
+    assert_custom_err(&err, ERR_INVALID_NAME, "non-UTF-8 name");
+}

--- a/contracts/ab-integration-tests/tests/axis_vault_coverage.rs
+++ b/contracts/ab-integration-tests/tests/axis_vault_coverage.rs
@@ -291,6 +291,311 @@ fn create_etf_rejects_empty_name() {
     assert_custom_err(&err, ERR_INVALID_NAME, "empty name");
 }
 
+// ─── Deposit rejection paths ────────────────────────────────────────────
+// Pre-seed an EtfState PDA + a full set of supporting SPL accounts so
+// Deposit's pre-CPI validation branches fire.
+
+const ERR_MINT_MISMATCH: u32 = 9009;
+const ERR_VAULT_MISMATCH: u32 = 9013;
+
+/// EtfState offsets (verified via offset_of! probe against the real
+/// struct — 520 bytes total):
+///   0    discriminator [u8;8]   = "etfstat2"
+///   8    authority [u8;32]
+///   40   etf_mint  [u8;32]
+///   72   token_count u8
+///   73   token_mints [[u8;32];5]
+///   233  token_vaults [[u8;32];5]
+///   394  weights_bps [u16;5]
+///   408  total_supply u64
+///   416  treasury [u8;32]
+///   448  fee_bps u16
+///   450  paused u8
+///   451  bump u8
+///   452  name [u8;32]
+///   484  ticker [u8;16]
+///   504  created_at_slot u64
+///   512  _padding [u8;4]
+#[allow(clippy::too_many_arguments)]
+fn build_etf_state(
+    authority: &Address,
+    etf_mint: &Address,
+    token_count: u8,
+    token_mints: &[Address],
+    token_vaults: &[Address],
+    weights_bps: &[u16],
+    total_supply: u64,
+    treasury: &Address,
+    bump: u8,
+    name: &[u8],
+) -> Vec<u8> {
+    let mut d = vec![0u8; 520];
+    d[0..8].copy_from_slice(b"etfstat2");
+    d[8..40].copy_from_slice(authority.as_ref());
+    d[40..72].copy_from_slice(etf_mint.as_ref());
+    d[72] = token_count;
+    for i in 0..token_count as usize {
+        d[73 + i * 32..73 + (i + 1) * 32].copy_from_slice(token_mints[i].as_ref());
+        d[233 + i * 32..233 + (i + 1) * 32].copy_from_slice(token_vaults[i].as_ref());
+        d[394 + i * 2..394 + (i + 1) * 2].copy_from_slice(&weights_bps[i].to_le_bytes());
+    }
+    d[408..416].copy_from_slice(&total_supply.to_le_bytes());
+    d[416..448].copy_from_slice(treasury.as_ref());
+    d[448..450].copy_from_slice(&30u16.to_le_bytes()); // fee_bps = 30
+    d[450] = 0; // paused
+    d[451] = bump;
+    d[452..452 + name.len()].copy_from_slice(name);
+    d[484..484 + 2].copy_from_slice(b"AX");
+    d
+}
+
+/// Build an SPL mint account blob (82 bytes) with a specific
+/// `mint_authority`.
+fn build_mint_with_authority(mint_authority: &Address, decimals: u8) -> Vec<u8> {
+    let mut d = vec![0u8; 82];
+    d[0..4].copy_from_slice(&1u32.to_le_bytes()); // COption::Some tag
+    d[4..36].copy_from_slice(mint_authority.as_ref());
+    d[44] = decimals;
+    d[45] = 1; // is_initialized
+    d
+}
+
+struct DepositFixture {
+    svm: LiteSVM,
+    payer: Keypair,
+    etf_state: Address,
+    etf_mint: Address,
+    treasury: Address,
+    basket_mints: Vec<Address>,
+    vaults: Vec<Address>,
+    user_basket_atas: Vec<Address>,
+    user_etf_ata: Address,
+    treasury_etf_ata: Address,
+    name: Vec<u8>,
+}
+
+fn seed_deposit(n: usize, paused: bool, total_supply: u64) -> Option<DepositFixture> {
+    let mut svm = LiteSVM::new();
+    if !std::path::Path::new(AXIS_VAULT_SO).exists() {
+        eprintln!("SKIP: axis_vault.so fixture missing");
+        return None;
+    }
+    svm.add_program_from_file(axis_vault_id(), AXIS_VAULT_SO).ok()?;
+
+    let payer = Keypair::new();
+    svm.airdrop(&payer.pubkey(), 100 * LAMPORTS_PER_SOL).unwrap();
+
+    let name = b"TESTETF".to_vec();
+
+    let (etf_state, bump) = Address::find_program_address(
+        &[b"etf", payer.pubkey().as_ref(), &name],
+        &axis_vault_id(),
+    );
+
+    // ETF mint — owned by Token Program, mint_authority = etf_state PDA.
+    let etf_mint = Address::new_unique();
+    svm.set_account(
+        etf_mint,
+        Account {
+            lamports: LAMPORTS_PER_SOL,
+            data: build_mint_with_authority(&etf_state, 6),
+            owner: token_program_id(),
+            executable: false,
+            rent_epoch: 0,
+        },
+    )
+    .unwrap();
+
+    let treasury = Address::new_unique();
+
+    // Basket mints + pool-PDA-owned vaults + user ATAs for each.
+    let mut basket_mints = Vec::with_capacity(n);
+    let mut vaults = Vec::with_capacity(n);
+    let mut user_basket_atas = Vec::with_capacity(n);
+    for _ in 0..n {
+        let mint = Address::new_unique();
+        create_mint(&mut svm, mint, &payer.pubkey(), 6);
+        basket_mints.push(mint);
+
+        let vault = Address::new_unique();
+        // Seed vault with a sensible balance so per-vault mint math
+        // runs cleanly (divide-by-zero otherwise).
+        create_token_account(&mut svm, vault, &mint, &etf_state, 1_000_000);
+        vaults.push(vault);
+
+        let user = Address::new_unique();
+        create_token_account(&mut svm, user, &mint, &payer.pubkey(), 1_000_000_000);
+        user_basket_atas.push(user);
+    }
+
+    // User + treasury ETF ATAs.
+    let user_etf_ata = Address::new_unique();
+    create_token_account(&mut svm, user_etf_ata, &etf_mint, &payer.pubkey(), 0);
+    let treasury_etf_ata = Address::new_unique();
+    create_token_account(&mut svm, treasury_etf_ata, &etf_mint, &treasury, 0);
+
+    // EtfState.
+    let weights_bps: Vec<u16> = (0..n).map(|_| (10_000 / n as u16)).collect();
+    let mut weights = weights_bps.clone();
+    // Fix residual so sum = 10_000
+    let sum: u16 = weights.iter().sum();
+    if sum != 10_000 {
+        *weights.last_mut().unwrap() += 10_000 - sum;
+    }
+    let mut data = build_etf_state(
+        &payer.pubkey(), &etf_mint, n as u8,
+        &basket_mints, &vaults, &weights,
+        total_supply, &treasury, bump, &name,
+    );
+    if paused {
+        data[450] = 1;
+    }
+
+    svm.set_account(
+        etf_state,
+        Account {
+            lamports: LAMPORTS_PER_SOL,
+            data,
+            owner: axis_vault_id(),
+            executable: false,
+            rent_epoch: 0,
+        },
+    )
+    .unwrap();
+
+    Some(DepositFixture {
+        svm, payer, etf_state, etf_mint, treasury,
+        basket_mints, vaults, user_basket_atas,
+        user_etf_ata, treasury_etf_ata, name,
+    })
+}
+
+#[allow(clippy::too_many_arguments)]
+fn deposit_ix(
+    depositor: Address,
+    etf_state: Address,
+    etf_mint: Address,
+    user_etf_ata: Address,
+    treasury_etf_ata: Address,
+    user_basket_atas: &[Address],
+    vaults: &[Address],
+    name: &[u8],
+    amount: u64,
+) -> Instruction {
+    let mut data = vec![1u8]; // Deposit
+    data.extend_from_slice(&amount.to_le_bytes());
+    data.extend_from_slice(&0u64.to_le_bytes()); // min_mint_out
+    data.push(name.len() as u8);
+    data.extend_from_slice(name);
+
+    let mut accts = vec![
+        AccountMeta::new(depositor, true),
+        AccountMeta::new(etf_state, false),
+        AccountMeta::new(etf_mint, false),
+        AccountMeta::new(user_etf_ata, false),
+        AccountMeta::new_readonly(token_program_id(), false),
+        AccountMeta::new(treasury_etf_ata, false),
+    ];
+    for a in user_basket_atas {
+        accts.push(AccountMeta::new(*a, false));
+    }
+    for v in vaults {
+        accts.push(AccountMeta::new(*v, false));
+    }
+
+    Instruction { program_id: axis_vault_id(), accounts: accts, data }
+}
+
+fn send_tx(svm: &mut LiteSVM, ix: Instruction, payer: &Keypair) -> Result<u64, String> {
+    let tx = Transaction::new_signed_with_payer(
+        &[ix],
+        Some(&payer.pubkey()),
+        &[payer],
+        svm.latest_blockhash(),
+    );
+    match svm.send_transaction(tx) {
+        Ok(meta) => Ok(meta.compute_units_consumed),
+        Err(e) => {
+            let mut msg = format!("{:?}", e.err);
+            for log in &e.meta.logs {
+                msg.push_str(&format!("\n  {}", log));
+            }
+            Err(msg)
+        }
+    }
+}
+
+#[test]
+fn deposit_rejects_wrong_etf_mint() {
+    require_fixture!(AXIS_VAULT_SO);
+    let DepositFixture {
+        mut svm, payer, etf_state, etf_mint: _, treasury: _,
+        basket_mints: _, vaults, user_basket_atas,
+        user_etf_ata, treasury_etf_ata, name,
+    } = match seed_deposit(3, false, 0) {
+        Some(f) => f, None => return,
+    };
+
+    // Pass a rogue etf_mint — real SPL mint but not the one stored
+    // on the EtfState. Pre-fix this would have let a depositor mint
+    // against an attacker-controlled mint.
+    let rogue_mint = Address::new_unique();
+    svm.set_account(
+        rogue_mint,
+        Account {
+            lamports: LAMPORTS_PER_SOL,
+            data: build_mint_with_authority(&payer.pubkey(), 6),
+            owner: token_program_id(),
+            executable: false,
+            rent_epoch: 0,
+        },
+    ).unwrap();
+
+    let err = send_tx(
+        &mut svm,
+        deposit_ix(
+            payer.pubkey(), etf_state, rogue_mint,
+            user_etf_ata, treasury_etf_ata,
+            &user_basket_atas, &vaults, &name, 10_000_000,
+        ),
+        &payer,
+    )
+    .err()
+    .expect("wrong etf_mint should reject");
+    assert_custom_err(&err, ERR_MINT_MISMATCH, "deposit wrong mint");
+}
+
+#[test]
+fn deposit_rejects_wrong_vault() {
+    require_fixture!(AXIS_VAULT_SO);
+    let DepositFixture {
+        mut svm, payer, etf_state, etf_mint, treasury: _,
+        basket_mints, mut vaults, user_basket_atas,
+        user_etf_ata, treasury_etf_ata, name,
+    } = match seed_deposit(3, false, 0) {
+        Some(f) => f, None => return,
+    };
+
+    // Replace vaults[0] with a rogue token account of the correct
+    // mint but not the program-registered vault.
+    let rogue_vault = Address::new_unique();
+    create_token_account(&mut svm, rogue_vault, &basket_mints[0], &etf_state, 0);
+    vaults[0] = rogue_vault;
+
+    let err = send_tx(
+        &mut svm,
+        deposit_ix(
+            payer.pubkey(), etf_state, etf_mint,
+            user_etf_ata, treasury_etf_ata,
+            &user_basket_atas, &vaults, &name, 10_000_000,
+        ),
+        &payer,
+    )
+    .err()
+    .expect("wrong vault should reject");
+    assert_custom_err(&err, ERR_VAULT_MISMATCH, "deposit wrong vault");
+}
+
 #[test]
 fn create_etf_rejects_invalid_utf8_name() {
     require_fixture!(AXIS_VAULT_SO);

--- a/contracts/ab-integration-tests/tests/axis_vault_coverage.rs
+++ b/contracts/ab-integration-tests/tests/axis_vault_coverage.rs
@@ -565,6 +565,179 @@ fn deposit_rejects_wrong_etf_mint() {
     assert_custom_err(&err, ERR_MINT_MISMATCH, "deposit wrong mint");
 }
 
+// ─── Second-depositor proportional-mint math (real CreateEtf flow) ─────
+// This one can't use the pre-seeded-state shortcut: proportional math
+// only runs when `total_supply > 0`, and we need the vault balances to
+// have come from a genuine Deposit so the `vault_balance /
+// total_supply` ratio is consistent with on-chain bookkeeping.
+
+#[allow(clippy::too_many_arguments)]
+fn create_etf_ix(
+    authority: Address,
+    etf_state: Address,
+    etf_mint: Address,
+    treasury: Address,
+    basket_mints: &[Address],
+    basket_vaults: &[Address],
+    token_count: u8,
+    weights_bps: &[u16],
+    ticker: &[u8],
+    name: &[u8],
+) -> Instruction {
+    let mut data = vec![0u8];
+    data.push(token_count);
+    for w in weights_bps {
+        data.extend_from_slice(&w.to_le_bytes());
+    }
+    data.push(ticker.len() as u8);
+    data.extend_from_slice(ticker);
+    data.push(name.len() as u8);
+    data.extend_from_slice(name);
+
+    let mut accts = vec![
+        AccountMeta::new(authority, true),
+        AccountMeta::new(etf_state, false),
+        AccountMeta::new(etf_mint, false),
+        AccountMeta::new_readonly(treasury, false),
+        AccountMeta::new_readonly(system_program_id(), false),
+        AccountMeta::new_readonly(token_program_id(), false),
+    ];
+    for m in basket_mints {
+        accts.push(AccountMeta::new_readonly(*m, false));
+    }
+    for v in basket_vaults {
+        accts.push(AccountMeta::new(*v, false));
+    }
+    Instruction { program_id: axis_vault_id(), accounts: accts, data }
+}
+
+#[test]
+fn deposit_second_depositor_mints_proportional_amount() {
+    require_fixture!(AXIS_VAULT_SO);
+    let mut svm = LiteSVM::new();
+    if !std::path::Path::new(AXIS_VAULT_SO).exists() { return; }
+    svm.add_program_from_file(axis_vault_id(), AXIS_VAULT_SO).unwrap();
+
+    let payer = Keypair::new();
+    svm.airdrop(&payer.pubkey(), 100 * LAMPORTS_PER_SOL).unwrap();
+
+    // 3-token equal-weight basket. 3334 + 3333 + 3333 = 10_000.
+    let name = b"PROP".to_vec();
+    let ticker = b"AX".to_vec();
+    let weights: [u16; 3] = [3334, 3333, 3333];
+
+    // Basket mints (real Token-Program SPL mints).
+    let basket_mints: Vec<Address> = (0..3).map(|_| {
+        let m = Address::new_unique();
+        create_mint(&mut svm, m, &payer.pubkey(), 6);
+        m
+    }).collect();
+
+    // User ATAs for each basket mint — pre-fund with plenty.
+    let user_basket_atas: Vec<Address> = (0..3).map(|i| {
+        let a = Address::new_unique();
+        create_token_account(&mut svm, a, &basket_mints[i], &payer.pubkey(), 1_000_000_000);
+        a
+    }).collect();
+
+    // Uninitialized vaults — axis-vault's CreateEtf calls
+    // InitializeAccount3 on each.
+    let vaults: Vec<Address> = (0..3).map(|_| {
+        let v = Address::new_unique();
+        create_uninit_token_account(&mut svm, v);
+        v
+    }).collect();
+
+    // Uninitialized ETF mint — CreateEtf calls InitializeMint2.
+    let etf_mint = Address::new_unique();
+    create_uninit_mint_account(&mut svm, etf_mint);
+
+    let treasury = Address::new_unique();
+
+    let (etf_state, _bump) = Address::find_program_address(
+        &[b"etf", payer.pubkey().as_ref(), &name],
+        &axis_vault_id(),
+    );
+
+    // Real CreateEtf — drives InitializeMint2 + InitializeAccount3 x3
+    // + SystemCreateAccount for etf_state.
+    send(
+        &mut svm,
+        create_etf_ix(
+            payer.pubkey(), etf_state, etf_mint, treasury,
+            &basket_mints, &vaults, 3, &weights, &ticker, &name,
+        ),
+        &payer,
+    )
+    .expect("CreateEtf setup");
+
+    // ETF ATAs for depositor and treasury — created post-CreateEtf
+    // because the mint wasn't a real SPL mint until then.
+    let user_etf_ata = Address::new_unique();
+    create_token_account(&mut svm, user_etf_ata, &etf_mint, &payer.pubkey(), 0);
+    let treasury_etf_ata = Address::new_unique();
+    create_token_account(&mut svm, treasury_etf_ata, &etf_mint, &treasury, 0);
+
+    // ── First deposit: 10_000_000. amount == base units spread across
+    //    3 legs by weights: 3_334_000 / 3_333_000 / 3_333_000.
+    //    mint = amount = 10_000_000. fee = 30 bps = 30_000. liquidity
+    //    lock = 1_000 (virtual). net to user = 9_969_000.
+    svm.expire_blockhash();
+    send(
+        &mut svm,
+        deposit_ix(
+            payer.pubkey(), etf_state, etf_mint,
+            user_etf_ata, treasury_etf_ata,
+            &user_basket_atas, &vaults, &name, 10_000_000,
+        ),
+        &payer,
+    )
+    .expect("first Deposit");
+
+    let user_after_first = read_token_amount(&svm, &user_etf_ata);
+    assert_eq!(
+        user_after_first, 9_969_000,
+        "first-deposit net mint should equal amount - fee - MINIMUM_LIQUIDITY"
+    );
+
+    // Vault balances after first deposit (for reference in the math):
+    //   vault[0] = 3_334_000, vault[1..2] = 3_333_000 each
+    //   etf.total_supply = 10_000_000 (includes 1_000 lock)
+
+    // ── Second deposit: 5_000_000. Proportional math:
+    //   token_amounts[0] = 5_000_000 * 3334 / 10_000 = 1_667_000
+    //   token_amounts[1] = 5_000_000 * 3333 / 10_000 = 1_666_500
+    //   token_amounts[2] = 5_000_000 * 3333 / 10_000 = 1_666_500
+    //   candidate[i] = token_amounts[i] * total_supply / vault_balance[i]
+    //     leg 0: 1_667_000 * 10_000_000 / 3_334_000 = 5_000_000 (exact)
+    //     leg 1: 1_666_500 * 10_000_000 / 3_333_000 = 5_000_000 (exact)
+    //     leg 2: 1_666_500 * 10_000_000 / 3_333_000 = 5_000_000 (exact)
+    //   mint_amount = min = 5_000_000
+    //   fee = 5_000_000 * 30 / 10_000 = 15_000
+    //   net_mint = 4_985_000
+    svm.expire_blockhash();
+    send(
+        &mut svm,
+        deposit_ix(
+            payer.pubkey(), etf_state, etf_mint,
+            user_etf_ata, treasury_etf_ata,
+            &user_basket_atas, &vaults, &name, 5_000_000,
+        ),
+        &payer,
+    )
+    .expect("second Deposit");
+
+    let user_after_second = read_token_amount(&svm, &user_etf_ata);
+    let second_depositor_delta = user_after_second - user_after_first;
+    assert_eq!(
+        second_depositor_delta, 4_985_000,
+        "second-depositor proportional mint should equal 5M - 15k fee \
+         (proof that vault_balance / total_supply math holds across \
+         deposits — regression guard for the NAV-deviation / per-vault \
+         candidate logic)"
+    );
+}
+
 #[test]
 fn deposit_rejects_wrong_vault() {
     require_fixture!(AXIS_VAULT_SO);

--- a/contracts/ab-integration-tests/tests/close_delay.rs
+++ b/contracts/ab-integration-tests/tests/close_delay.rs
@@ -1,0 +1,436 @@
+//! Close-delay success paths (issue #33).
+//!
+//! Kidney flagged that `CloseBatchHistory` and `CloseExpiredTicket` in
+//! both pfda-amm and pfda-amm-3 had never had their success path
+//! exercised — the 100-batch / 200-batch delays made it impractical to
+//! drive through a real flow in unit tests.
+//!
+//! LiteSVM lets us sidestep that by pre-seeding account state via
+//! `set_account`: fabricate a ClearedBatchHistory3 / UserOrderTicket3
+//! at the canonical PDA, advance pool.current_batch_id past the delay,
+//! and invoke the close instruction. The on-chain program logic is
+//! exercised in full — only the intermediate ClearBatch / time-waiting
+//! scaffolding is skipped.
+//!
+//! Covered here (pfda-amm-3):
+//!   1. CloseBatchHistory success once 100 batches have elapsed.
+//!   2. CloseBatchHistory rejection before the delay elapses.
+//!   3. CloseExpiredTicket success once 200 batches have elapsed.
+//!   4. CloseExpiredTicket rejection before the delay elapses.
+//!
+//! pfda-amm has the same instruction shape and delay constants; a
+//! follow-up PR can clone this file against that program's account
+//! layout.
+
+use ab_integration_tests::helpers::{account_builder::*, svm_setup::*, token_factory::*};
+use ab_integration_tests::require_fixture;
+use litesvm::LiteSVM;
+use solana_account::Account;
+use solana_address::Address;
+use solana_instruction::{account_meta::AccountMeta, Instruction};
+use solana_keypair::Keypair;
+use solana_native_token::LAMPORTS_PER_SOL;
+use solana_signer::Signer;
+use solana_transaction::Transaction;
+
+// ─── Account fabrication ────────────────────────────────────────────────
+// Sizes confirmed via `cargo test print_sizes -- --nocapture` in
+// contracts/pfda-amm-3/src/lib.rs (both structs are 128 bytes).
+
+fn build_cleared_batch_history_3(
+    pool: &Address,
+    batch_id: u64,
+    fee_bps: u16,
+    bump: u8,
+) -> Vec<u8> {
+    let mut d = vec![0u8; 128];
+    // Layout (repr(C), total 128 bytes):
+    //   0:   discriminator [8]        = b"clrd3h\0\0"
+    //   8:   pool          [32]
+    //  40:   batch_id      u64
+    //  48:   clearing_prices [u64; 3]  (Q32.32)
+    //  72:   total_out     [u64; 3]
+    //  96:   total_in      [u64; 3]
+    // 120:   fee_bps       u16
+    // 122:   is_cleared    bool
+    // 123:   bump          u8
+    // 124:   _padding      [u8; 4]
+    d[0..8].copy_from_slice(b"clrd3h\0\0");
+    d[8..40].copy_from_slice(pool.as_ref());
+    d[40..48].copy_from_slice(&batch_id.to_le_bytes());
+    // clearing_prices / total_out / total_in stay zero — CloseBatchHistory
+    // doesn't read them.
+    d[120..122].copy_from_slice(&fee_bps.to_le_bytes());
+    d[122] = 1; // is_cleared
+    d[123] = bump;
+    d
+}
+
+fn build_user_order_ticket_3(
+    owner: &Address,
+    pool: &Address,
+    batch_id: u64,
+    bump: u8,
+) -> Vec<u8> {
+    let mut d = vec![0u8; 128];
+    // Layout (repr(C), total 128 bytes):
+    //   0:   discriminator [8] = b"usrord3\0"
+    //   8:   owner         [32]
+    //  40:   pool          [32]
+    //  72:   batch_id      u64
+    //  80:   amounts_in    [u64; 3]
+    // 104:   out_token_idx u8
+    // 105:   padding to u64 align (7)  ← verified via print_sizes
+    // 112:   min_amount_out u64
+    // 120:   is_claimed    bool
+    // 121:   bump          u8
+    // 122:   _padding      [u8; 5]  + trailing alignment pad = 6 bytes → 128
+    d[0..8].copy_from_slice(b"usrord3\0");
+    d[8..40].copy_from_slice(owner.as_ref());
+    d[40..72].copy_from_slice(pool.as_ref());
+    d[72..80].copy_from_slice(&batch_id.to_le_bytes());
+    // amounts_in / out_token_idx / min_amount_out stay zero — CloseExpiredTicket
+    // only reads owner + batch_id off the ticket.
+    d[120] = 0; // is_claimed = false (so it's eligible to close)
+    d[121] = bump;
+    d
+}
+
+// ─── Instruction builders ───────────────────────────────────────────────
+
+fn pfda3_close_batch_history_ix(
+    program: Address,
+    rent_recipient: Address,
+    pool: Address,
+    history: Address,
+) -> Instruction {
+    Instruction {
+        program_id: program,
+        accounts: vec![
+            AccountMeta::new(rent_recipient, true),
+            AccountMeta::new_readonly(pool, false),
+            AccountMeta::new(history, false),
+        ],
+        data: vec![7u8], // disc = CloseBatchHistory
+    }
+}
+
+fn pfda3_close_expired_ticket_ix(
+    program: Address,
+    caller: Address,
+    pool: Address,
+    ticket: Address,
+    rent_recipient: Address,
+) -> Instruction {
+    Instruction {
+        program_id: program,
+        accounts: vec![
+            AccountMeta::new(caller, true),
+            AccountMeta::new_readonly(pool, false),
+            AccountMeta::new(ticket, false),
+            AccountMeta::new(rent_recipient, false),
+        ],
+        data: vec![8u8], // disc = CloseExpiredTicket
+    }
+}
+
+fn send(svm: &mut LiteSVM, ix: Instruction, payer: &Keypair) -> Result<u64, String> {
+    let tx = Transaction::new_signed_with_payer(
+        &[ix],
+        Some(&payer.pubkey()),
+        &[payer],
+        svm.latest_blockhash(),
+    );
+    match svm.send_transaction(tx) {
+        Ok(meta) => Ok(meta.compute_units_consumed),
+        Err(e) => {
+            let mut msg = format!("{:?}", e.err);
+            for log in &e.meta.logs {
+                msg.push_str(&format!("\n  {}", log));
+            }
+            Err(msg)
+        }
+    }
+}
+
+// ─── Test scaffolding ───────────────────────────────────────────────────
+
+struct Seed {
+    svm: LiteSVM,
+    payer: Keypair,
+    pool: Address,
+}
+
+/// Build a LiteSVM with pfda-amm-3 loaded, pre-seed a pool and its three
+/// vault token accounts, and return handles.
+///
+/// `current_batch_id` is written straight onto the pool so individual
+/// tests can pick where in the batch timeline they want to land (e.g.
+/// 150 for a history-eligible pool, 50 for a rejection case).
+fn seed_pool(current_batch_id: u64) -> Option<Seed> {
+    let mut svm = LiteSVM::new();
+    if !std::path::Path::new(PFDA_AMM_3_SO).exists() {
+        eprintln!("SKIP: pfda_amm_3.so fixture missing");
+        return None;
+    }
+    svm.add_program_from_file(pfda3_id(), PFDA_AMM_3_SO).ok()?;
+
+    let payer = Keypair::new();
+    svm.airdrop(&payer.pubkey(), 100 * LAMPORTS_PER_SOL).unwrap();
+
+    let mints = [
+        Address::new_unique(),
+        Address::new_unique(),
+        Address::new_unique(),
+    ];
+    for &m in &mints {
+        create_mint(&mut svm, m, &payer.pubkey(), 6);
+    }
+
+    let (pool, bump) = Address::find_program_address(
+        &[
+            b"pool3",
+            mints[0].as_ref(),
+            mints[1].as_ref(),
+            mints[2].as_ref(),
+        ],
+        &pfda3_id(),
+    );
+    let vaults = [
+        Address::new_unique(),
+        Address::new_unique(),
+        Address::new_unique(),
+    ];
+    for i in 0..3 {
+        create_token_account(&mut svm, vaults[i], &mints[i], &pool, 1_000_000);
+    }
+
+    // Treasury distinct from authority so we can also catch TreasuryMismatch
+    // regressions if close_batch_history ever gains that gate.
+    let treasury = Address::new_unique();
+
+    let pd = build_pfda3_pool_state(
+        &mints,
+        &vaults,
+        &[1_000_000; 3],
+        &[333_333, 333_333, 333_334],
+        1,                       // window_slots
+        current_batch_id,        // current_batch_id
+        10,                      // current_window_end (doesn't matter for close)
+        &treasury,
+        &payer.pubkey(),         // authority — required for PR #50 rent_recipient gate
+        30,                      // base_fee_bps
+        bump,
+    );
+    svm.set_account(
+        pool,
+        Account {
+            lamports: LAMPORTS_PER_SOL,
+            data: pd,
+            owner: pfda3_id(),
+            executable: false,
+            rent_epoch: 0,
+        },
+    )
+    .unwrap();
+
+    Some(Seed { svm, payer, pool })
+}
+
+// ─── Tests ──────────────────────────────────────────────────────────────
+
+#[test]
+fn close_batch_history_success_after_delay() {
+    require_fixture!(PFDA_AMM_3_SO);
+    let Seed { mut svm, payer, pool } = match seed_pool(/*current_batch_id=*/ 150) {
+        Some(s) => s,
+        None => return,
+    };
+
+    let old_batch_id: u64 = 0;
+    let (history, hbump) = Address::find_program_address(
+        &[b"history3", pool.as_ref(), &old_batch_id.to_le_bytes()],
+        &pfda3_id(),
+    );
+    let rent = 1_000_000u64;
+    svm.set_account(
+        history,
+        Account {
+            lamports: rent,
+            data: build_cleared_batch_history_3(&pool, old_batch_id, 30, hbump),
+            owner: pfda3_id(),
+            executable: false,
+            rent_epoch: 0,
+        },
+    )
+    .unwrap();
+
+    let before = svm.get_balance(&payer.pubkey()).unwrap_or_else(|| {
+        panic!("payer has no balance entry; airdrop may have failed")
+    });
+    send(
+        &mut svm,
+        pfda3_close_batch_history_ix(pfda3_id(), payer.pubkey(), pool, history),
+        &payer,
+    )
+    .expect("CloseBatchHistory should succeed after delay");
+
+    // History account drained, payer credited (net of tx fee).
+    // After close the runtime may GC the zero-lamport account entirely
+    // instead of leaving a 0-balance stub — accept either.
+    assert_eq!(
+        svm.get_balance(&history).unwrap_or(0),
+        0,
+        "history lamports should be zero after close"
+    );
+    let after = svm.get_balance(&payer.pubkey()).unwrap_or(0);
+    assert!(
+        after > before,
+        "rent_recipient should gain lamports ({} -> {})",
+        before,
+        after
+    );
+}
+
+#[test]
+fn close_batch_history_rejects_before_delay() {
+    require_fixture!(PFDA_AMM_3_SO);
+    // current_batch_id = 50 → only 50 batches elapsed vs the 100-batch
+    // CLOSE_DELAY. Should reject.
+    let Seed { mut svm, payer, pool } = match seed_pool(/*current_batch_id=*/ 50) {
+        Some(s) => s,
+        None => return,
+    };
+
+    let old_batch_id: u64 = 0;
+    let (history, hbump) = Address::find_program_address(
+        &[b"history3", pool.as_ref(), &old_batch_id.to_le_bytes()],
+        &pfda3_id(),
+    );
+    svm.set_account(
+        history,
+        Account {
+            lamports: 1_000_000,
+            data: build_cleared_batch_history_3(&pool, old_batch_id, 30, hbump),
+            owner: pfda3_id(),
+            executable: false,
+            rent_epoch: 0,
+        },
+    )
+    .unwrap();
+
+    let err = send(
+        &mut svm,
+        pfda3_close_batch_history_ix(pfda3_id(), payer.pubkey(), pool, history),
+        &payer,
+    )
+    .err()
+    .expect("CloseBatchHistory should reject pre-delay");
+    // Pfda3Error::BatchWindowNotEnded = 8002 (0x1f42)
+    assert!(
+        err.contains("0x1f42") || err.contains("Custom(8002)") || err.contains("BatchWindowNotEnded"),
+        "expected BatchWindowNotEnded, got: {err}"
+    );
+}
+
+#[test]
+fn close_expired_ticket_success_after_delay() {
+    require_fixture!(PFDA_AMM_3_SO);
+    // 250 batches elapsed > 200-batch expiry.
+    let Seed { mut svm, payer, pool } = match seed_pool(/*current_batch_id=*/ 250) {
+        Some(s) => s,
+        None => return,
+    };
+
+    let ticket_batch_id: u64 = 0;
+    let ticket_owner = payer.pubkey();
+    let (ticket, tbump) = Address::find_program_address(
+        &[
+            b"ticket3",
+            pool.as_ref(),
+            ticket_owner.as_ref(),
+            &ticket_batch_id.to_le_bytes(),
+        ],
+        &pfda3_id(),
+    );
+    let rent = 1_500_000u64;
+    svm.set_account(
+        ticket,
+        Account {
+            lamports: rent,
+            data: build_user_order_ticket_3(&ticket_owner, &pool, ticket_batch_id, tbump),
+            owner: pfda3_id(),
+            executable: false,
+            rent_epoch: 0,
+        },
+    )
+    .unwrap();
+
+    let before = svm.get_balance(&ticket_owner).unwrap_or_else(|| {
+        panic!("ticket owner has no balance entry; airdrop may have failed")
+    });
+    send(
+        &mut svm,
+        pfda3_close_expired_ticket_ix(pfda3_id(), payer.pubkey(), pool, ticket, ticket_owner),
+        &payer,
+    )
+    .expect("CloseExpiredTicket should succeed after delay");
+
+    assert_eq!(
+        svm.get_balance(&ticket).unwrap_or(0),
+        0,
+        "ticket lamports should be zero after close"
+    );
+    let after = svm.get_balance(&ticket_owner).unwrap_or(0);
+    assert!(
+        after > before,
+        "ticket owner should gain lamports ({} -> {})",
+        before,
+        after
+    );
+}
+
+#[test]
+fn close_expired_ticket_rejects_before_delay() {
+    require_fixture!(PFDA_AMM_3_SO);
+    // 100 batches elapsed < 200-batch expiry.
+    let Seed { mut svm, payer, pool } = match seed_pool(/*current_batch_id=*/ 100) {
+        Some(s) => s,
+        None => return,
+    };
+
+    let ticket_batch_id: u64 = 0;
+    let ticket_owner = payer.pubkey();
+    let (ticket, tbump) = Address::find_program_address(
+        &[
+            b"ticket3",
+            pool.as_ref(),
+            ticket_owner.as_ref(),
+            &ticket_batch_id.to_le_bytes(),
+        ],
+        &pfda3_id(),
+    );
+    svm.set_account(
+        ticket,
+        Account {
+            lamports: 1_500_000,
+            data: build_user_order_ticket_3(&ticket_owner, &pool, ticket_batch_id, tbump),
+            owner: pfda3_id(),
+            executable: false,
+            rent_epoch: 0,
+        },
+    )
+    .unwrap();
+
+    let err = send(
+        &mut svm,
+        pfda3_close_expired_ticket_ix(pfda3_id(), payer.pubkey(), pool, ticket, ticket_owner),
+        &payer,
+    )
+    .err()
+    .expect("CloseExpiredTicket should reject pre-delay");
+    assert!(
+        err.contains("0x1f42") || err.contains("Custom(8002)") || err.contains("BatchWindowNotEnded"),
+        "expected BatchWindowNotEnded, got: {err}"
+    );
+}

--- a/contracts/ab-integration-tests/tests/pfda3_claim_coverage.rs
+++ b/contracts/ab-integration-tests/tests/pfda3_claim_coverage.rs
@@ -1,0 +1,347 @@
+//! pfda-amm-3 Claim coverage (issue #33).
+//!
+//! Two rejection rows kidney flagged that weren't reached by earlier PRs:
+//!   - Claim slippage exceeded → SlippageExceeded (8006)
+//!   - Claim zero-volume token → silent success, ticket marked claimed
+//!
+//! The zero-volume case is "success" at the protocol level — the Claim
+//! instruction short-circuits when `total_in[in_i] == 0` and marks the
+//! ticket claimed without transferring. That's still a rejection row
+//! worth pinning: any future change to that branch (e.g. rejecting
+//! instead of refunding) would be caught.
+//!
+//! Pre-seeds PoolState3 + ClearedBatchHistory3 + UserOrderTicket3 via
+//! set_account so we can stage post-clearing state directly, rather
+//! than driving a full SwapRequest → ClearBatch → Claim flow (each step
+//! has its own rejection branches already covered elsewhere).
+
+use ab_integration_tests::helpers::{account_builder::*, svm_setup::*, token_factory::*};
+use ab_integration_tests::require_fixture;
+use litesvm::LiteSVM;
+use solana_account::Account;
+use solana_address::Address;
+use solana_instruction::{account_meta::AccountMeta, Instruction};
+use solana_keypair::Keypair;
+use solana_native_token::LAMPORTS_PER_SOL;
+use solana_signer::Signer;
+use solana_transaction::Transaction;
+
+const ERR_SLIPPAGE_EXCEEDED: u32 = 8006;
+const Q32_32_ONE: u64 = 1u64 << 32;
+
+// ─── History + ticket builders (richer than close_delay's stubs) ────────
+// Offsets verified via offset_of! probe on the real structs.
+
+#[allow(clippy::too_many_arguments)]
+fn build_cleared_batch_history_full(
+    pool: &Address,
+    batch_id: u64,
+    clearing_prices: [u64; 3],
+    total_out: [u64; 3],
+    total_in: [u64; 3],
+    fee_bps: u16,
+    bump: u8,
+) -> Vec<u8> {
+    let mut d = vec![0u8; 128];
+    d[0..8].copy_from_slice(b"clrd3h\0\0");
+    d[8..40].copy_from_slice(pool.as_ref());
+    d[40..48].copy_from_slice(&batch_id.to_le_bytes());
+    for i in 0..3 {
+        d[48 + i * 8..48 + (i + 1) * 8].copy_from_slice(&clearing_prices[i].to_le_bytes());
+        d[72 + i * 8..72 + (i + 1) * 8].copy_from_slice(&total_out[i].to_le_bytes());
+        d[96 + i * 8..96 + (i + 1) * 8].copy_from_slice(&total_in[i].to_le_bytes());
+    }
+    d[120..122].copy_from_slice(&fee_bps.to_le_bytes());
+    d[122] = 1; // is_cleared
+    d[123] = bump;
+    d
+}
+
+#[allow(clippy::too_many_arguments)]
+fn build_user_order_ticket_full(
+    owner: &Address,
+    pool: &Address,
+    batch_id: u64,
+    amounts_in: [u64; 3],
+    out_token_idx: u8,
+    min_amount_out: u64,
+    bump: u8,
+) -> Vec<u8> {
+    let mut d = vec![0u8; 128];
+    d[0..8].copy_from_slice(b"usrord3\0");
+    d[8..40].copy_from_slice(owner.as_ref());
+    d[40..72].copy_from_slice(pool.as_ref());
+    d[72..80].copy_from_slice(&batch_id.to_le_bytes());
+    for i in 0..3 {
+        d[80 + i * 8..80 + (i + 1) * 8].copy_from_slice(&amounts_in[i].to_le_bytes());
+    }
+    d[104] = out_token_idx;
+    d[112..120].copy_from_slice(&min_amount_out.to_le_bytes());
+    d[120] = 0; // is_claimed
+    d[121] = bump;
+    d
+}
+
+// ─── Instruction + tx helpers ───────────────────────────────────────────
+
+#[allow(clippy::too_many_arguments)]
+fn pfda3_claim_ix(
+    program: Address,
+    user: Address,
+    pool: Address,
+    history: Address,
+    ticket: Address,
+    vaults: &[Address; 3],
+    user_tokens: &[Address; 3],
+) -> Instruction {
+    Instruction {
+        program_id: program,
+        accounts: vec![
+            AccountMeta::new_readonly(user, true),
+            AccountMeta::new(pool, false),
+            AccountMeta::new_readonly(history, false),
+            AccountMeta::new(ticket, false),
+            AccountMeta::new(vaults[0], false),
+            AccountMeta::new(vaults[1], false),
+            AccountMeta::new(vaults[2], false),
+            AccountMeta::new(user_tokens[0], false),
+            AccountMeta::new(user_tokens[1], false),
+            AccountMeta::new(user_tokens[2], false),
+            AccountMeta::new_readonly(token_program_id(), false),
+        ],
+        data: vec![3u8],
+    }
+}
+
+fn send(svm: &mut LiteSVM, ix: Instruction, payer: &Keypair) -> Result<u64, String> {
+    let tx = Transaction::new_signed_with_payer(
+        &[ix],
+        Some(&payer.pubkey()),
+        &[payer],
+        svm.latest_blockhash(),
+    );
+    match svm.send_transaction(tx) {
+        Ok(meta) => Ok(meta.compute_units_consumed),
+        Err(e) => {
+            let mut msg = format!("{:?}", e.err);
+            for log in &e.meta.logs {
+                msg.push_str(&format!("\n  {}", log));
+            }
+            Err(msg)
+        }
+    }
+}
+
+fn assert_custom_err(err: &str, code: u32, label: &str) {
+    let hex = format!("0x{:x}", code);
+    let custom = format!("Custom({})", code);
+    assert!(
+        err.contains(&hex) || err.contains(&custom),
+        "{label}: expected {code} ({hex}), got: {err}"
+    );
+}
+
+// ─── Fixture ────────────────────────────────────────────────────────────
+
+struct Fixture {
+    svm: LiteSVM,
+    payer: Keypair,
+    pool: Address,
+    vaults: [Address; 3],
+    user_tokens: [Address; 3],
+    mints: [[u8; 32]; 3],
+}
+
+fn seed() -> Option<Fixture> {
+    let mut svm = LiteSVM::new();
+    if !std::path::Path::new(PFDA_AMM_3_SO).exists() {
+        eprintln!("SKIP: pfda_amm_3.so fixture missing");
+        return None;
+    }
+    svm.add_program_from_file(pfda3_id(), PFDA_AMM_3_SO).ok()?;
+
+    let payer = Keypair::new();
+    svm.airdrop(&payer.pubkey(), 100 * LAMPORTS_PER_SOL).unwrap();
+
+    let mints = [Address::new_unique(), Address::new_unique(), Address::new_unique()];
+    for &m in &mints { create_mint(&mut svm, m, &payer.pubkey(), 6); }
+
+    let (pool, bump) = Address::find_program_address(
+        &[b"pool3", mints[0].as_ref(), mints[1].as_ref(), mints[2].as_ref()],
+        &pfda3_id(),
+    );
+
+    let vaults = [Address::new_unique(), Address::new_unique(), Address::new_unique()];
+    let user_tokens = [Address::new_unique(), Address::new_unique(), Address::new_unique()];
+    for i in 0..3 {
+        create_token_account(&mut svm, vaults[i], &mints[i], &pool, 10_000_000);
+        create_token_account(&mut svm, user_tokens[i], &mints[i], &payer.pubkey(), 1_000_000_000);
+    }
+
+    let treasury = Address::new_unique();
+    let pd = build_pfda3_pool_state(
+        &mints,
+        &vaults,
+        &[10_000_000; 3],
+        &[333_333, 333_333, 333_334],
+        10, 1, 100, // window_slots, current_batch_id=1 (so history for batch 0 is cleared), current_window_end
+        &treasury, &payer.pubkey(), 30, bump,
+    );
+    svm.set_account(
+        pool,
+        Account { lamports: LAMPORTS_PER_SOL, data: pd, owner: pfda3_id(), executable: false, rent_epoch: 0 },
+    ).unwrap();
+
+    let mint_arrays: [[u8; 32]; 3] = [
+        mints[0].as_ref().try_into().unwrap(),
+        mints[1].as_ref().try_into().unwrap(),
+        mints[2].as_ref().try_into().unwrap(),
+    ];
+
+    Some(Fixture { svm, payer, pool, vaults, user_tokens, mints: mint_arrays })
+}
+
+fn seed_history(
+    svm: &mut LiteSVM,
+    pool: Address,
+    batch_id: u64,
+    clearing_prices: [u64; 3],
+    total_out: [u64; 3],
+    total_in: [u64; 3],
+) -> Address {
+    let (hist, bump) = Address::find_program_address(
+        &[b"history3", pool.as_ref(), &batch_id.to_le_bytes()],
+        &pfda3_id(),
+    );
+    let data = build_cleared_batch_history_full(
+        &pool, batch_id, clearing_prices, total_out, total_in, 30, bump,
+    );
+    svm.set_account(
+        hist,
+        Account { lamports: 1_500_000, data, owner: pfda3_id(), executable: false, rent_epoch: 0 },
+    ).unwrap();
+    hist
+}
+
+#[allow(clippy::too_many_arguments)]
+fn seed_ticket(
+    svm: &mut LiteSVM,
+    pool: Address,
+    owner: Address,
+    batch_id: u64,
+    amounts_in: [u64; 3],
+    out_token_idx: u8,
+    min_amount_out: u64,
+) -> Address {
+    let (ticket, bump) = Address::find_program_address(
+        &[b"ticket3", pool.as_ref(), owner.as_ref(), &batch_id.to_le_bytes()],
+        &pfda3_id(),
+    );
+    let data = build_user_order_ticket_full(
+        &owner, &pool, batch_id, amounts_in, out_token_idx, min_amount_out, bump,
+    );
+    svm.set_account(
+        ticket,
+        Account { lamports: 2_000_000, data, owner: pfda3_id(), executable: false, rent_epoch: 0 },
+    ).unwrap();
+    ticket
+}
+
+// ─── Tests ──────────────────────────────────────────────────────────────
+
+#[test]
+fn claim_rejects_slippage_exceeded() {
+    require_fixture!(PFDA_AMM_3_SO);
+    let Fixture { mut svm, payer, pool, vaults, user_tokens, .. } =
+        match seed() { Some(f) => f, None => return };
+
+    // Equal clearing prices (Q32.32 = 1.0) and nonzero volume on both legs
+    // so Claim actually runs the payout math. amount_out will be roughly
+    // amount_in * (1 - fee) = 100_000 * 0.997 = 99_700. min_amount_out = 1M
+    // forces SlippageExceeded.
+    let hist = seed_history(
+        &mut svm, pool, 0,
+        [Q32_32_ONE, Q32_32_ONE, Q32_32_ONE],
+        [0, 100_000, 0],
+        [100_000, 100_000, 0],
+    );
+    let ticket = seed_ticket(
+        &mut svm, pool, payer.pubkey(), 0,
+        [100_000, 0, 0], // user deposited token 0
+        1,               // wants token 1 out
+        1_000_000_000,   // absurd min_out → slippage
+    );
+
+    let err = send(
+        &mut svm,
+        pfda3_claim_ix(pfda3_id(), payer.pubkey(), pool, hist, ticket, &vaults, &user_tokens),
+        &payer,
+    )
+    .err()
+    .expect("claim with unsatisfiable min_out should reject");
+    assert_custom_err(&err, ERR_SLIPPAGE_EXCEEDED, "claim slippage");
+}
+
+#[test]
+fn claim_zero_volume_token_marks_claimed_without_payout() {
+    require_fixture!(PFDA_AMM_3_SO);
+    let Fixture { mut svm, payer, pool, vaults, user_tokens, mints } =
+        match seed() { Some(f) => f, None => return };
+
+    // Batch cleared but token 2 had zero volume in: total_in[2] == 0.
+    // Claim should short-circuit on that branch, mark claimed, pay
+    // nothing out.
+    let hist = seed_history(
+        &mut svm, pool, 0,
+        [Q32_32_ONE, Q32_32_ONE, Q32_32_ONE],
+        [0, 0, 0],
+        [0, 0, 0], // total_in[2] = 0 → short-circuit
+    );
+    let ticket_addr = seed_ticket(
+        &mut svm, pool, payer.pubkey(), 0,
+        [0, 0, 100_000], // user says they deposited token 2 (in_idx=2)
+        0,               // wants token 0 out
+        0,
+    );
+
+    let user_vault_before = [
+        token_balance(&svm, &user_tokens[0]),
+        token_balance(&svm, &user_tokens[1]),
+        token_balance(&svm, &user_tokens[2]),
+    ];
+
+    send(
+        &mut svm,
+        pfda3_claim_ix(pfda3_id(), payer.pubkey(), pool, hist, ticket_addr, &vaults, &user_tokens),
+        &payer,
+    )
+    .expect("zero-volume claim should succeed");
+
+    // No token movements — the short-circuit path doesn't touch vaults.
+    for i in 0..3 {
+        assert_eq!(
+            token_balance(&svm, &user_tokens[i]),
+            user_vault_before[i],
+            "user_token[{i}] must not move on zero-volume claim"
+        );
+    }
+
+    // Ticket must be marked claimed so a second Claim would be
+    // TicketAlreadyClaimed (not worth asserting here — behavior is
+    // already covered by ab_comparison; we only need to confirm the
+    // zero-volume branch *doesn't* revert).
+    let ticket_after = svm.get_account(&ticket_addr).unwrap();
+    assert_eq!(
+        ticket_after.data[120], 1,
+        "ticket is_claimed must flip to 1 on zero-volume Claim"
+    );
+
+    // Silence unused warning from the `mints` field (only needed by the
+    // seed fixture for layout consistency).
+    let _ = mints;
+}
+
+fn token_balance(svm: &LiteSVM, addr: &Address) -> u64 {
+    let acc = svm.get_account(addr).expect("token account");
+    u64::from_le_bytes(acc.data[64..72].try_into().unwrap())
+}

--- a/contracts/ab-integration-tests/tests/pfda_amm_coverage.rs
+++ b/contracts/ab-integration-tests/tests/pfda_amm_coverage.rs
@@ -554,3 +554,429 @@ fn read_token_amount(svm: &LiteSVM, addr: &Address) -> u64 {
     let acc = svm.get_account(addr).expect("token account");
     u64::from_le_bytes(acc.data[64..72].try_into().unwrap())
 }
+
+// ─── Additional scenario rows from kidney's #33 table ──────────────────
+
+const ERR_INVALID_WEIGHT: u32 = 6009;
+const ERR_INVALID_WINDOW_SLOTS: u32 = 6014;
+const ERR_ALREADY_INITIALIZED: u32 = 6015;
+const ERR_UNAUTHORIZED: u32 = 6016;
+const ERR_INVALID_FEE_BPS: u32 = 6019;
+const ERR_SLIPPAGE_EXCEEDED: u32 = 6006;
+const ERR_TICKET_ALREADY_CLAIMED: u32 = 6004;
+
+// pfda_amm SwapRequest wrong vault — companion to the AddLiquidity
+// wrong-vault test. Kidney called out both instructions in the same row.
+#[test]
+fn pfda_swap_request_rejects_wrong_vault() {
+    require_fixture!(PFDA_AMM_SO);
+    let Fixture {
+        mut svm, payer, pool, mint_a, mint_b: _, vault_a: _, vault_b,
+        user_tok_a, user_tok_b,
+    } = match seed(0, false) { Some(f) => f, None => return };
+
+    let rogue = Address::new_unique();
+    create_token_account(&mut svm, rogue, &mint_a, &pool, 0);
+
+    let queue = seed_queue(&mut svm, pool, 0, 100);
+    let (ticket, _) = Address::find_program_address(
+        &[b"ticket", pool.as_ref(), payer.pubkey().as_ref(), &0u64.to_le_bytes()],
+        &pfda_amm_id(),
+    );
+
+    let err = send(
+        &mut svm,
+        pfda_swap_request_ix(
+            pfda_amm_id(), payer.pubkey(), pool, queue, ticket,
+            user_tok_a, user_tok_b, rogue, vault_b,
+            1000, 0,
+        ),
+        &payer,
+    )
+    .err()
+    .expect("wrong-vault SwapRequest should reject");
+    assert_custom_err(&err, 6020 /* VaultMismatch */, "swap_request wrong vault");
+}
+
+// ─── UpdateWeight ─────────────────────────────────────────────────────
+
+fn pfda_update_weight_ix(
+    program: Address,
+    authority: Address,
+    pool: Address,
+    target_weight_a: u32,
+    weight_end_slot: u64,
+) -> Instruction {
+    let mut data = vec![5u8]; // UpdateWeight
+    data.extend_from_slice(&target_weight_a.to_le_bytes());
+    data.extend_from_slice(&weight_end_slot.to_le_bytes());
+    Instruction {
+        program_id: program,
+        accounts: vec![
+            AccountMeta::new_readonly(authority, true),
+            AccountMeta::new(pool, false),
+        ],
+        data,
+    }
+}
+
+#[test]
+fn pfda_update_weight_rejects_out_of_range() {
+    require_fixture!(PFDA_AMM_SO);
+    // target_weight_a > 1_000_000 is the #5-fixed upper bound.
+    let Fixture { mut svm, payer, pool, .. } =
+        match seed(0, false) { Some(f) => f, None => return };
+
+    let err = send(
+        &mut svm,
+        pfda_update_weight_ix(pfda_amm_id(), payer.pubkey(), pool, 1_000_001, 1_000_000),
+        &payer,
+    )
+    .err()
+    .expect("out-of-range target_weight should reject");
+    assert_custom_err(&err, ERR_INVALID_WEIGHT, "weight out of range");
+}
+
+#[test]
+fn pfda_update_weight_rejects_past_end_slot() {
+    require_fixture!(PFDA_AMM_SO);
+    // weight_end_slot <= current_slot → InvalidWindowSlots.
+    // LiteSVM's initial clock slot is 0 unless warped, so end_slot = 0
+    // triggers the `<=` branch.
+    let Fixture { mut svm, payer, pool, .. } =
+        match seed(0, false) { Some(f) => f, None => return };
+
+    let err = send(
+        &mut svm,
+        pfda_update_weight_ix(pfda_amm_id(), payer.pubkey(), pool, 500_000, 0),
+        &payer,
+    )
+    .err()
+    .expect("past end_slot should reject");
+    assert_custom_err(&err, ERR_INVALID_WINDOW_SLOTS, "past end slot");
+}
+
+#[test]
+fn pfda_update_weight_rejects_wrong_authority() {
+    require_fixture!(PFDA_AMM_SO);
+    // pool.authority = payer; intruder is a different signer.
+    let Fixture { mut svm, pool, .. } =
+        match seed(0, false) { Some(f) => f, None => return };
+
+    let intruder = Keypair::new();
+    svm.airdrop(&intruder.pubkey(), LAMPORTS_PER_SOL).unwrap();
+
+    let err = send(
+        &mut svm,
+        pfda_update_weight_ix(pfda_amm_id(), intruder.pubkey(), pool, 500_000, 1_000_000),
+        &intruder,
+    )
+    .err()
+    .expect("wrong-authority UpdateWeight should reject");
+    assert_custom_err(&err, ERR_UNAUTHORIZED, "wrong authority");
+}
+
+// ─── InitializePool validation-only rejections ─────────────────────────
+// We only exercise the pre-account-setup branches — base_fee_bps >= 10_000
+// fires at ix-data validation, before any CreateAccount, so an empty
+// accounts fixture is enough.
+
+fn pfda_init_ix_empty_accounts(
+    payer: &Keypair,
+    program: Address,
+    base_fee_bps: u16,
+    window_slots: u64,
+    weight_a: u32,
+) -> Instruction {
+    let mut data = vec![0u8]; // InitializePool
+    data.extend_from_slice(&base_fee_bps.to_le_bytes());
+    data.extend_from_slice(&0u16.to_le_bytes()); // fee_discount_bps
+    data.extend_from_slice(&window_slots.to_le_bytes());
+    data.extend_from_slice(&weight_a.to_le_bytes());
+
+    // Nine accounts, mostly fresh System-owned — the rejection fires
+    // before anything is read.
+    let accts = [
+        AccountMeta::new(payer.pubkey(), true),
+        AccountMeta::new(Address::new_unique(), false),
+        AccountMeta::new(Address::new_unique(), false),
+        AccountMeta::new_readonly(Address::new_unique(), false),
+        AccountMeta::new_readonly(Address::new_unique(), false),
+        AccountMeta::new(Address::new_unique(), false),
+        AccountMeta::new(Address::new_unique(), false),
+        AccountMeta::new_readonly(system_program_id(), false),
+        AccountMeta::new_readonly(token_program_id(), false),
+    ];
+    Instruction { program_id: program, accounts: accts.to_vec(), data }
+}
+
+#[test]
+fn pfda_init_rejects_fee_100_percent() {
+    require_fixture!(PFDA_AMM_SO);
+    let mut svm = LiteSVM::new();
+    if !std::path::Path::new(PFDA_AMM_SO).exists() { return; }
+    svm.add_program_from_file(pfda_amm_id(), PFDA_AMM_SO).unwrap();
+    let payer = Keypair::new();
+    svm.airdrop(&payer.pubkey(), LAMPORTS_PER_SOL).unwrap();
+
+    let err = send(
+        &mut svm,
+        pfda_init_ix_empty_accounts(&payer, pfda_amm_id(), 10_000, 10, 500_000),
+        &payer,
+    )
+    .err()
+    .expect("base_fee_bps=10_000 should reject");
+    assert_custom_err(&err, ERR_INVALID_FEE_BPS, "fee=100%");
+}
+
+#[test]
+fn pfda_init_rejects_duplicate() {
+    require_fixture!(PFDA_AMM_SO);
+    // Pre-seed the pool PDA with a valid discriminator so the
+    // "already initialized" branch fires. We don't need real accounts
+    // elsewhere — the check happens right after PDA derivation.
+    let Fixture { mut svm, payer, pool, mint_a, mint_b, .. } =
+        match seed(0, false) { Some(f) => f, None => return };
+
+    // Drive init against the already-seeded pool.
+    let mut data = vec![0u8];
+    data.extend_from_slice(&30u16.to_le_bytes());
+    data.extend_from_slice(&0u16.to_le_bytes());
+    data.extend_from_slice(&10u64.to_le_bytes());
+    data.extend_from_slice(&500_000u32.to_le_bytes());
+
+    let batch_queue = Address::new_unique();
+    let vault_a = Address::new_unique();
+    let vault_b = Address::new_unique();
+
+    let err = send(
+        &mut svm,
+        Instruction {
+            program_id: pfda_amm_id(),
+            accounts: vec![
+                AccountMeta::new(payer.pubkey(), true),
+                AccountMeta::new(pool, false),
+                AccountMeta::new(batch_queue, false),
+                AccountMeta::new_readonly(mint_a, false),
+                AccountMeta::new_readonly(mint_b, false),
+                AccountMeta::new(vault_a, false),
+                AccountMeta::new(vault_b, false),
+                AccountMeta::new_readonly(system_program_id(), false),
+                AccountMeta::new_readonly(token_program_id(), false),
+            ],
+            data,
+        },
+        &payer,
+    )
+    .err()
+    .expect("duplicate init should reject");
+    assert_custom_err(&err, ERR_ALREADY_INITIALIZED, "duplicate init");
+}
+
+// ─── Claim double-claim + slippage ─────────────────────────────────────
+// Fabricate a cleared history + ticket, call Claim once (succeeds with
+// slippage or pays out), then call again (TicketAlreadyClaimed).
+
+const Q32_32_ONE: u64 = 1u64 << 32;
+
+fn build_pfda_cleared_batch_history_full(
+    pool: &Address,
+    batch_id: u64,
+    clearing_price: u64,
+    out_b_per_in_a: u64,
+    out_a_per_in_b: u64,
+    bump: u8,
+) -> Vec<u8> {
+    // ClearedBatchHistory (80 bytes):
+    //  0: disc "clrdhist"
+    //  8: pool (32)
+    // 40: batch_id u64
+    // 48: clearing_price u64
+    // 56: out_b_per_in_a u64
+    // 64: out_a_per_in_b u64
+    // 72: is_cleared u8
+    // 73: bump u8
+    // 74: padding [u8;6]
+    let mut d = vec![0u8; 80];
+    d[0..8].copy_from_slice(b"clrdhist");
+    d[8..40].copy_from_slice(pool.as_ref());
+    d[40..48].copy_from_slice(&batch_id.to_le_bytes());
+    d[48..56].copy_from_slice(&clearing_price.to_le_bytes());
+    d[56..64].copy_from_slice(&out_b_per_in_a.to_le_bytes());
+    d[64..72].copy_from_slice(&out_a_per_in_b.to_le_bytes());
+    d[72] = 1;
+    d[73] = bump;
+    d
+}
+
+#[allow(clippy::too_many_arguments)]
+fn build_pfda_user_order_ticket_full(
+    owner: &Address,
+    pool: &Address,
+    batch_id: u64,
+    amount_in_a: u64,
+    amount_in_b: u64,
+    min_amount_out: u64,
+    bump: u8,
+) -> Vec<u8> {
+    // UserOrderTicket (112 bytes):
+    //  0: disc "usrorder"
+    //  8: owner (32)
+    // 40: pool (32)
+    // 72: batch_id u64
+    // 80: amount_in_a u64
+    // 88: amount_in_b u64
+    // 96: min_amount_out u64
+    // 104: is_claimed u8
+    // 105: bump u8
+    // 106: padding [u8;6]
+    let mut d = vec![0u8; 112];
+    d[0..8].copy_from_slice(b"usrorder");
+    d[8..40].copy_from_slice(owner.as_ref());
+    d[40..72].copy_from_slice(pool.as_ref());
+    d[72..80].copy_from_slice(&batch_id.to_le_bytes());
+    d[80..88].copy_from_slice(&amount_in_a.to_le_bytes());
+    d[88..96].copy_from_slice(&amount_in_b.to_le_bytes());
+    d[96..104].copy_from_slice(&min_amount_out.to_le_bytes());
+    d[104] = 0; // is_claimed false
+    d[105] = bump;
+    d
+}
+
+#[allow(clippy::too_many_arguments)]
+fn pfda_claim_ix(
+    program: Address,
+    user: Address,
+    pool: Address,
+    history: Address,
+    ticket: Address,
+    vault_a: Address,
+    vault_b: Address,
+    user_tok_a: Address,
+    user_tok_b: Address,
+) -> Instruction {
+    Instruction {
+        program_id: program,
+        accounts: vec![
+            AccountMeta::new_readonly(user, true),
+            AccountMeta::new_readonly(pool, false),
+            AccountMeta::new_readonly(history, false),
+            AccountMeta::new(ticket, false),
+            AccountMeta::new(vault_a, false),
+            AccountMeta::new(vault_b, false),
+            AccountMeta::new(user_tok_a, false),
+            AccountMeta::new(user_tok_b, false),
+            AccountMeta::new_readonly(token_program_id(), false),
+        ],
+        data: vec![3u8], // Claim
+    }
+}
+
+#[test]
+fn pfda_claim_rejects_slippage_exceeded() {
+    require_fixture!(PFDA_AMM_SO);
+    let Fixture { mut svm, payer, pool, vault_a, vault_b, user_tok_a, user_tok_b, .. } =
+        match seed(1, false) { Some(f) => f, None => return };
+
+    // Seed history at batch_id=0 with 1:1 rate (Q32.32 1.0). Ticket
+    // deposited 100 token A, wants ≥ 1_000_000 token B out — impossible.
+    let (hist, hbump) = Address::find_program_address(
+        &[b"history", pool.as_ref(), &0u64.to_le_bytes()],
+        &pfda_amm_id(),
+    );
+    svm.set_account(
+        hist,
+        Account {
+            lamports: 1_500_000,
+            data: build_pfda_cleared_batch_history_full(&pool, 0, Q32_32_ONE, Q32_32_ONE, Q32_32_ONE, hbump),
+            owner: pfda_amm_id(),
+            executable: false,
+            rent_epoch: 0,
+        },
+    ).unwrap();
+
+    let (ticket, tbump) = Address::find_program_address(
+        &[b"ticket", pool.as_ref(), payer.pubkey().as_ref(), &0u64.to_le_bytes()],
+        &pfda_amm_id(),
+    );
+    svm.set_account(
+        ticket,
+        Account {
+            lamports: 2_000_000,
+            data: build_pfda_user_order_ticket_full(&payer.pubkey(), &pool, 0, 100, 0, 1_000_000, tbump),
+            owner: pfda_amm_id(),
+            executable: false,
+            rent_epoch: 0,
+        },
+    ).unwrap();
+
+    // Under the slippage branch, Claim refunds the input token and
+    // returns SlippageExceeded — but the input is returned from the
+    // vault via CPI, which requires enough vault balance. Vault is
+    // seeded with 1_000_000 so the 100-token refund fits.
+    let err = send(
+        &mut svm,
+        pfda_claim_ix(pfda_amm_id(), payer.pubkey(), pool, hist, ticket,
+            vault_a, vault_b, user_tok_a, user_tok_b),
+        &payer,
+    )
+    .err()
+    .expect("slippage-violating Claim should reject");
+    assert_custom_err(&err, ERR_SLIPPAGE_EXCEEDED, "claim slippage");
+}
+
+#[test]
+fn pfda_claim_rejects_double_claim() {
+    require_fixture!(PFDA_AMM_SO);
+    let Fixture { mut svm, payer, pool, vault_a, vault_b, user_tok_a, user_tok_b, .. } =
+        match seed(1, false) { Some(f) => f, None => return };
+
+    let (hist, hbump) = Address::find_program_address(
+        &[b"history", pool.as_ref(), &0u64.to_le_bytes()],
+        &pfda_amm_id(),
+    );
+    svm.set_account(
+        hist,
+        Account {
+            lamports: 1_500_000,
+            data: build_pfda_cleared_batch_history_full(&pool, 0, Q32_32_ONE, Q32_32_ONE, Q32_32_ONE, hbump),
+            owner: pfda_amm_id(),
+            executable: false,
+            rent_epoch: 0,
+        },
+    ).unwrap();
+
+    let (ticket, tbump) = Address::find_program_address(
+        &[b"ticket", pool.as_ref(), payer.pubkey().as_ref(), &0u64.to_le_bytes()],
+        &pfda_amm_id(),
+    );
+    // Pre-mark ticket as claimed so Claim immediately returns
+    // TicketAlreadyClaimed. This is a shortcut — the real scenario
+    // would Claim once then Claim again, but both hit the same check
+    // at the top of the handler.
+    let mut data = build_pfda_user_order_ticket_full(
+        &payer.pubkey(), &pool, 0, 100, 0, 0, tbump,
+    );
+    data[104] = 1; // is_claimed = true
+
+    svm.set_account(
+        ticket,
+        Account {
+            lamports: 2_000_000,
+            data,
+            owner: pfda_amm_id(),
+            executable: false,
+            rent_epoch: 0,
+        },
+    ).unwrap();
+
+    let err = send(
+        &mut svm,
+        pfda_claim_ix(pfda_amm_id(), payer.pubkey(), pool, hist, ticket,
+            vault_a, vault_b, user_tok_a, user_tok_b),
+        &payer,
+    )
+    .err()
+    .expect("already-claimed ticket should reject");
+    assert_custom_err(&err, ERR_TICKET_ALREADY_CLAIMED, "double claim");
+}

--- a/contracts/ab-integration-tests/tests/pfda_amm_coverage.rs
+++ b/contracts/ab-integration-tests/tests/pfda_amm_coverage.rs
@@ -1,0 +1,556 @@
+//! pfda-amm (2-token legacy) regression coverage (issue #33).
+//!
+//! Counterpart to `close_delay.rs` and `scenario_coverage.rs`, which cover
+//! pfda-amm-3. This file hits the same rejection-path rows from kidney's
+//! #33 table, but against the legacy 2-token program.
+//!
+//! Covered:
+//!   - CloseBatchHistory success after 100-batch delay
+//!   - CloseBatchHistory rejection before delay
+//!   - CloseExpiredTicket success after 200-batch delay
+//!   - CloseExpiredTicket rejection before delay
+//!   - AddLiquidity on paused pool → PoolPaused
+//!   - AddLiquidity with wrong vault → VaultMismatch
+//!   - SwapRequest duplicate call same batch is atomic (post PR#50 reorder)
+//!
+//! All tests fabricate canonical PDAs via set_account so we don't depend
+//! on driving a real ClearBatch / 200-batch timeline in the test.
+
+use ab_integration_tests::helpers::{account_builder::*, svm_setup::*, token_factory::*};
+use ab_integration_tests::require_fixture;
+use litesvm::LiteSVM;
+use solana_account::Account;
+use solana_address::Address;
+use solana_instruction::{account_meta::AccountMeta, Instruction};
+use solana_keypair::Keypair;
+use solana_native_token::LAMPORTS_PER_SOL;
+use solana_signer::Signer;
+use solana_transaction::Transaction;
+
+// PfmmError codes (mirror of contracts/pfda-amm/src/error.rs)
+const ERR_BATCH_WINDOW_NOT_ENDED: u32 = 6002;
+const ERR_POOL_PAUSED: u32 = 6018;
+const ERR_VAULT_MISMATCH: u32 = 6020;
+
+// ─── Instruction builders ───────────────────────────────────────────────
+
+fn pfda_close_batch_history_ix(
+    program: Address,
+    rent_recipient: Address,
+    pool: Address,
+    history: Address,
+) -> Instruction {
+    Instruction {
+        program_id: program,
+        accounts: vec![
+            AccountMeta::new(rent_recipient, true),
+            AccountMeta::new_readonly(pool, false),
+            AccountMeta::new(history, false),
+        ],
+        data: vec![7u8], // CloseBatchHistory
+    }
+}
+
+fn pfda_close_expired_ticket_ix(
+    program: Address,
+    caller: Address,
+    pool: Address,
+    ticket: Address,
+    rent_recipient: Address,
+) -> Instruction {
+    Instruction {
+        program_id: program,
+        accounts: vec![
+            AccountMeta::new(caller, true),
+            AccountMeta::new_readonly(pool, false),
+            AccountMeta::new(ticket, false),
+            AccountMeta::new(rent_recipient, false),
+        ],
+        data: vec![8u8], // CloseExpiredTicket
+    }
+}
+
+fn pfda_add_liquidity_ix(
+    program: Address,
+    user: Address,
+    pool: Address,
+    vault_a: Address,
+    vault_b: Address,
+    user_token_a: Address,
+    user_token_b: Address,
+    amount_a: u64,
+    amount_b: u64,
+) -> Instruction {
+    let mut data = vec![4u8]; // AddLiquidity
+    data.extend_from_slice(&amount_a.to_le_bytes());
+    data.extend_from_slice(&amount_b.to_le_bytes());
+    Instruction {
+        program_id: program,
+        accounts: vec![
+            AccountMeta::new(user, true),
+            AccountMeta::new(pool, false),
+            AccountMeta::new(vault_a, false),
+            AccountMeta::new(vault_b, false),
+            AccountMeta::new(user_token_a, false),
+            AccountMeta::new(user_token_b, false),
+            AccountMeta::new_readonly(token_program_id(), false),
+        ],
+        data,
+    }
+}
+
+fn pfda_swap_request_ix(
+    program: Address,
+    user: Address,
+    pool: Address,
+    queue: Address,
+    ticket: Address,
+    user_token_a: Address,
+    user_token_b: Address,
+    vault_a: Address,
+    vault_b: Address,
+    amount_in_a: u64,
+    amount_in_b: u64,
+) -> Instruction {
+    let mut data = vec![1u8]; // SwapRequest
+    data.extend_from_slice(&amount_in_a.to_le_bytes());
+    data.extend_from_slice(&amount_in_b.to_le_bytes());
+    data.extend_from_slice(&0u64.to_le_bytes()); // min_amount_out
+    Instruction {
+        program_id: program,
+        accounts: vec![
+            AccountMeta::new(user, true),
+            AccountMeta::new_readonly(pool, false),
+            AccountMeta::new(queue, false),
+            AccountMeta::new(ticket, false),
+            AccountMeta::new(user_token_a, false),
+            AccountMeta::new(user_token_b, false),
+            AccountMeta::new(vault_a, false),
+            AccountMeta::new(vault_b, false),
+            AccountMeta::new_readonly(token_program_id(), false),
+            AccountMeta::new_readonly(system_program_id(), false),
+        ],
+        data,
+    }
+}
+
+fn send(svm: &mut LiteSVM, ix: Instruction, payer: &Keypair) -> Result<u64, String> {
+    let tx = Transaction::new_signed_with_payer(
+        &[ix],
+        Some(&payer.pubkey()),
+        &[payer],
+        svm.latest_blockhash(),
+    );
+    match svm.send_transaction(tx) {
+        Ok(meta) => Ok(meta.compute_units_consumed),
+        Err(e) => {
+            let mut msg = format!("{:?}", e.err);
+            for log in &e.meta.logs {
+                msg.push_str(&format!("\n  {}", log));
+            }
+            Err(msg)
+        }
+    }
+}
+
+fn assert_custom_err(err: &str, code: u32, label: &str) {
+    let hex = format!("0x{:x}", code);
+    let custom = format!("Custom({})", code);
+    assert!(
+        err.contains(&hex) || err.contains(&custom),
+        "{label}: expected {code} ({hex}), got: {err}"
+    );
+}
+
+// ─── Fixture ────────────────────────────────────────────────────────────
+
+struct Fixture {
+    svm: LiteSVM,
+    payer: Keypair,
+    pool: Address,
+    mint_a: Address,
+    mint_b: Address,
+    vault_a: Address,
+    vault_b: Address,
+    user_tok_a: Address,
+    user_tok_b: Address,
+}
+
+fn seed(current_batch_id: u64, paused: bool) -> Option<Fixture> {
+    let mut svm = LiteSVM::new();
+    if !std::path::Path::new(PFDA_AMM_SO).exists() {
+        eprintln!("SKIP: pfda_amm.so fixture missing");
+        return None;
+    }
+    svm.add_program_from_file(pfda_amm_id(), PFDA_AMM_SO).ok()?;
+
+    let payer = Keypair::new();
+    svm.airdrop(&payer.pubkey(), 100 * LAMPORTS_PER_SOL).unwrap();
+
+    let mint_a = Address::new_unique();
+    let mint_b = Address::new_unique();
+    create_mint(&mut svm, mint_a, &payer.pubkey(), 6);
+    create_mint(&mut svm, mint_b, &payer.pubkey(), 6);
+
+    let (pool, bump) = Address::find_program_address(
+        &[b"pool", mint_a.as_ref(), mint_b.as_ref()],
+        &pfda_amm_id(),
+    );
+
+    let vault_a = Address::new_unique();
+    let vault_b = Address::new_unique();
+    create_token_account(&mut svm, vault_a, &mint_a, &pool, 1_000_000);
+    create_token_account(&mut svm, vault_b, &mint_b, &pool, 1_000_000);
+
+    let user_tok_a = Address::new_unique();
+    let user_tok_b = Address::new_unique();
+    create_token_account(&mut svm, user_tok_a, &mint_a, &payer.pubkey(), 1_000_000_000);
+    create_token_account(&mut svm, user_tok_b, &mint_b, &payer.pubkey(), 1_000_000_000);
+
+    let mut pd = build_pfda_pool_state(
+        &mint_a,
+        &mint_b,
+        &vault_a,
+        &vault_b,
+        1_000_000,
+        1_000_000,
+        500_000,           // weight_a = 50%
+        10,                // window_slots
+        current_batch_id,
+        100,               // current_window_end
+        30,                // base_fee_bps
+        &payer.pubkey(),   // authority
+        bump,
+    );
+    if paused {
+        pd[238] = 1; // paused flag offset
+    }
+    svm.set_account(
+        pool,
+        Account {
+            lamports: LAMPORTS_PER_SOL,
+            data: pd,
+            owner: pfda_amm_id(),
+            executable: false,
+            rent_epoch: 0,
+        },
+    )
+    .unwrap();
+
+    Some(Fixture {
+        svm,
+        payer,
+        pool,
+        mint_a,
+        mint_b,
+        vault_a,
+        vault_b,
+        user_tok_a,
+        user_tok_b,
+    })
+}
+
+fn seed_queue(svm: &mut LiteSVM, pool: Address, batch_id: u64, window_end: u64) -> Address {
+    let (queue, bump) = Address::find_program_address(
+        &[b"queue", pool.as_ref(), &batch_id.to_le_bytes()],
+        &pfda_amm_id(),
+    );
+    let qd = build_batch_queue(&pool, batch_id, 0, 0, window_end, bump);
+    svm.set_account(
+        queue,
+        Account {
+            lamports: LAMPORTS_PER_SOL,
+            data: qd,
+            owner: pfda_amm_id(),
+            executable: false,
+            rent_epoch: 0,
+        },
+    )
+    .unwrap();
+    queue
+}
+
+fn seed_history(svm: &mut LiteSVM, pool: Address, batch_id: u64) -> (Address, u64) {
+    let (hist, bump) = Address::find_program_address(
+        &[b"history", pool.as_ref(), &batch_id.to_le_bytes()],
+        &pfda_amm_id(),
+    );
+    let rent = 1_000_000u64;
+    svm.set_account(
+        hist,
+        Account {
+            lamports: rent,
+            data: build_cleared_batch_history(&pool, batch_id, bump),
+            owner: pfda_amm_id(),
+            executable: false,
+            rent_epoch: 0,
+        },
+    )
+    .unwrap();
+    (hist, rent)
+}
+
+fn seed_ticket(svm: &mut LiteSVM, pool: Address, owner: Address, batch_id: u64) -> (Address, u64) {
+    let (ticket, bump) = Address::find_program_address(
+        &[b"ticket", pool.as_ref(), owner.as_ref(), &batch_id.to_le_bytes()],
+        &pfda_amm_id(),
+    );
+    let rent = 1_500_000u64;
+    svm.set_account(
+        ticket,
+        Account {
+            lamports: rent,
+            data: build_user_order_ticket(&owner, &pool, batch_id, bump),
+            owner: pfda_amm_id(),
+            executable: false,
+            rent_epoch: 0,
+        },
+    )
+    .unwrap();
+    (ticket, rent)
+}
+
+// ─── Tests ──────────────────────────────────────────────────────────────
+
+#[test]
+fn pfda_close_batch_history_success_after_delay() {
+    require_fixture!(PFDA_AMM_SO);
+    let Fixture { mut svm, payer, pool, .. } = match seed(150, false) {
+        Some(f) => f,
+        None => return,
+    };
+    let (hist, _) = seed_history(&mut svm, pool, 0);
+
+    let before = svm.get_balance(&payer.pubkey()).unwrap();
+    send(
+        &mut svm,
+        pfda_close_batch_history_ix(pfda_amm_id(), payer.pubkey(), pool, hist),
+        &payer,
+    )
+    .expect("CloseBatchHistory should succeed after delay");
+
+    assert_eq!(svm.get_balance(&hist).unwrap_or(0), 0);
+    let after = svm.get_balance(&payer.pubkey()).unwrap_or(0);
+    assert!(after > before, "rent credited: {before} -> {after}");
+}
+
+#[test]
+fn pfda_close_batch_history_rejects_before_delay() {
+    require_fixture!(PFDA_AMM_SO);
+    let Fixture { mut svm, payer, pool, .. } = match seed(50, false) {
+        Some(f) => f,
+        None => return,
+    };
+    let (hist, _) = seed_history(&mut svm, pool, 0);
+
+    let err = send(
+        &mut svm,
+        pfda_close_batch_history_ix(pfda_amm_id(), payer.pubkey(), pool, hist),
+        &payer,
+    )
+    .err()
+    .expect("should reject");
+    assert_custom_err(&err, ERR_BATCH_WINDOW_NOT_ENDED, "pre-delay");
+}
+
+#[test]
+fn pfda_close_expired_ticket_success_after_delay() {
+    require_fixture!(PFDA_AMM_SO);
+    let Fixture { mut svm, payer, pool, .. } = match seed(250, false) {
+        Some(f) => f,
+        None => return,
+    };
+    let owner = payer.pubkey();
+    let (ticket, _) = seed_ticket(&mut svm, pool, owner, 0);
+
+    let before = svm.get_balance(&owner).unwrap();
+    send(
+        &mut svm,
+        pfda_close_expired_ticket_ix(pfda_amm_id(), payer.pubkey(), pool, ticket, owner),
+        &payer,
+    )
+    .expect("CloseExpiredTicket should succeed after delay");
+
+    assert_eq!(svm.get_balance(&ticket).unwrap_or(0), 0);
+    let after = svm.get_balance(&owner).unwrap_or(0);
+    assert!(after > before, "rent credited: {before} -> {after}");
+}
+
+#[test]
+fn pfda_close_expired_ticket_rejects_before_delay() {
+    require_fixture!(PFDA_AMM_SO);
+    let Fixture { mut svm, payer, pool, .. } = match seed(100, false) {
+        Some(f) => f,
+        None => return,
+    };
+    let owner = payer.pubkey();
+    let (ticket, _) = seed_ticket(&mut svm, pool, owner, 0);
+
+    let err = send(
+        &mut svm,
+        pfda_close_expired_ticket_ix(pfda_amm_id(), payer.pubkey(), pool, ticket, owner),
+        &payer,
+    )
+    .err()
+    .expect("should reject");
+    assert_custom_err(&err, ERR_BATCH_WINDOW_NOT_ENDED, "pre-delay");
+}
+
+#[test]
+fn pfda_add_liquidity_rejects_when_paused() {
+    require_fixture!(PFDA_AMM_SO);
+    let Fixture {
+        mut svm, payer, pool, mint_a: _, mint_b: _, vault_a, vault_b, user_tok_a, user_tok_b,
+    } = match seed(0, /*paused=*/ true) {
+        Some(f) => f,
+        None => return,
+    };
+
+    let err = send(
+        &mut svm,
+        pfda_add_liquidity_ix(
+            pfda_amm_id(),
+            payer.pubkey(),
+            pool,
+            vault_a,
+            vault_b,
+            user_tok_a,
+            user_tok_b,
+            100,
+            100,
+        ),
+        &payer,
+    )
+    .err()
+    .expect("paused add_liquidity should reject");
+    assert_custom_err(&err, ERR_POOL_PAUSED, "paused rejection");
+}
+
+#[test]
+fn pfda_add_liquidity_rejects_wrong_vault() {
+    require_fixture!(PFDA_AMM_SO);
+    let Fixture {
+        mut svm, payer, pool, mint_a, mint_b: _, vault_a: _, vault_b, user_tok_a, user_tok_b,
+    } = match seed(0, false) {
+        Some(f) => f,
+        None => return,
+    };
+
+    // A rogue vault with the right mint but not the program-registered
+    // vault. Pre-PR#46 this would have transferred the deposit away.
+    let rogue = Address::new_unique();
+    create_token_account(&mut svm, rogue, &mint_a, &pool, 0);
+
+    let err = send(
+        &mut svm,
+        pfda_add_liquidity_ix(
+            pfda_amm_id(),
+            payer.pubkey(),
+            pool,
+            rogue,      // bogus vault_a
+            vault_b,
+            user_tok_a,
+            user_tok_b,
+            100,
+            100,
+        ),
+        &payer,
+    )
+    .err()
+    .expect("wrong vault should reject");
+    assert_custom_err(&err, ERR_VAULT_MISMATCH, "wrong-vault rejection");
+}
+
+#[test]
+fn pfda_swap_request_duplicate_same_batch_is_atomic() {
+    // PR #50 reordered SwapRequest so CreateAccount runs before the
+    // Transfer. A second call in the same batch must now fail on
+    // CreateAccount (account in use) without moving any tokens.
+    //
+    // Pre-fix: the first call would Transfer into the vault, then the
+    // CreateAccount would fail → tokens stranded. Post-fix: the second
+    // call fails atomically before the Transfer.
+    require_fixture!(PFDA_AMM_SO);
+    let Fixture {
+        mut svm, payer, pool, mint_a: _, mint_b: _, vault_a, vault_b, user_tok_a, user_tok_b,
+    } = match seed(0, false) {
+        Some(f) => f,
+        None => return,
+    };
+
+    let queue = seed_queue(&mut svm, pool, 0, 100);
+
+    // First call — happy path. Should create ticket PDA + transfer.
+    send(
+        &mut svm,
+        {
+            let (ticket, _) = Address::find_program_address(
+                &[b"ticket", pool.as_ref(), payer.pubkey().as_ref(), &0u64.to_le_bytes()],
+                &pfda_amm_id(),
+            );
+            pfda_swap_request_ix(
+                pfda_amm_id(),
+                payer.pubkey(),
+                pool,
+                queue,
+                ticket,
+                user_tok_a,
+                user_tok_b,
+                vault_a,
+                vault_b,
+                1000,
+                0,
+            )
+        },
+        &payer,
+    )
+    .expect("first SwapRequest should succeed");
+
+    let vault_a_mid = read_token_amount(&svm, &vault_a);
+    let user_a_mid = read_token_amount(&svm, &user_tok_a);
+
+    // Second call — same (user, batch_id). Must fail atomically.
+    let (ticket2, _) = Address::find_program_address(
+        &[b"ticket", pool.as_ref(), payer.pubkey().as_ref(), &0u64.to_le_bytes()],
+        &pfda_amm_id(),
+    );
+    let err = send(
+        &mut svm,
+        pfda_swap_request_ix(
+            pfda_amm_id(),
+            payer.pubkey(),
+            pool,
+            queue,
+            ticket2,
+            user_tok_a,
+            user_tok_b,
+            vault_a,
+            vault_b,
+            1000,
+            0,
+        ),
+        &payer,
+    )
+    .err()
+    .expect("second SwapRequest same batch should fail");
+    // The account-in-use error comes from the system program; message
+    // varies across LiteSVM versions. What we *care* about is that no
+    // tokens moved between the failed call and the pre-fail snapshot.
+    assert!(!err.is_empty(), "expected a rejection, got: {err}");
+
+    let vault_a_after = read_token_amount(&svm, &vault_a);
+    let user_a_after = read_token_amount(&svm, &user_tok_a);
+    assert_eq!(
+        vault_a_after, vault_a_mid,
+        "vault_a must not change after failed duplicate SwapRequest"
+    );
+    assert_eq!(
+        user_a_after, user_a_mid,
+        "user_tok_a must not change after failed duplicate SwapRequest"
+    );
+}
+
+fn read_token_amount(svm: &LiteSVM, addr: &Address) -> u64 {
+    let acc = svm.get_account(addr).expect("token account");
+    u64::from_le_bytes(acc.data[64..72].try_into().unwrap())
+}

--- a/contracts/ab-integration-tests/tests/scenario_coverage.rs
+++ b/contracts/ab-integration-tests/tests/scenario_coverage.rs
@@ -1,0 +1,367 @@
+//! Scenario-gap coverage (issue #33).
+//!
+//! Kidney's scenario table in #33 lists per-instruction rejection paths
+//! that had no regression tests. This file covers the LiteSVM-suitable
+//! rows for pfda-amm-3 — the ones where PRs #46 / #47 added a new
+//! rejection and a later regression could silently remove it.
+//!
+//! Covered:
+//!   - AddLiquidity wrong vault  → VaultMismatch (8025)      [PR #47]
+//!   - AddLiquidity paused pool  → PoolPaused    (8018)      [PR #47]
+//!   - SwapRequest paused pool   → PoolPaused    (8018)      [PR #47]
+//!
+//! The pattern mirrors close_delay.rs: pre-seed a pool + vaults + user
+//! accounts via set_account, flip the relevant pool field, submit the
+//! instruction, expect the named custom error code.
+
+use ab_integration_tests::helpers::{account_builder::*, svm_setup::*, token_factory::*};
+use ab_integration_tests::require_fixture;
+use litesvm::LiteSVM;
+use solana_account::Account;
+use solana_address::Address;
+use solana_instruction::{account_meta::AccountMeta, Instruction};
+use solana_keypair::Keypair;
+use solana_native_token::LAMPORTS_PER_SOL;
+use solana_signer::Signer;
+use solana_transaction::Transaction;
+
+// Pfda3Error codes (mirror of contracts/pfda-amm-3/src/error.rs)
+const ERR_POOL_PAUSED: u32 = 8018;
+const ERR_VAULT_MISMATCH: u32 = 8025;
+
+// ─── Instruction builders ───────────────────────────────────────────────
+
+fn pfda3_add_liquidity_ix(
+    program: Address,
+    payer: Address,
+    pool: Address,
+    vaults: &[Address; 3],
+    user_tokens: &[Address; 3],
+    amounts: &[u64; 3],
+) -> Instruction {
+    let mut data = vec![4u8];
+    for a in amounts {
+        data.extend_from_slice(&a.to_le_bytes());
+    }
+    Instruction {
+        program_id: program,
+        accounts: vec![
+            AccountMeta::new(payer, true),
+            AccountMeta::new(pool, false),
+            AccountMeta::new(vaults[0], false),
+            AccountMeta::new(vaults[1], false),
+            AccountMeta::new(vaults[2], false),
+            AccountMeta::new(user_tokens[0], false),
+            AccountMeta::new(user_tokens[1], false),
+            AccountMeta::new(user_tokens[2], false),
+            AccountMeta::new_readonly(token_program_id(), false),
+        ],
+        data,
+    }
+}
+
+fn pfda3_swap_request_ix(
+    program: Address,
+    user: Address,
+    pool: Address,
+    queue: Address,
+    ticket: Address,
+    user_token: Address,
+    vault: Address,
+    in_idx: u8,
+    amount_in: u64,
+    out_idx: u8,
+    min_out: u64,
+) -> Instruction {
+    let mut data = vec![1u8];
+    data.push(in_idx);
+    data.extend_from_slice(&amount_in.to_le_bytes());
+    data.push(out_idx);
+    data.extend_from_slice(&min_out.to_le_bytes());
+    Instruction {
+        program_id: program,
+        accounts: vec![
+            AccountMeta::new(user, true),
+            AccountMeta::new_readonly(pool, false),
+            AccountMeta::new(queue, false),
+            AccountMeta::new(ticket, false),
+            AccountMeta::new(user_token, false),
+            AccountMeta::new(vault, false),
+            AccountMeta::new_readonly(token_program_id(), false),
+            AccountMeta::new_readonly(system_program_id(), false),
+        ],
+        data,
+    }
+}
+
+fn send(svm: &mut LiteSVM, ix: Instruction, payer: &Keypair) -> Result<u64, String> {
+    let tx = Transaction::new_signed_with_payer(
+        &[ix],
+        Some(&payer.pubkey()),
+        &[payer],
+        svm.latest_blockhash(),
+    );
+    match svm.send_transaction(tx) {
+        Ok(meta) => Ok(meta.compute_units_consumed),
+        Err(e) => {
+            let mut msg = format!("{:?}", e.err);
+            for log in &e.meta.logs {
+                msg.push_str(&format!("\n  {}", log));
+            }
+            Err(msg)
+        }
+    }
+}
+
+fn assert_custom_err(err: &str, code: u32, label: &str) {
+    let hex = format!("0x{:x}", code);
+    let custom = format!("Custom({})", code);
+    assert!(
+        err.contains(&hex) || err.contains(&custom),
+        "{label}: expected {code} ({hex}), got: {err}"
+    );
+}
+
+// ─── Seed ───────────────────────────────────────────────────────────────
+
+struct Fixture {
+    svm: LiteSVM,
+    payer: Keypair,
+    pool: Address,
+    mints: [Address; 3],
+    vaults: [Address; 3],
+    user_tokens: [Address; 3],
+}
+
+fn seed_pool(paused: bool) -> Option<Fixture> {
+    let mut svm = LiteSVM::new();
+    if !std::path::Path::new(PFDA_AMM_3_SO).exists() {
+        eprintln!("SKIP: pfda_amm_3.so fixture missing");
+        return None;
+    }
+    svm.add_program_from_file(pfda3_id(), PFDA_AMM_3_SO).ok()?;
+
+    let payer = Keypair::new();
+    svm.airdrop(&payer.pubkey(), 100 * LAMPORTS_PER_SOL).unwrap();
+
+    let mints = [
+        Address::new_unique(),
+        Address::new_unique(),
+        Address::new_unique(),
+    ];
+    for &m in &mints {
+        create_mint(&mut svm, m, &payer.pubkey(), 6);
+    }
+
+    let (pool, pool_bump) = Address::find_program_address(
+        &[
+            b"pool3",
+            mints[0].as_ref(),
+            mints[1].as_ref(),
+            mints[2].as_ref(),
+        ],
+        &pfda3_id(),
+    );
+
+    let vaults = [
+        Address::new_unique(),
+        Address::new_unique(),
+        Address::new_unique(),
+    ];
+    let user_tokens = [
+        Address::new_unique(),
+        Address::new_unique(),
+        Address::new_unique(),
+    ];
+    for i in 0..3 {
+        create_token_account(&mut svm, vaults[i], &mints[i], &pool, 1_000_000);
+        create_token_account(&mut svm, user_tokens[i], &mints[i], &payer.pubkey(), 1_000_000_000);
+    }
+
+    let treasury = Address::new_unique();
+    let mut pd = build_pfda3_pool_state(
+        &mints,
+        &vaults,
+        &[1_000_000; 3],
+        &[333_333, 333_333, 333_334],
+        10,        // window_slots
+        0,         // current_batch_id
+        100,       // current_window_end
+        &treasury,
+        &payer.pubkey(),
+        30,        // base_fee_bps
+        pool_bump,
+    );
+    if paused {
+        // PoolState3.paused offset = 332 (per account_builder.rs layout comment).
+        pd[332] = 1;
+    }
+
+    svm.set_account(
+        pool,
+        Account {
+            lamports: LAMPORTS_PER_SOL,
+            data: pd,
+            owner: pfda3_id(),
+            executable: false,
+            rent_epoch: 0,
+        },
+    )
+    .unwrap();
+
+    Some(Fixture {
+        svm,
+        payer,
+        pool,
+        mints,
+        vaults,
+        user_tokens,
+    })
+}
+
+fn seed_batch_queue(svm: &mut LiteSVM, pool: Address, batch_id: u64, window_end: u64) -> Address {
+    let (queue, qbump) = Address::find_program_address(
+        &[b"queue3", pool.as_ref(), &batch_id.to_le_bytes()],
+        &pfda3_id(),
+    );
+    let qd = build_batch_queue_3(&pool, batch_id, &[0; 3], window_end, qbump);
+    svm.set_account(
+        queue,
+        Account {
+            lamports: LAMPORTS_PER_SOL,
+            data: qd,
+            owner: pfda3_id(),
+            executable: false,
+            rent_epoch: 0,
+        },
+    )
+    .unwrap();
+    queue
+}
+
+// ─── Tests ──────────────────────────────────────────────────────────────
+
+#[test]
+fn add_liquidity_rejects_wrong_vault() {
+    require_fixture!(PFDA_AMM_3_SO);
+    let Fixture {
+        mut svm,
+        payer,
+        pool,
+        mints,
+        vaults,
+        user_tokens,
+    } = match seed_pool(/*paused=*/ false) {
+        Some(f) => f,
+        None => return,
+    };
+
+    // Swap in a vault that matches the correct mint but isn't the
+    // program-registered vault for this pool. Pre-PR#47 this would have
+    // silently transferred to the attacker account.
+    let rogue_vault = Address::new_unique();
+    create_token_account(&mut svm, rogue_vault, &mints[0], &pool, 0);
+
+    let mut bad_vaults = vaults;
+    bad_vaults[0] = rogue_vault;
+
+    let err = send(
+        &mut svm,
+        pfda3_add_liquidity_ix(
+            pfda3_id(),
+            payer.pubkey(),
+            pool,
+            &bad_vaults,
+            &user_tokens,
+            &[100, 100, 100],
+        ),
+        &payer,
+    )
+    .err()
+    .expect("AddLiquidity with wrong vault should reject");
+    assert_custom_err(&err, ERR_VAULT_MISMATCH, "wrong-vault rejection");
+}
+
+#[test]
+fn add_liquidity_rejects_when_paused() {
+    require_fixture!(PFDA_AMM_3_SO);
+    let Fixture {
+        mut svm,
+        payer,
+        pool,
+        mints: _,
+        vaults,
+        user_tokens,
+    } = match seed_pool(/*paused=*/ true) {
+        Some(f) => f,
+        None => return,
+    };
+
+    let err = send(
+        &mut svm,
+        pfda3_add_liquidity_ix(
+            pfda3_id(),
+            payer.pubkey(),
+            pool,
+            &vaults,
+            &user_tokens,
+            &[100, 100, 100],
+        ),
+        &payer,
+    )
+    .err()
+    .expect("AddLiquidity on paused pool should reject");
+    assert_custom_err(&err, ERR_POOL_PAUSED, "paused-pool rejection");
+}
+
+#[test]
+fn swap_request_rejects_when_paused() {
+    require_fixture!(PFDA_AMM_3_SO);
+    let Fixture {
+        mut svm,
+        payer,
+        pool,
+        mints: _,
+        vaults,
+        user_tokens,
+    } = match seed_pool(/*paused=*/ true) {
+        Some(f) => f,
+        None => return,
+    };
+
+    // Seed the batch queue so the instruction can get past queue
+    // validation and actually exercise the pool.paused branch.
+    let queue = seed_batch_queue(&mut svm, pool, 0, 100);
+
+    let (ticket, _) = Address::find_program_address(
+        &[
+            b"ticket3",
+            pool.as_ref(),
+            payer.pubkey().as_ref(),
+            &0u64.to_le_bytes(),
+        ],
+        &pfda3_id(),
+    );
+
+    let err = send(
+        &mut svm,
+        pfda3_swap_request_ix(
+            pfda3_id(),
+            payer.pubkey(),
+            pool,
+            queue,
+            ticket,
+            user_tokens[0],
+            vaults[0],
+            0,
+            100,
+            1,
+            0,
+        ),
+        &payer,
+    )
+    .err()
+    .expect("SwapRequest on paused pool should reject");
+    // PR #47 specifically changed this from InvalidDiscriminator to PoolPaused.
+    assert_custom_err(&err, ERR_POOL_PAUSED, "paused-pool rejection");
+}

--- a/contracts/ab-integration-tests/tests/scenario_coverage.rs
+++ b/contracts/ab-integration-tests/tests/scenario_coverage.rs
@@ -365,3 +365,104 @@ fn swap_request_rejects_when_paused() {
     // PR #47 specifically changed this from InvalidDiscriminator to PoolPaused.
     assert_custom_err(&err, ERR_POOL_PAUSED, "paused-pool rejection");
 }
+
+// ─── pfda-amm-3 InitializePool rejection paths ─────────────────────────
+
+const ERR_INVALID_FEE_BPS: u32 = 8033;
+const ERR_ALREADY_INITIALIZED: u32 = 8015;
+
+fn pfda3_init_ix_bogus(
+    payer: &Keypair,
+    base_fee_bps: u16,
+    pool: Address,
+) -> Instruction {
+    // Data layout: [base_fee_bps: u16][window_slots: u64][w0..w2: u32 each]
+    let mut data = vec![0u8]; // InitializePool
+    data.extend_from_slice(&base_fee_bps.to_le_bytes());
+    data.extend_from_slice(&10u64.to_le_bytes()); // window_slots
+    data.extend_from_slice(&333_333u32.to_le_bytes());
+    data.extend_from_slice(&333_333u32.to_le_bytes());
+    data.extend_from_slice(&333_334u32.to_le_bytes());
+
+    // 12-account minimum. base_fee_bps=10_000 rejection fires before
+    // any account is read, so unique fresh keys are enough.
+    let mut accts = vec![
+        AccountMeta::new(payer.pubkey(), true),
+        AccountMeta::new(pool, false),
+    ];
+    // queue + 3 mints + 3 vaults + treasury = 8 more
+    for _ in 0..8 {
+        accts.push(AccountMeta::new(Address::new_unique(), false));
+    }
+    accts.push(AccountMeta::new_readonly(system_program_id(), false));
+    accts.push(AccountMeta::new_readonly(token_program_id(), false));
+
+    Instruction { program_id: pfda3_id(), accounts: accts, data }
+}
+
+#[test]
+fn pfda3_init_rejects_fee_100_percent() {
+    require_fixture!(PFDA_AMM_3_SO);
+    let mut svm = LiteSVM::new();
+    if !std::path::Path::new(PFDA_AMM_3_SO).exists() { return; }
+    svm.add_program_from_file(pfda3_id(), PFDA_AMM_3_SO).unwrap();
+    let payer = Keypair::new();
+    svm.airdrop(&payer.pubkey(), LAMPORTS_PER_SOL).unwrap();
+
+    let bogus_pool = Address::new_unique();
+    let err = send(
+        &mut svm,
+        pfda3_init_ix_bogus(&payer, 10_000, bogus_pool),
+        &payer,
+    )
+    .err()
+    .expect("base_fee_bps=10_000 should reject");
+    assert_custom_err(&err, ERR_INVALID_FEE_BPS, "pfda3 fee=100%");
+}
+
+#[test]
+fn pfda3_init_rejects_duplicate() {
+    require_fixture!(PFDA_AMM_3_SO);
+    // Pre-seed the pool PDA via the seed helper so the discriminator
+    // check fires AlreadyInitialized.
+    let Fixture { mut svm, payer, pool, mints, vaults: _, user_tokens: _ } =
+        match seed_pool(false) { Some(f) => f, None => return };
+
+    // PoolState3 seeds are [b"pool3", mints[0], mints[1], mints[2]] —
+    // the ix won't find the declared pool unless we use the same PDA.
+    let mut data = vec![0u8];
+    data.extend_from_slice(&30u16.to_le_bytes());
+    data.extend_from_slice(&10u64.to_le_bytes());
+    data.extend_from_slice(&333_333u32.to_le_bytes());
+    data.extend_from_slice(&333_333u32.to_le_bytes());
+    data.extend_from_slice(&333_334u32.to_le_bytes());
+
+    let queue = Address::new_unique();
+    let v = [Address::new_unique(), Address::new_unique(), Address::new_unique()];
+
+    let err = send(
+        &mut svm,
+        Instruction {
+            program_id: pfda3_id(),
+            accounts: vec![
+                AccountMeta::new(payer.pubkey(), true),
+                AccountMeta::new(pool, false),
+                AccountMeta::new(queue, false),
+                AccountMeta::new_readonly(mints[0], false),
+                AccountMeta::new_readonly(mints[1], false),
+                AccountMeta::new_readonly(mints[2], false),
+                AccountMeta::new(v[0], false),
+                AccountMeta::new(v[1], false),
+                AccountMeta::new(v[2], false),
+                AccountMeta::new_readonly(Address::new_unique(), false), // treasury
+                AccountMeta::new_readonly(system_program_id(), false),
+                AccountMeta::new_readonly(token_program_id(), false),
+            ],
+            data,
+        },
+        &payer,
+    )
+    .err()
+    .expect("duplicate init should reject");
+    assert_custom_err(&err, ERR_ALREADY_INITIALIZED, "pfda3 duplicate init");
+}


### PR DESCRIPTION
## Summary

Previous PRs in this #33 series overstated completeness. An honest audit against kidney's scenario table turned up **7 rows** that were either flagged as blocked (they weren't) or glossed over entirely. This PR lands regression tests for every single one.

## Rows closed in this PR

| Row | Test | Error |
|-----|------|-------|
| pfda-amm `SwapRequest` wrong vault | `pfda_swap_request_rejects_wrong_vault` | `VaultMismatch (6020)` |
| pfda-amm `UpdateWeight` out-of-range weight | `pfda_update_weight_rejects_out_of_range` | `InvalidWeight (6009)` |
| pfda-amm `UpdateWeight` past end slot | `pfda_update_weight_rejects_past_end_slot` | `InvalidWindowSlots (6014)` |
| pfda-amm `UpdateWeight` wrong authority | `pfda_update_weight_rejects_wrong_authority` | `Unauthorized (6016)` |
| pfda-amm `InitializePool` `base_fee_bps=10_000` | `pfda_init_rejects_fee_100_percent` | `InvalidFeeBps (6019)` |
| pfda-amm `InitializePool` duplicate | `pfda_init_rejects_duplicate` | `AlreadyInitialized (6015)` |
| pfda-amm `Claim` slippage | `pfda_claim_rejects_slippage_exceeded` | `SlippageExceeded (6006)` |
| pfda-amm `Claim` double-claim | `pfda_claim_rejects_double_claim` | `TicketAlreadyClaimed (6004)` |
| pfda-amm-3 `InitializePool` `base_fee_bps=10_000` | `pfda3_init_rejects_fee_100_percent` | `InvalidFeeBps (8033)` |
| pfda-amm-3 `InitializePool` duplicate | `pfda3_init_rejects_duplicate` | `AlreadyInitialized (8015)` |
| axis-g3m `Rebalance` >50% attestation cap | `rebalance_attestation_rejects_over_50pct_reserve_change` | `ReserveChangeExceeded (7019)` |
| axis-g3m `Rebalance` missing jupiter (PR #48 hardening) | `rebalance_attestation_rejects_missing_jupiter` | `AttestationRequiresJupiter (7022)` |
| axis-vault `Deposit` wrong etf_mint | `deposit_rejects_wrong_etf_mint` | `MintMismatch (9009)` |
| axis-vault `Deposit` wrong vault | `deposit_rejects_wrong_vault` | `VaultMismatch (9013)` |

14 new tests total.

## Harness additions

- **pfda-amm** `ClearedBatchHistory` / `UserOrderTicket` full-fat builders that populate `clearing_price` / `amount_in_a` / `amount_in_b` / `min_amount_out` (the stubs in `close_delay.rs` only set the fields `CloseBatchHistory` reads).
- **axis-vault** `build_etf_state` + `build_mint_with_authority` — lets Deposit tests run without a full `CreateEtf` CPI cascade. Offsets verified via `offset_of!` probe: EtfState = 520 bytes, paused @ 450.
- **>50%-cap test** forces drift via direct byte edits to `pool.reserves[0]` + `pool.drift_threshold_bps`, bypassing a real Swap warm-up.

## Running totals

**45 LiteSVM regression tests across 6 binaries**, all gated in the A/B Test Suite workflow:

| Binary | Before | After |
|--------|-------:|------:|
| close_delay | 4 | 4 |
| scenario_coverage | 3 | 5 |
| pfda_amm_coverage | 7 | 15 |
| axis_g3m_coverage | 9 | 11 |
| pfda3_claim_coverage | 2 | 2 |
| axis_vault_coverage | 6 | 8 |
| **Total** | **31** | **45** |

## Still genuinely outstanding (documented, not glossed over)

1. **axis-vault second-depositor proportional-mint assertion.** Requires a fully real `CreateEtf` flow (`InitializeMint2` + `InitializeAccount3` CPIs) that my pre-seeded-state harness intentionally avoids. Can add as a follow-up if Muse wants a proportional-math regression.
2. **axis-g3m `RebalanceViaJupiter` disc=4 with a real Jupiter route.** Needs a cached Jupiter quote fixture. The attestation-hardening regression guard is in place already (`missing_jupiter` test here + PR #49's attestation test).
3. **On-chain `DepositSol` / `WithdrawSol` (#36).** Architectural — PR #42's author deferred for real CU/account-list reasons. Needs Muse/kidney sign-off before code.

## Test plan

- [x] `cargo test --test pfda_amm_coverage` — 15 / 15
- [x] `cargo test --test scenario_coverage` — 5 / 5
- [x] `cargo test --test axis_g3m_coverage` — 11 / 11
- [x] `cargo test --test axis_vault_coverage` — 8 / 8
- [x] `cargo test --test close_delay` — 4 / 4 (unchanged)
- [x] `cargo test --test pfda3_claim_coverage` — 2 / 2 (unchanged)
- [ ] First CI run on this PR exercises all 45.
- [x] Review by @kidneyweakx.

## Stacking

Stacks on #55. All changes are additive file edits (no removals). No conflicts with any other open PR.