### PR TITLE
feat(axis-vault): DepositSol / WithdrawSol scaffolding (#36)

### DIFF
--- a/.github/workflows/litesvm-jupiter-cpi.yml
+++ b/.github/workflows/litesvm-jupiter-cpi.yml
@@ -133,6 +133,15 @@ jobs:
           cd contracts/ab-integration-tests
           cargo test --test axis_vault_coverage -- --nocapture
 
+      # #36: DepositSol / WithdrawSol scaffolding guards. Locks down
+      # the parameter-validation surface (zero amount, basket-size cap)
+      # and the NotYetImplemented placeholder so the dispatcher stays
+      # sane while the Jupiter CPI body is being designed.
+      - name: Run axis-vault SOL-ix scaffold tests (LiteSVM)
+        run: |
+          cd contracts/ab-integration-tests
+          cargo test --test axis_vault_sol_ix_scaffold -- --nocapture
+
       - name: Generate LiteSVM A/B report
         run: |
           cd contracts/ab-integration-tests

--- a/contracts/ab-integration-tests/Cargo.toml
+++ b/contracts/ab-integration-tests/Cargo.toml
@@ -35,6 +35,10 @@ path = "tests/pfda3_claim_coverage.rs"
 name = "axis_vault_coverage"
 path = "tests/axis_vault_coverage.rs"
 
+[[test]]
+name = "axis_vault_sol_ix_scaffold"
+path = "tests/axis_vault_sol_ix_scaffold.rs"
+
 [dependencies]
 litesvm = "0.11"
 solana-keypair = "3.1"

--- a/contracts/ab-integration-tests/tests/axis_vault_sol_ix_scaffold.rs
+++ b/contracts/ab-integration-tests/tests/axis_vault_sol_ix_scaffold.rs
@@ -1,0 +1,173 @@
+//! axis-vault DepositSol / WithdrawSol scaffolding tests (#36, PR #58).
+//!
+//! These tests lock down the scaffolding behavior so the dispatcher +
+//! parameter validation stay correct while the Jupiter CPI body is
+//! being designed in follow-up. Each case hits one of the two early
+//! validation branches:
+//!
+//!   - sol_in / burn_amount == 0 → ZeroDeposit (9004)
+//!   - leg_count == 0 or > 3    → BasketTooLargeForOnchainSol (9025)
+//!   - otherwise                → NotYetImplemented (9024)
+//!
+//! When the real implementation lands, the `NotYetImplemented` branch
+//! goes away and the happy-path tests move into the axis_vault_coverage
+//! sibling file.
+
+use ab_integration_tests::helpers::{svm_setup::*, token_factory::*};
+use ab_integration_tests::require_fixture;
+use litesvm::LiteSVM;
+use solana_address::Address;
+use solana_instruction::{account_meta::AccountMeta, Instruction};
+use solana_keypair::Keypair;
+use solana_native_token::LAMPORTS_PER_SOL;
+use solana_signer::Signer;
+use solana_transaction::Transaction;
+
+const ERR_ZERO_DEPOSIT: u32 = 9004;
+const ERR_NOT_YET_IMPLEMENTED: u32 = 9024;
+const ERR_BASKET_TOO_LARGE: u32 = 9025;
+
+fn send(svm: &mut LiteSVM, ix: Instruction, payer: &Keypair) -> Result<u64, String> {
+    let tx = Transaction::new_signed_with_payer(
+        &[ix],
+        Some(&payer.pubkey()),
+        &[payer],
+        svm.latest_blockhash(),
+    );
+    match svm.send_transaction(tx) {
+        Ok(meta) => Ok(meta.compute_units_consumed),
+        Err(e) => {
+            let mut msg = format!("{:?}", e.err);
+            for log in &e.meta.logs {
+                msg.push_str(&format!("\n  {}", log));
+            }
+            Err(msg)
+        }
+    }
+}
+
+fn assert_custom_err(err: &str, code: u32, label: &str) {
+    let hex = format!("0x{:x}", code);
+    let custom = format!("Custom({})", code);
+    assert!(
+        err.contains(&hex) || err.contains(&custom),
+        "{label}: expected {code} ({hex}), got: {err}"
+    );
+}
+
+fn bootstrap_svm() -> Option<(LiteSVM, Keypair)> {
+    let mut svm = LiteSVM::new();
+    if !std::path::Path::new(AXIS_VAULT_SO).exists() {
+        eprintln!("SKIP: axis_vault.so fixture missing");
+        return None;
+    }
+    svm.add_program_from_file(axis_vault_id(), AXIS_VAULT_SO).ok()?;
+    let payer = Keypair::new();
+    svm.airdrop(&payer.pubkey(), 10 * LAMPORTS_PER_SOL).unwrap();
+    Some((svm, payer))
+}
+
+/// Build a placeholder DepositSol / WithdrawSol tx. The scaffolding
+/// rejects on parameter-validation before touching accounts, so fresh
+/// unique addresses are enough padding. 18 bytes = sol_in + min_out +
+/// name_len(0) + leg_count.
+fn make_data(disc: u8, amount: u64, min_out: u64, leg_count: u8) -> Vec<u8> {
+    let mut d = Vec::with_capacity(18);
+    d.push(disc);
+    d.extend_from_slice(&amount.to_le_bytes());
+    d.extend_from_slice(&min_out.to_le_bytes());
+    d.push(0u8); // name_len = 0
+    d.push(leg_count);
+    d
+}
+
+fn make_accounts(payer: &Keypair) -> Vec<AccountMeta> {
+    // Scaffolded body doesn't dereference any of these — but the ix
+    // needs a non-trivial account vec so the runtime accepts the tx.
+    vec![
+        AccountMeta::new(payer.pubkey(), true),
+        AccountMeta::new(Address::new_unique(), false),
+        AccountMeta::new(Address::new_unique(), false),
+        AccountMeta::new(Address::new_unique(), false),
+        AccountMeta::new_readonly(token_program_id(), false),
+        AccountMeta::new(Address::new_unique(), false),
+    ]
+}
+
+// ─── DepositSol ────────────────────────────────────────────────────────
+
+#[test]
+fn deposit_sol_rejects_zero_amount() {
+    require_fixture!(AXIS_VAULT_SO);
+    let (mut svm, payer) = match bootstrap_svm() { Some(x) => x, None => return };
+    let err = send(
+        &mut svm,
+        Instruction { program_id: axis_vault_id(), accounts: make_accounts(&payer), data: make_data(5, 0, 0, 3) },
+        &payer,
+    ).err().expect("sol_in=0 must reject");
+    assert_custom_err(&err, ERR_ZERO_DEPOSIT, "zero sol_in");
+}
+
+#[test]
+fn deposit_sol_rejects_basket_too_large() {
+    require_fixture!(AXIS_VAULT_SO);
+    let (mut svm, payer) = match bootstrap_svm() { Some(x) => x, None => return };
+    let err = send(
+        &mut svm,
+        Instruction { program_id: axis_vault_id(), accounts: make_accounts(&payer), data: make_data(5, 1_000_000, 0, 4) },
+        &payer,
+    ).err().expect("leg_count=4 must reject");
+    assert_custom_err(&err, ERR_BASKET_TOO_LARGE, "4-leg deposit_sol");
+}
+
+#[test]
+fn deposit_sol_placeholder_returns_not_yet_implemented() {
+    require_fixture!(AXIS_VAULT_SO);
+    let (mut svm, payer) = match bootstrap_svm() { Some(x) => x, None => return };
+    // sol_in > 0, leg_count within bounds → falls through parameter
+    // validation and returns the placeholder.
+    let err = send(
+        &mut svm,
+        Instruction { program_id: axis_vault_id(), accounts: make_accounts(&payer), data: make_data(5, 1_000_000, 0, 2) },
+        &payer,
+    ).err().expect("placeholder body must return NotYetImplemented");
+    assert_custom_err(&err, ERR_NOT_YET_IMPLEMENTED, "deposit_sol placeholder");
+}
+
+// ─── WithdrawSol ───────────────────────────────────────────────────────
+
+#[test]
+fn withdraw_sol_rejects_zero_amount() {
+    require_fixture!(AXIS_VAULT_SO);
+    let (mut svm, payer) = match bootstrap_svm() { Some(x) => x, None => return };
+    let err = send(
+        &mut svm,
+        Instruction { program_id: axis_vault_id(), accounts: make_accounts(&payer), data: make_data(6, 0, 0, 3) },
+        &payer,
+    ).err().expect("burn_amount=0 must reject");
+    assert_custom_err(&err, ERR_ZERO_DEPOSIT, "zero burn_amount");
+}
+
+#[test]
+fn withdraw_sol_rejects_basket_too_large() {
+    require_fixture!(AXIS_VAULT_SO);
+    let (mut svm, payer) = match bootstrap_svm() { Some(x) => x, None => return };
+    let err = send(
+        &mut svm,
+        Instruction { program_id: axis_vault_id(), accounts: make_accounts(&payer), data: make_data(6, 500_000, 0, 5) },
+        &payer,
+    ).err().expect("leg_count=5 must reject");
+    assert_custom_err(&err, ERR_BASKET_TOO_LARGE, "5-leg withdraw_sol");
+}
+
+#[test]
+fn withdraw_sol_placeholder_returns_not_yet_implemented() {
+    require_fixture!(AXIS_VAULT_SO);
+    let (mut svm, payer) = match bootstrap_svm() { Some(x) => x, None => return };
+    let err = send(
+        &mut svm,
+        Instruction { program_id: axis_vault_id(), accounts: make_accounts(&payer), data: make_data(6, 500_000, 0, 2) },
+        &payer,
+    ).err().expect("placeholder body must return NotYetImplemented");
+    assert_custom_err(&err, ERR_NOT_YET_IMPLEMENTED, "withdraw_sol placeholder");
+}

--- a/contracts/axis-vault/src/error.rs
+++ b/contracts/axis-vault/src/error.rs
@@ -27,6 +27,13 @@ pub enum VaultError {
     SweepForbidden = 9021,
     NothingToSweep = 9022,
     TreasuryNotApproved = 9023,
+    /// DepositSol / WithdrawSol scaffolding shipped; native Jupiter CPI
+    /// implementation is a follow-up after design review. Issue #36.
+    NotYetImplemented = 9024,
+    /// DepositSol / WithdrawSol restrict basket size to keep CU + tx
+    /// account count within the 1.4M / versioned-tx envelopes. 5-leg
+    /// baskets must use the client-bundled flow from PR #42. Issue #36.
+    BasketTooLargeForOnchainSol = 9025,
 }
 
 impl From<VaultError> for ProgramError {

--- a/contracts/axis-vault/src/instructions/deposit_sol.rs
+++ b/contracts/axis-vault/src/instructions/deposit_sol.rs
@@ -1,0 +1,118 @@
+//! DepositSol — SOL-in variant of Deposit. Issue #36.
+//!
+//! # Status: SCAFFOLDING
+//!
+//! This file ships the instruction dispatcher hook + account layout +
+//! error path so downstream clients can start planning. The Jupiter CPI
+//! body is **intentionally not implemented** and returns
+//! `VaultError::NotYetImplemented` until Muse / kidney sign off on the
+//! design discussed in PR body #58.
+//!
+//! # Why a scaffold and not the full thing
+//!
+//! PR #42's author explicitly deferred on-chain SOL ixes because of:
+//!
+//! 1. **Account-list blow-up** — one Jupiter route carries 20-40
+//!    accounts. At tc=5 the per-leg Jupiter expansion pushes a single
+//!    versioned tx past the 64-signer / ~250-account envelope even
+//!    with ALT.
+//! 2. **CU budget** — a Jupiter swap costs 200-400k CU. 5-leg on-chain
+//!    CPI = 1.0-2.0M CU, straddling the 1.4M cap.
+//! 3. **Testability** — Jupiter V6 is mainnet-only, so every e2e has
+//!    to go through a mainnet-fork.
+//!
+//! The client-bundled flow in `scripts/axis-vault/deposit-sol.ts`
+//! avoids all three by letting the user sign a single versioned tx
+//! with `[ComputeBudget][Jupiter × N][axis-vault Deposit]`. Atomicity
+//! is preserved by the tx envelope itself.
+//!
+//! # What the on-chain variant gives
+//!
+//! Strict on-chain `min_etf_out` / `min_sol_out` enforcement with
+//! single-signer UX. Useful when the caller is another program (not
+//! a wallet-signed user) and can't rely on client-side slippage checks.
+//!
+//! # Scope limits (deliberate)
+//!
+//! - `tc <= 3` basket size — reserves full CU + account envelope for
+//!   the axis-vault Deposit tail + compute budget + rent. tc=4,5 uses
+//!   client-bundled.
+//! - Single-Jupiter-program assumption — we pin to `JUPITER_PROGRAM_ID`
+//!   (mirrors axis-g3m).
+//!
+//! # Account layout (design target)
+//!
+//! ```text
+//! 0: [signer, writable]  depositor (pays SOL)
+//! 1: [writable]          etf_state PDA
+//! 2: [writable]          etf_mint
+//! 3: [writable]          depositor_etf_ata
+//! 4: []                  token_program
+//! 5: [writable]          treasury_etf_ata
+//! 6: [writable]          wsol_ata (depositor-owned, holds wrapped SOL for CPI)
+//! 7: []                  wsol_mint (So11111111111111111111111111111111111111112)
+//! 8: []                  jupiter_program
+//! 9: []                  system_program
+//! 10..10+tc: [writable]  per-leg basket vaults
+//! 11+tc..: variable       per-leg Jupiter route accounts
+//! ```
+//!
+//! # Instruction data (design target)
+//!
+//! ```text
+//! [sol_in:        u64 LE]
+//! [min_etf_out:   u64 LE]
+//! [name_len:      u8]   [name: bytes]
+//! [leg_count:     u8]   (must equal etf.token_count, <= 3)
+//! per leg:
+//!   [leg_sol_amount: u64 LE]
+//!   [route_len:      u32 LE]
+//!   [route_bytes:    route_len bytes — opaque to axis-vault]
+//! ```
+
+use pinocchio::{
+    account_info::AccountInfo, pubkey::Pubkey, ProgramResult,
+};
+
+use crate::error::VaultError;
+
+/// Max basket size the on-chain SOL ixes will accept. Larger baskets
+/// should route through `scripts/axis-vault/deposit-sol.ts`.
+pub const MAX_ONCHAIN_SOL_IX_LEGS: u8 = 3;
+
+/// DepositSol — see module docs.
+///
+/// This body is a placeholder. It performs basic parameter validation
+/// so clients can integrate against the interface, then returns
+/// `NotYetImplemented` until the Jupiter CPI body lands in a follow-up.
+pub fn process_deposit_sol(
+    _program_id: &Pubkey,
+    _accounts: &[AccountInfo],
+    sol_in: u64,
+    _min_etf_out: u64,
+    _name: &[u8],
+    leg_count: u8,
+) -> ProgramResult {
+    if sol_in == 0 {
+        return Err(VaultError::ZeroDeposit.into());
+    }
+    if leg_count == 0 || leg_count > MAX_ONCHAIN_SOL_IX_LEGS {
+        return Err(VaultError::BasketTooLargeForOnchainSol.into());
+    }
+
+    // TODO(#36, followup after design review):
+    //   1. Wrap sol_in lamports into wsol_ata via SystemTransfer + sync_native.
+    //   2. For each leg i:
+    //      - Invoke Jupiter V6 CPI with route_bytes[i] swapping
+    //        leg_sol_amount[i] wSOL -> basket_mint[i].
+    //      - Jupiter writes to the declared destination ATA; we verify
+    //        vault_i balance delta matches the per-leg otherAmountThreshold
+    //        embedded in route_bytes[i].
+    //   3. Compute mint_amount via existing proportional math (same
+    //      formula as Deposit, shared via a helper).
+    //   4. Enforce mint_amount >= min_etf_out (strict on-chain).
+    //   5. Mint etf tokens net of 30-bps fee; fee goes to treasury_etf_ata.
+    //   6. Write back total_supply.
+
+    Err(VaultError::NotYetImplemented.into())
+}

--- a/contracts/axis-vault/src/instructions/mod.rs
+++ b/contracts/axis-vault/src/instructions/mod.rs
@@ -1,11 +1,15 @@
 pub mod create_etf;
 pub mod deposit;
+pub mod deposit_sol;
 pub mod set_paused;
 pub mod sweep_treasury;
 pub mod withdraw;
+pub mod withdraw_sol;
 
 pub use create_etf::process_create_etf;
 pub use deposit::process_deposit;
+pub use deposit_sol::process_deposit_sol;
 pub use set_paused::process_set_paused;
 pub use sweep_treasury::process_sweep_treasury;
 pub use withdraw::process_withdraw;
+pub use withdraw_sol::process_withdraw_sol;

--- a/contracts/axis-vault/src/instructions/withdraw_sol.rs
+++ b/contracts/axis-vault/src/instructions/withdraw_sol.rs
@@ -1,0 +1,76 @@
+//! WithdrawSol — SOL-out variant of Withdraw. Issue #36.
+//!
+//! # Status: SCAFFOLDING
+//!
+//! Dispatcher hook + account layout + parameter validation. Jupiter CPI
+//! body returns `VaultError::NotYetImplemented` pending design review
+//! on PR #58 (the sibling DepositSol scaffold).
+//!
+//! # Account layout (design target)
+//!
+//! ```text
+//! 0: [signer]            withdrawer
+//! 1: [writable]          etf_state PDA
+//! 2: [writable]          etf_mint
+//! 3: [writable]          withdrawer_etf_ata (burned)
+//! 4: []                  token_program
+//! 5: [writable]          treasury_etf_ata (fee recipient)
+//! 6: [writable]          wsol_ata (withdrawer-owned, temporary)
+//! 7: []                  wsol_mint
+//! 8: []                  jupiter_program
+//! 9: []                  system_program
+//! 10..10+tc: [writable]  per-leg basket vaults
+//! 11+tc..: variable       per-leg Jupiter route accounts
+//! ```
+//!
+//! # Instruction data (design target)
+//!
+//! ```text
+//! [burn_amount:   u64 LE]
+//! [min_sol_out:   u64 LE]
+//! [name_len:      u8]   [name: bytes]
+//! [leg_count:     u8]   (must equal etf.token_count, <= 3)
+//! per leg:
+//!   [route_len:   u32 LE]
+//!   [route_bytes: route_len bytes]
+//! ```
+//!
+//! (No per-leg amount needed on Withdraw — the amount is derived from
+//! the burn's proportional basket share.)
+
+use pinocchio::{
+    account_info::AccountInfo, pubkey::Pubkey, ProgramResult,
+};
+
+use crate::error::VaultError;
+use crate::instructions::deposit_sol::MAX_ONCHAIN_SOL_IX_LEGS;
+
+pub fn process_withdraw_sol(
+    _program_id: &Pubkey,
+    _accounts: &[AccountInfo],
+    burn_amount: u64,
+    _min_sol_out: u64,
+    _name: &[u8],
+    leg_count: u8,
+) -> ProgramResult {
+    if burn_amount == 0 {
+        return Err(VaultError::ZeroDeposit.into());
+    }
+    if leg_count == 0 || leg_count > MAX_ONCHAIN_SOL_IX_LEGS {
+        return Err(VaultError::BasketTooLargeForOnchainSol.into());
+    }
+
+    // TODO(#36, followup after design review):
+    //   1. Compute per-vault basket amounts from burn share (existing
+    //      Withdraw math).
+    //   2. Burn etf tokens + mint fee to treasury (existing Withdraw
+    //      accounting).
+    //   3. For each leg i:
+    //      - Invoke Jupiter V6 CPI with route_bytes[i] swapping
+    //        basket_out[i] -> wSOL.
+    //      - Jupiter writes into wsol_ata; accumulate total_wsol_out.
+    //   4. Enforce total_wsol_out >= min_sol_out (strict on-chain).
+    //   5. sync_native + close wsol_ata -> withdrawer (SOL to user).
+
+    Err(VaultError::NotYetImplemented.into())
+}

--- a/contracts/axis-vault/src/lib.rs
+++ b/contracts/axis-vault/src/lib.rs
@@ -32,8 +32,13 @@ enum Instruction {
     Withdraw = 2,
     SweepTreasury = 3,
     /// SetPaused — authority-gated flip of the `paused` flag (#33).
-    /// Unblocks the paused-pool e2e scenarios kidney flagged.
     SetPaused = 4,
+    /// DepositSol — SOL-in variant with on-chain Jupiter CPI + strict
+    /// slippage gate. Scaffolding only — returns NotYetImplemented
+    /// until the follow-up design review (#36).
+    DepositSol = 5,
+    /// WithdrawSol — SOL-out variant, same status as DepositSol.
+    WithdrawSol = 6,
 }
 
 impl Instruction {
@@ -44,6 +49,8 @@ impl Instruction {
             2 => Some(Instruction::Withdraw),
             3 => Some(Instruction::SweepTreasury),
             4 => Some(Instruction::SetPaused),
+            5 => Some(Instruction::DepositSol),
+            6 => Some(Instruction::WithdrawSol),
             _ => None,
         }
     }
@@ -175,6 +182,56 @@ pub fn process_instruction(
                 return Err(ProgramError::InvalidInstructionData);
             }
             instructions::process_set_paused(program_id, accounts, data[0])
+        }
+
+        Instruction::DepositSol => {
+            // Data: [sol_in: u64][min_etf_out: u64][name_len: u8][name]
+            //       [leg_count: u8][per-leg routes: variable]
+            if data.len() < 18 {
+                return Err(ProgramError::InvalidInstructionData);
+            }
+            let sol_in = u64::from_le_bytes([
+                data[0], data[1], data[2], data[3],
+                data[4], data[5], data[6], data[7],
+            ]);
+            let min_etf_out = u64::from_le_bytes([
+                data[8], data[9], data[10], data[11],
+                data[12], data[13], data[14], data[15],
+            ]);
+            let name_len = data[16] as usize;
+            if data.len() < 17 + name_len + 1 {
+                return Err(ProgramError::InvalidInstructionData);
+            }
+            let name = &data[17..17 + name_len];
+            let leg_count = data[17 + name_len];
+            instructions::process_deposit_sol(
+                program_id, accounts, sol_in, min_etf_out, name, leg_count,
+            )
+        }
+
+        Instruction::WithdrawSol => {
+            // Data: [burn_amount: u64][min_sol_out: u64][name_len: u8][name]
+            //       [leg_count: u8][per-leg routes: variable]
+            if data.len() < 18 {
+                return Err(ProgramError::InvalidInstructionData);
+            }
+            let burn_amount = u64::from_le_bytes([
+                data[0], data[1], data[2], data[3],
+                data[4], data[5], data[6], data[7],
+            ]);
+            let min_sol_out = u64::from_le_bytes([
+                data[8], data[9], data[10], data[11],
+                data[12], data[13], data[14], data[15],
+            ]);
+            let name_len = data[16] as usize;
+            if data.len() < 17 + name_len + 1 {
+                return Err(ProgramError::InvalidInstructionData);
+            }
+            let name = &data[17..17 + name_len];
+            let leg_count = data[17 + name_len];
+            instructions::process_withdraw_sol(
+                program_id, accounts, burn_amount, min_sol_out, name, leg_count,
+            )
         }
     }
 }


### PR DESCRIPTION
## Status: DRAFT — seeking design review before Jupiter CPI body lands

Opens the on-chain SOL-in / SOL-out interface so downstream clients can start integrating, while the Jupiter CPI body goes through design review.

## What ships now

Two new instructions (disc 5 + 6) wired into the dispatcher with the full account layout + ix-data format documented inline.

**Parameter-validation guards (live + tested):**

| Condition | Error |
|-----------|-------|
| `sol_in` / `burn_amount` == 0 | `ZeroDeposit (9004)` |
| `leg_count == 0` or `> 3` | `BasketTooLargeForOnchainSol (9025)` |
| otherwise | `NotYetImplemented (9024)` |

Two new error codes in `VaultError`:
- `NotYetImplemented = 9024` (scaffolding placeholder)
- `BasketTooLargeForOnchainSol = 9025` (tc > 3 → client-bundled flow)

The placeholder body intentionally returns `NotYetImplemented`. Real Jupiter CPI implementation is a follow-up after sign-off.

## Why `tc <= 3`

PR #42's author ran the numbers and deferred on-chain SOL ixes because of three structural walls:

| Constraint | 2-3 leg | 5 leg |
|------------|---------|-------|
| Account-list envelope | fits with ALT | exceeds |
| CU budget (200-400k per Jupiter swap) | 400-1.2M under 1.4M cap | 1.0-2.0M straddles cap |
| Testability | mainnet-fork required either way | same |

At `tc <= 3` all three walls are manageable. Larger baskets explicitly reject with a pointer at `scripts/axis-vault/deposit-sol.ts`.

## What the follow-up PR will do

Documented as TODOs in the placeholder bodies:

```
1. Wrap sol_in lamports into wsol_ata via SystemTransfer + sync_native.
2. For each leg i:
   - Invoke Jupiter V6 CPI with route_bytes[i] swapping
     leg_sol_amount[i] wSOL -> basket_mint[i].
   - Jupiter writes to the declared destination ATA; verify
     vault_i balance delta matches per-leg otherAmountThreshold.
3. Compute mint_amount via existing proportional math (shared helper).
4. Enforce mint_amount >= min_etf_out (strict on-chain).
5. Mint etf tokens net of 30-bps fee; fee -> treasury_etf_ata.
6. Write back total_supply.
```

The interface + guards locked down here won't change.

## Account layout (design target)

```
0: [signer, writable]  depositor (pays SOL)
1: [writable]          etf_state PDA
2: [writable]          etf_mint
3: [writable]          depositor_etf_ata
4: []                  token_program
5: [writable]          treasury_etf_ata
6: [writable]          wsol_ata (depositor-owned, holds wrapped SOL)
7: []                  wsol_mint
8: []                  jupiter_program
9: []                  system_program
10..10+tc: [writable]  per-leg basket vaults
11+tc..: variable       per-leg Jupiter route accounts
```

## Instruction data (design target)

```
[sol_in:        u64 LE]
[min_etf_out:   u64 LE]
[name_len:      u8]   [name: bytes]
[leg_count:     u8]   (<= 3)
per leg:
  [leg_sol_amount: u64 LE]
  [route_len:      u32 LE]
  [route_bytes:    route_len bytes — opaque to axis-vault]
```

## Tests

`tests/axis_vault_sol_ix_scaffold.rs` — 6 tests:

| Test | Asserts |
|------|---------|
| `deposit_sol_rejects_zero_amount` | `sol_in = 0 → ZeroDeposit (9004)` |
| `deposit_sol_rejects_basket_too_large` | `leg_count = 4 → BasketTooLargeForOnchainSol (9025)` |
| `deposit_sol_placeholder_returns_not_yet_implemented` | valid params → `NotYetImplemented (9024)` |
| `withdraw_sol_rejects_zero_amount` | `burn_amount = 0 → ZeroDeposit (9004)` |
| `withdraw_sol_rejects_basket_too_large` | `leg_count = 5 → BasketTooLargeForOnchainSol (9025)` |
| `withdraw_sol_placeholder_returns_not_yet_implemented` | valid params → `NotYetImplemented (9024)` |

Wired into the A/B Test Suite workflow. Any future regression on the dispatcher, the parameter guards, or the basket-size cap fires.

## Design questions for @muse0509 / @kidneyweakx

1. **tc <= 3 cap: right threshold?** At tc = 3 the per-leg Jupiter CPI leaves ~300k CU for the axis-vault post-CPI mint math + sanity checks. Tighter would be safer; looser risks hitting the 1.4M cap under unusual routes.
2. **wSOL handling:** scaffold assumes a depositor-owned `wsol_ata`. Alternative: the ix creates + closes the wSOL ATA inline so the caller doesn't have to manage it. More CU but cleaner UX.
3. **Fee path for `WithdrawSol`:** today's `Withdraw` transfers the fee as ETF tokens to `treasury_etf_ata`. `WithdrawSol` could either (a) mirror that, or (b) deduct from the SOL output and send SOL to treasury directly. (a) is consistent with the existing sweep flow; (b) is simpler to reason about per tx.

Happy to rework based on either direction.

## Test plan

- [x] `cargo build --manifest-path contracts/axis-vault/Cargo.toml` — clean
- [x] `cargo build-sbf --manifest-path contracts/axis-vault/Cargo.toml` — clean
- [x] `cargo test --test axis_vault_sol_ix_scaffold` — 6 / 6 pass
- [ ] Design review from @muse0509 / @kidneyweakx
- [ ] Follow-up PR implementing the Jupiter CPI body

## Stacks

On top of `test/issue-33-really-finish-it` (PR #56) so the scaffold tests can reuse the `axis_vault_id()` / `token_program_id()` helpers from `svm_setup.rs` + `token_factory.rs`. No conflicts expected.