### PR TITLE
fix(issue-59): close three P0/P1 mainnet blockers

### DIFF
--- a/contracts/ab-integration-tests/Cargo.toml
+++ b/contracts/ab-integration-tests/Cargo.toml
@@ -35,6 +35,10 @@ path = "tests/pfda3_claim_coverage.rs"
 name = "axis_vault_coverage"
 path = "tests/axis_vault_coverage.rs"
 
+[[test]]
+name = "issue_59_coverage"
+path = "tests/issue_59_coverage.rs"
+
 [dependencies]
 litesvm = "0.11"
 solana-keypair = "3.1"

--- a/contracts/ab-integration-tests/tests/issue_59_coverage.rs
+++ b/contracts/ab-integration-tests/tests/issue_59_coverage.rs
@@ -1,0 +1,706 @@
+//! #59 mainnet-blocker regression coverage.
+//!
+//! Locks down the three code fixes in PR "fix/issue-59-mainnet-blockers":
+//!
+//!   1. [P0] pfda-amm-3 `SwapRequest` rejects a token account of the
+//!      right mint but wrong key (`VaultMismatch` = 8025). Pre-fix the
+//!      instruction only checked the mint, so a cranker could pass in a
+//!      user-owned token account and user tokens would be Transfer'd
+//!      there while the batch queue still incremented.
+//!
+//!   2. [P0] pfda-amm-3 `Claim` rejects the same spoof. The check has
+//!      been present since PR #3 but #59 flagged it as a possible gap;
+//!      we cover it explicitly so any regression is caught.
+//!
+//!   3. [P1] pfda-amm `ClearBatch` rejects a non-authority bid
+//!      recipient (`TreasuryMismatch` = 6023) and a missing bid
+//!      recipient when `bid_lamports > 0` (`BidWithoutTreasury` = 6024).
+//!      Pre-fix, account[8] was Transfer'd to without any check.
+//!
+//!   4. [P1] pfda-amm-3 `SetPaused` (new disc=6): authority-gated flip
+//!      of `pool.paused`. Without this ix the byte was dead after
+//!      deploy.
+//!
+//!   5. [P1] axis-g3m `SetPaused` (new disc=5): same shape.
+
+use ab_integration_tests::helpers::{account_builder::*, svm_setup::*, token_factory::*};
+use ab_integration_tests::require_fixture;
+use litesvm::LiteSVM;
+use solana_account::Account;
+use solana_address::Address;
+use solana_instruction::{account_meta::AccountMeta, Instruction};
+use solana_keypair::Keypair;
+use solana_native_token::LAMPORTS_PER_SOL;
+use solana_signer::Signer;
+use solana_transaction::Transaction;
+
+// ─── error codes (mirror program error enums) ───────────────────────────
+const PFDA_ERR_TREASURY_MISMATCH: u32 = 6023;
+const PFDA_ERR_BID_WITHOUT_TREASURY: u32 = 6024;
+const PFDA3_ERR_VAULT_MISMATCH: u32 = 8025;
+const PFDA3_ERR_UNAUTHORIZED: u32 = 8035;
+const G3M_ERR_UNAUTHORIZED: u32 = 7020;
+
+// ─── common tx helpers ──────────────────────────────────────────────────
+fn send(svm: &mut LiteSVM, ix: Instruction, payer: &Keypair) -> Result<u64, String> {
+    let tx = Transaction::new_signed_with_payer(
+        &[ix],
+        Some(&payer.pubkey()),
+        &[payer],
+        svm.latest_blockhash(),
+    );
+    match svm.send_transaction(tx) {
+        Ok(meta) => Ok(meta.compute_units_consumed),
+        Err(e) => {
+            let mut msg = format!("{:?}", e.err);
+            for log in &e.meta.logs {
+                msg.push_str(&format!("\n  {}", log));
+            }
+            Err(msg)
+        }
+    }
+}
+
+fn send_signed_by(
+    svm: &mut LiteSVM,
+    ix: Instruction,
+    payer: &Keypair,
+    signer: &Keypair,
+) -> Result<u64, String> {
+    let tx = Transaction::new_signed_with_payer(
+        &[ix],
+        Some(&payer.pubkey()),
+        &[payer, signer],
+        svm.latest_blockhash(),
+    );
+    match svm.send_transaction(tx) {
+        Ok(meta) => Ok(meta.compute_units_consumed),
+        Err(e) => {
+            let mut msg = format!("{:?}", e.err);
+            for log in &e.meta.logs {
+                msg.push_str(&format!("\n  {}", log));
+            }
+            Err(msg)
+        }
+    }
+}
+
+fn assert_custom_err(err: &str, code: u32, label: &str) {
+    let hex = format!("0x{:x}", code);
+    let custom = format!("Custom({})", code);
+    assert!(
+        err.contains(&hex) || err.contains(&custom),
+        "{label}: expected {code} ({hex}), got: {err}"
+    );
+}
+
+// ─── pfda-amm-3 SwapRequest vault-key spoofing ─────────────────────────
+
+struct Pfda3Fixture {
+    svm: LiteSVM,
+    payer: Keypair,
+    pool: Address,
+    mints: [Address; 3],
+    vaults: [Address; 3],
+    user_tokens: [Address; 3],
+}
+
+fn seed_pfda3_pool() -> Option<Pfda3Fixture> {
+    let mut svm = LiteSVM::new();
+    if !std::path::Path::new(PFDA_AMM_3_SO).exists() {
+        eprintln!("SKIP: pfda_amm_3.so fixture missing");
+        return None;
+    }
+    svm.add_program_from_file(pfda3_id(), PFDA_AMM_3_SO).ok()?;
+
+    let payer = Keypair::new();
+    svm.airdrop(&payer.pubkey(), 100 * LAMPORTS_PER_SOL).unwrap();
+
+    let mints = [Address::new_unique(), Address::new_unique(), Address::new_unique()];
+    for &m in &mints {
+        create_mint(&mut svm, m, &payer.pubkey(), 6);
+    }
+
+    let (pool, pool_bump) = Address::find_program_address(
+        &[b"pool3", mints[0].as_ref(), mints[1].as_ref(), mints[2].as_ref()],
+        &pfda3_id(),
+    );
+
+    let vaults = [Address::new_unique(), Address::new_unique(), Address::new_unique()];
+    let user_tokens = [Address::new_unique(), Address::new_unique(), Address::new_unique()];
+    for i in 0..3 {
+        create_token_account(&mut svm, vaults[i], &mints[i], &pool, 1_000_000);
+        create_token_account(&mut svm, user_tokens[i], &mints[i], &payer.pubkey(), 1_000_000_000);
+    }
+
+    let treasury = Address::new_unique();
+    let pd = build_pfda3_pool_state(
+        &mints,
+        &vaults,
+        &[1_000_000; 3],
+        &[333_333, 333_333, 333_334],
+        10,
+        0,
+        100,
+        &treasury,
+        &payer.pubkey(),
+        30,
+        pool_bump,
+    );
+    svm.set_account(
+        pool,
+        Account {
+            lamports: LAMPORTS_PER_SOL,
+            data: pd,
+            owner: pfda3_id(),
+            executable: false,
+            rent_epoch: 0,
+        },
+    )
+    .unwrap();
+
+    Some(Pfda3Fixture { svm, payer, pool, mints, vaults, user_tokens })
+}
+
+fn pfda3_swap_request_ix(
+    user: Address,
+    pool: Address,
+    queue: Address,
+    ticket: Address,
+    user_token: Address,
+    vault: Address,
+) -> Instruction {
+    let mut data = vec![1u8];
+    data.push(0u8); // in_idx
+    data.extend_from_slice(&100u64.to_le_bytes()); // amount_in
+    data.push(1u8); // out_idx
+    data.extend_from_slice(&0u64.to_le_bytes()); // min_out
+    Instruction {
+        program_id: pfda3_id(),
+        accounts: vec![
+            AccountMeta::new(user, true),
+            AccountMeta::new_readonly(pool, false),
+            AccountMeta::new(queue, false),
+            AccountMeta::new(ticket, false),
+            AccountMeta::new(user_token, false),
+            AccountMeta::new(vault, false),
+            AccountMeta::new_readonly(token_program_id(), false),
+            AccountMeta::new_readonly(system_program_id(), false),
+        ],
+        data,
+    }
+}
+
+fn seed_batch_queue_pfda3(svm: &mut LiteSVM, pool: Address, batch_id: u64, window_end: u64) -> Address {
+    let (queue, qbump) = Address::find_program_address(
+        &[b"queue3", pool.as_ref(), &batch_id.to_le_bytes()],
+        &pfda3_id(),
+    );
+    let qd = build_batch_queue_3(&pool, batch_id, &[0; 3], window_end, qbump);
+    svm.set_account(
+        queue,
+        Account {
+            lamports: LAMPORTS_PER_SOL,
+            data: qd,
+            owner: pfda3_id(),
+            executable: false,
+            rent_epoch: 0,
+        },
+    )
+    .unwrap();
+    queue
+}
+
+#[test]
+fn pfda3_swap_request_rejects_spoofed_vault_key() {
+    require_fixture!(PFDA_AMM_3_SO);
+    let Pfda3Fixture { mut svm, payer, pool, mints, vaults: _, user_tokens } =
+        match seed_pfda3_pool() { Some(f) => f, None => return };
+
+    let queue = seed_batch_queue_pfda3(&mut svm, pool, 0, 100);
+    let (ticket, _) = Address::find_program_address(
+        &[b"ticket3", pool.as_ref(), payer.pubkey().as_ref(), &0u64.to_le_bytes()],
+        &pfda3_id(),
+    );
+
+    // Rogue token account: same mint as vaults[0], pool-owned, but NOT
+    // the vault registered on PoolState3. Pre-fix, the mint-only check
+    // in SwapRequest would have accepted this and Transfer'd tokens to
+    // the attacker. Post-fix we reject with VaultMismatch.
+    let rogue = Address::new_unique();
+    create_token_account(&mut svm, rogue, &mints[0], &pool, 0);
+
+    let err = send(
+        &mut svm,
+        pfda3_swap_request_ix(
+            payer.pubkey(), pool, queue, ticket,
+            user_tokens[0], rogue,
+        ),
+        &payer,
+    )
+    .err()
+    .expect("spoofed vault key must be rejected");
+    assert_custom_err(&err, PFDA3_ERR_VAULT_MISMATCH, "swap_request spoofed vault");
+}
+
+// ─── pfda-amm-3 Claim vault-key regression ─────────────────────────────
+//
+// PR #47 already covers this; #59 asked us to verify the guard is
+// genuinely exercised.
+
+fn pfda3_claim_ix(
+    user: Address,
+    pool: Address,
+    history: Address,
+    ticket: Address,
+    vaults: &[Address; 3],
+    user_tokens: &[Address; 3],
+) -> Instruction {
+    Instruction {
+        program_id: pfda3_id(),
+        accounts: vec![
+            AccountMeta::new_readonly(user, true),
+            AccountMeta::new(pool, false),
+            AccountMeta::new_readonly(history, false),
+            AccountMeta::new(ticket, false),
+            AccountMeta::new(vaults[0], false),
+            AccountMeta::new(vaults[1], false),
+            AccountMeta::new(vaults[2], false),
+            AccountMeta::new(user_tokens[0], false),
+            AccountMeta::new(user_tokens[1], false),
+            AccountMeta::new(user_tokens[2], false),
+            AccountMeta::new_readonly(token_program_id(), false),
+        ],
+        data: vec![3u8],
+    }
+}
+
+#[test]
+fn pfda3_claim_rejects_spoofed_vault_key() {
+    require_fixture!(PFDA_AMM_3_SO);
+    let Pfda3Fixture { mut svm, payer, pool, mints, vaults, user_tokens } =
+        match seed_pfda3_pool() { Some(f) => f, None => return };
+
+    // Seed a history + ticket so Claim reaches the vault-validation loop.
+    let (hist, hbump) = Address::find_program_address(
+        &[b"history3", pool.as_ref(), &0u64.to_le_bytes()],
+        &pfda3_id(),
+    );
+    let mut hd = vec![0u8; 176];
+    hd[0..8].copy_from_slice(b"chist3\0\0");
+    hd[8..40].copy_from_slice(pool.as_ref());
+    // clearing_prices / total_in / total_out zeroed → Claim's total_in[in_idx]==0
+    // short-circuits to "mark claimed" before any Transfer, but the vault
+    // validation still runs first. Perfect for a negative test.
+    hd[160] = 30; // fee_bps low byte — irrelevant but keeps layout realistic
+    hd[168] = 1;  // is_cleared
+    hd[169] = hbump;
+    svm.set_account(
+        hist,
+        Account {
+            lamports: LAMPORTS_PER_SOL,
+            data: hd,
+            owner: pfda3_id(),
+            executable: false,
+            rent_epoch: 0,
+        },
+    )
+    .unwrap();
+
+    let (ticket, tbump) = Address::find_program_address(
+        &[b"ticket3", pool.as_ref(), payer.pubkey().as_ref(), &0u64.to_le_bytes()],
+        &pfda3_id(),
+    );
+    let mut td = vec![0u8; 80];
+    td[0..8].copy_from_slice(b"tick3\0\0\0");
+    td[8..40].copy_from_slice(payer.pubkey().as_ref());
+    td[40..72].copy_from_slice(pool.as_ref());
+    // batch_id = 0 (already zero)
+    // amounts_in left zero
+    td[72] = 1; // out_token_idx = 1
+    // min_amount_out zero
+    td[78] = tbump;
+    svm.set_account(
+        ticket,
+        Account {
+            lamports: LAMPORTS_PER_SOL,
+            data: td,
+            owner: pfda3_id(),
+            executable: false,
+            rent_epoch: 0,
+        },
+    )
+    .unwrap();
+
+    // Replace vaults[0] with a pool-owned, same-mint token account the
+    // program does NOT have on record. Claim must reject before touching
+    // any token.
+    let rogue = Address::new_unique();
+    create_token_account(&mut svm, rogue, &mints[0], &pool, 0);
+    let bad_vaults = [rogue, vaults[1], vaults[2]];
+
+    let err = send(
+        &mut svm,
+        pfda3_claim_ix(payer.pubkey(), pool, hist, ticket, &bad_vaults, &user_tokens),
+        &payer,
+    )
+    .err()
+    .expect("Claim must reject spoofed vault key");
+    assert_custom_err(&err, PFDA3_ERR_VAULT_MISMATCH, "claim spoofed vault");
+}
+
+// ─── pfda-amm ClearBatch treasury validation ───────────────────────────
+
+struct PfdaFixture {
+    svm: LiteSVM,
+    payer: Keypair,
+    pool: Address,
+}
+
+fn seed_pfda_pool() -> Option<PfdaFixture> {
+    let mut svm = LiteSVM::new();
+    if !std::path::Path::new(PFDA_AMM_SO).exists() {
+        eprintln!("SKIP: pfda_amm.so fixture missing");
+        return None;
+    }
+    svm.add_program_from_file(pfda_amm_id(), PFDA_AMM_SO).ok()?;
+
+    let payer = Keypair::new();
+    svm.airdrop(&payer.pubkey(), 100 * LAMPORTS_PER_SOL).unwrap();
+
+    let mint_a = Address::new_unique();
+    let mint_b = Address::new_unique();
+    create_mint(&mut svm, mint_a, &payer.pubkey(), 6);
+    create_mint(&mut svm, mint_b, &payer.pubkey(), 6);
+
+    let (pool, bump) = Address::find_program_address(
+        &[b"pool", mint_a.as_ref(), mint_b.as_ref()],
+        &pfda_amm_id(),
+    );
+
+    let vault_a = Address::new_unique();
+    let vault_b = Address::new_unique();
+    create_token_account(&mut svm, vault_a, &mint_a, &pool, 1_000_000);
+    create_token_account(&mut svm, vault_b, &mint_b, &pool, 1_000_000);
+
+    let pd = build_pfda_pool_state(
+        &mint_a, &mint_b, &vault_a, &vault_b,
+        1_000_000, 1_000_000, 500_000,
+        10, 0, 0, // current_window_end = 0 so BatchWindowNotEnded doesn't block
+        30, &payer.pubkey(), bump,
+    );
+    svm.set_account(
+        pool,
+        Account {
+            lamports: LAMPORTS_PER_SOL,
+            data: pd,
+            owner: pfda_amm_id(),
+            executable: false,
+            rent_epoch: 0,
+        },
+    )
+    .unwrap();
+
+    Some(PfdaFixture { svm, payer, pool })
+}
+
+fn pfda_clear_batch_ix(
+    cranker: Address,
+    pool: Address,
+    batch_queue: Address,
+    history: Address,
+    new_queue: Address,
+    bid_lamports: u64,
+    treasury: Option<Address>,
+) -> Instruction {
+    let mut accounts = vec![
+        AccountMeta::new(cranker, true),
+        AccountMeta::new(pool, false),
+        AccountMeta::new(batch_queue, false),
+        AccountMeta::new(history, false),
+        AccountMeta::new(new_queue, false),
+        AccountMeta::new_readonly(system_program_id(), false),
+        AccountMeta::new_readonly(Address::new_unique(), false), // oracle placeholder 6
+        AccountMeta::new_readonly(Address::new_unique(), false), // oracle placeholder 7
+    ];
+    if let Some(t) = treasury {
+        accounts.push(AccountMeta::new(t, false));
+    }
+    let mut data = vec![2u8];
+    data.extend_from_slice(&bid_lamports.to_le_bytes());
+    Instruction {
+        program_id: pfda_amm_id(),
+        accounts,
+        data,
+    }
+}
+
+fn seed_pfda_batch_queue(svm: &mut LiteSVM, pool: Address, batch_id: u64, window_end: u64) -> Address {
+    let (queue, bump) = Address::find_program_address(
+        &[b"queue", pool.as_ref(), &batch_id.to_le_bytes()],
+        &pfda_amm_id(),
+    );
+    let qd = build_batch_queue(&pool, batch_id, 0, 0, window_end, bump);
+    svm.set_account(
+        queue,
+        Account {
+            lamports: LAMPORTS_PER_SOL,
+            data: qd,
+            owner: pfda_amm_id(),
+            executable: false,
+            rent_epoch: 0,
+        },
+    )
+    .unwrap();
+    queue
+}
+
+#[test]
+fn pfda_clear_batch_rejects_bid_to_wrong_treasury() {
+    require_fixture!(PFDA_AMM_SO);
+    let PfdaFixture { mut svm, payer, pool } =
+        match seed_pfda_pool() { Some(f) => f, None => return };
+
+    let queue = seed_pfda_batch_queue(&mut svm, pool, 0, 0);
+    let (hist, _) = Address::find_program_address(
+        &[b"history", pool.as_ref(), &0u64.to_le_bytes()],
+        &pfda_amm_id(),
+    );
+    let (new_queue, _) = Address::find_program_address(
+        &[b"queue", pool.as_ref(), &1u64.to_le_bytes()],
+        &pfda_amm_id(),
+    );
+
+    // Rogue treasury — not the pool.authority. Pre-fix this would have
+    // happily received the Transfer; post-fix we reject.
+    let rogue = Address::new_unique();
+    svm.airdrop(&rogue, LAMPORTS_PER_SOL).unwrap();
+
+    let err = send(
+        &mut svm,
+        pfda_clear_batch_ix(
+            payer.pubkey(), pool, queue, hist, new_queue,
+            2_000_000, Some(rogue),
+        ),
+        &payer,
+    )
+    .err()
+    .expect("bid to wrong treasury must be rejected");
+    assert_custom_err(&err, PFDA_ERR_TREASURY_MISMATCH, "wrong treasury");
+}
+
+#[test]
+fn pfda_clear_batch_rejects_bid_without_treasury_account() {
+    require_fixture!(PFDA_AMM_SO);
+    let PfdaFixture { mut svm, payer, pool, .. } =
+        match seed_pfda_pool() { Some(f) => f, None => return };
+
+    let queue = seed_pfda_batch_queue(&mut svm, pool, 0, 0);
+    let (hist, _) = Address::find_program_address(
+        &[b"history", pool.as_ref(), &0u64.to_le_bytes()],
+        &pfda_amm_id(),
+    );
+    let (new_queue, _) = Address::find_program_address(
+        &[b"queue", pool.as_ref(), &1u64.to_le_bytes()],
+        &pfda_amm_id(),
+    );
+
+    let err = send(
+        &mut svm,
+        pfda_clear_batch_ix(
+            payer.pubkey(), pool, queue, hist, new_queue,
+            2_000_000, None, // no treasury supplied
+        ),
+        &payer,
+    )
+    .err()
+    .expect("bid without treasury account must be rejected");
+    assert_custom_err(&err, PFDA_ERR_BID_WITHOUT_TREASURY, "missing treasury");
+}
+
+// ─── pfda-amm-3 SetPaused ──────────────────────────────────────────────
+
+fn pfda3_set_paused_ix(authority: Address, pool: Address, paused: u8) -> Instruction {
+    Instruction {
+        program_id: pfda3_id(),
+        accounts: vec![
+            AccountMeta::new_readonly(authority, true),
+            AccountMeta::new(pool, false),
+        ],
+        data: vec![6u8, paused],
+    }
+}
+
+#[test]
+fn pfda3_set_paused_authority_toggles_flag() {
+    require_fixture!(PFDA_AMM_3_SO);
+    let Pfda3Fixture { mut svm, payer, pool, .. } =
+        match seed_pfda3_pool() { Some(f) => f, None => return };
+
+    // pre: paused byte is 0
+    let before = svm.get_account(&pool).unwrap().data[332];
+    assert_eq!(before, 0, "pool starts unpaused");
+
+    send(
+        &mut svm,
+        pfda3_set_paused_ix(payer.pubkey(), pool, 1),
+        &payer,
+    )
+    .expect("authority-signed SetPaused should succeed");
+
+    let after = svm.get_account(&pool).unwrap().data[332];
+    assert_eq!(after, 1, "pool.paused set to 1");
+
+    // and back
+    send(
+        &mut svm,
+        pfda3_set_paused_ix(payer.pubkey(), pool, 0),
+        &payer,
+    )
+    .expect("authority can clear the pause");
+    assert_eq!(svm.get_account(&pool).unwrap().data[332], 0);
+}
+
+#[test]
+fn pfda3_set_paused_rejects_non_authority() {
+    require_fixture!(PFDA_AMM_3_SO);
+    let Pfda3Fixture { mut svm, payer, pool, .. } =
+        match seed_pfda3_pool() { Some(f) => f, None => return };
+
+    let intruder = Keypair::new();
+    svm.airdrop(&intruder.pubkey(), LAMPORTS_PER_SOL).unwrap();
+
+    let err = send_signed_by(
+        &mut svm,
+        pfda3_set_paused_ix(intruder.pubkey(), pool, 1),
+        &payer,
+        &intruder,
+    )
+    .err()
+    .expect("non-authority SetPaused must reject");
+    assert_custom_err(&err, PFDA3_ERR_UNAUTHORIZED, "non-authority");
+    assert_eq!(svm.get_account(&pool).unwrap().data[332], 0, "pool not paused");
+}
+
+// ─── axis-g3m SetPaused ────────────────────────────────────────────────
+
+struct G3mFixture {
+    svm: LiteSVM,
+    payer: Keypair,
+    pool: Address,
+    paused_offset: usize,
+}
+
+fn seed_g3m_pool() -> Option<G3mFixture> {
+    let mut svm = LiteSVM::new();
+    if !std::path::Path::new(AXIS_G3M_SO).exists() {
+        eprintln!("SKIP: axis_g3m.so fixture missing");
+        return None;
+    }
+    svm.add_program_from_file(axis_g3m_id(), AXIS_G3M_SO).ok()?;
+
+    let payer = Keypair::new();
+    svm.airdrop(&payer.pubkey(), 100 * LAMPORTS_PER_SOL).unwrap();
+
+    let mint_a = Address::new_unique();
+    let mint_b = Address::new_unique();
+    create_mint(&mut svm, mint_a, &payer.pubkey(), 6);
+    create_mint(&mut svm, mint_b, &payer.pubkey(), 6);
+
+    let pool = Address::new_unique();
+    let vault_a = Address::new_unique();
+    let vault_b = Address::new_unique();
+    create_token_account(&mut svm, vault_a, &mint_a, &pool, 1_000_000);
+    create_token_account(&mut svm, vault_b, &mint_b, &pool, 1_000_000);
+
+    let pd = build_g3m_pool_state(
+        &payer.pubkey(),
+        2,
+        &[mint_a, mint_b],
+        &[vault_a, vault_b],
+        &[5000, 5000],
+        &[10_000_000, 10_000_000],
+        100,
+        500,
+        0,
+        255,
+    );
+    // G3m paused offset: per axis_g3m_coverage.rs set_paused helper,
+    // the total size is 464 and paused sits at offset len-8 (= 456).
+    // After build_g3m_pool_state (455 bytes), LiteSVM writes the account
+    // with the given data length — we pad to the full 464 to match the
+    // program's on-disk size.
+    let mut padded = pd;
+    padded.resize(464, 0);
+    let paused_offset = padded.len() - 8;
+
+    svm.set_account(
+        pool,
+        Account {
+            lamports: LAMPORTS_PER_SOL,
+            data: padded,
+            owner: axis_g3m_id(),
+            executable: false,
+            rent_epoch: 0,
+        },
+    )
+    .unwrap();
+
+    Some(G3mFixture { svm, payer, pool, paused_offset })
+}
+
+fn g3m_set_paused_ix(authority: Address, pool: Address, paused: u8) -> Instruction {
+    Instruction {
+        program_id: axis_g3m_id(),
+        accounts: vec![
+            AccountMeta::new_readonly(authority, true),
+            AccountMeta::new(pool, false),
+        ],
+        data: vec![5u8, paused],
+    }
+}
+
+#[test]
+fn g3m_set_paused_authority_toggles_flag() {
+    require_fixture!(AXIS_G3M_SO);
+    let G3mFixture { mut svm, payer, pool, paused_offset } =
+        match seed_g3m_pool() { Some(f) => f, None => return };
+
+    send(
+        &mut svm,
+        g3m_set_paused_ix(payer.pubkey(), pool, 1),
+        &payer,
+    )
+    .expect("authority SetPaused should succeed");
+
+    assert_eq!(svm.get_account(&pool).unwrap().data[paused_offset], 1);
+
+    send(
+        &mut svm,
+        g3m_set_paused_ix(payer.pubkey(), pool, 0),
+        &payer,
+    )
+    .expect("authority can clear pause");
+    assert_eq!(svm.get_account(&pool).unwrap().data[paused_offset], 0);
+}
+
+#[test]
+fn g3m_set_paused_rejects_non_authority() {
+    require_fixture!(AXIS_G3M_SO);
+    let G3mFixture { mut svm, payer, pool, paused_offset } =
+        match seed_g3m_pool() { Some(f) => f, None => return };
+
+    let intruder = Keypair::new();
+    svm.airdrop(&intruder.pubkey(), LAMPORTS_PER_SOL).unwrap();
+
+    let err = send_signed_by(
+        &mut svm,
+        g3m_set_paused_ix(intruder.pubkey(), pool, 1),
+        &payer,
+        &intruder,
+    )
+    .err()
+    .expect("non-authority g3m SetPaused must reject");
+    assert_custom_err(&err, G3M_ERR_UNAUTHORIZED, "non-authority g3m");
+    assert_eq!(svm.get_account(&pool).unwrap().data[paused_offset], 0);
+}

--- a/contracts/axis-g3m/src/instructions/mod.rs
+++ b/contracts/axis-g3m/src/instructions/mod.rs
@@ -2,8 +2,10 @@ pub mod initialize_pool;
 pub mod swap;
 pub mod check_drift;
 pub mod rebalance;
+pub mod set_paused;
 
 pub use initialize_pool::*;
 pub use swap::*;
 pub use check_drift::*;
 pub use rebalance::*;
+pub use set_paused::process_set_paused;

--- a/contracts/axis-g3m/src/instructions/set_paused.rs
+++ b/contracts/axis-g3m/src/instructions/set_paused.rs
@@ -1,0 +1,65 @@
+use pinocchio::{
+    account_info::AccountInfo,
+    program_error::ProgramError,
+    pubkey::Pubkey,
+    ProgramResult,
+};
+
+use crate::error::G3mError;
+use crate::state::G3mPoolState;
+
+/// SetPaused — authority-gated toggle of `pool.paused` on an axis-g3m
+/// pool (#59). The pool already carries a `paused` byte used by Swap /
+/// Rebalance to short-circuit during outages; without this ix there
+/// was no way to flip it post-deploy.
+///
+/// Accounts:
+///   0: [signer]   authority (must equal pool.authority)
+///   1: [writable] pool PDA
+///
+/// Data: [paused: u8]  (any non-zero value normalizes to 1)
+pub fn process_set_paused(
+    program_id: &Pubkey,
+    accounts: &[AccountInfo],
+    paused: u8,
+) -> ProgramResult {
+    let [authority, pool_ai, ..] = accounts else {
+        return Err(ProgramError::NotEnoughAccountKeys);
+    };
+
+    if !authority.is_signer() {
+        return Err(ProgramError::MissingRequiredSignature);
+    }
+
+    if pool_ai.owner() != program_id {
+        return Err(G3mError::InvalidDiscriminator.into());
+    }
+
+    let stored_authority = {
+        let data = pool_ai.try_borrow_data()?;
+        if data.len() < core::mem::size_of::<G3mPoolState>() {
+            return Err(ProgramError::InvalidAccountData);
+        }
+        let pool = unsafe { &*(data.as_ptr() as *const G3mPoolState) };
+        if !pool.is_initialized() {
+            return Err(G3mError::InvalidDiscriminator.into());
+        }
+        pool.authority
+    };
+
+    if authority.key().as_ref() != &stored_authority {
+        return Err(G3mError::Unauthorized.into());
+    }
+
+    let normalized = if paused == 0 { 0 } else { 1 };
+    {
+        let mut data = pool_ai.try_borrow_mut_data()?;
+        if data.len() < core::mem::size_of::<G3mPoolState>() {
+            return Err(ProgramError::InvalidAccountData);
+        }
+        let pool = unsafe { &mut *(data.as_mut_ptr() as *mut G3mPoolState) };
+        pool.paused = normalized;
+    }
+
+    Ok(())
+}

--- a/contracts/axis-g3m/src/lib.rs
+++ b/contracts/axis-g3m/src/lib.rs
@@ -37,6 +37,10 @@ enum Instruction {
     CheckDrift = 2,
     Rebalance = 3,
     RebalanceViaJupiter = 4,
+    /// #59: authority-gated pause toggle. Mirrors pfda-amm /
+    /// pfda-amm-3 / axis-vault. The `paused` byte on G3mPoolState
+    /// was dead without this ix — no emergency-stop path existed.
+    SetPaused = 5,
 }
 
 impl Instruction {
@@ -47,6 +51,7 @@ impl Instruction {
             2 => Some(Instruction::CheckDrift),
             3 => Some(Instruction::Rebalance),
             4 => Some(Instruction::RebalanceViaJupiter),
+            5 => Some(Instruction::SetPaused),
             _ => None,
         }
     }
@@ -186,6 +191,13 @@ pub fn process_instruction(
             let jupiter_data = &data[4..4 + jup_len];
 
             jupiter::process_rebalance_via_jupiter(program_id, accounts, jupiter_data)
+        }
+
+        Instruction::SetPaused => {
+            if data.is_empty() {
+                return Err(ProgramError::InvalidInstructionData);
+            }
+            instructions::process_set_paused(program_id, accounts, data[0])
         }
     }
 }

--- a/contracts/pfda-amm-3/src/instructions/mod.rs
+++ b/contracts/pfda-amm-3/src/instructions/mod.rs
@@ -4,6 +4,7 @@ pub mod clear_batch;
 pub mod close_batch_history;
 pub mod close_expired_ticket;
 pub mod initialize_pool;
+pub mod set_paused;
 pub mod swap_request;
 pub mod withdraw_fees;
 
@@ -13,5 +14,6 @@ pub use clear_batch::process_clear_batch_3;
 pub use close_batch_history::process_close_batch_history_3;
 pub use close_expired_ticket::process_close_expired_ticket_3;
 pub use initialize_pool::process_initialize_pool_3;
+pub use set_paused::process_set_paused_3;
 pub use swap_request::process_swap_request_3;
 pub use withdraw_fees::process_withdraw_fees;

--- a/contracts/pfda-amm-3/src/instructions/set_paused.rs
+++ b/contracts/pfda-amm-3/src/instructions/set_paused.rs
@@ -1,0 +1,64 @@
+use pinocchio::{
+    account_info::AccountInfo,
+    program_error::ProgramError,
+    pubkey::Pubkey,
+    ProgramResult,
+};
+
+use crate::error::Pfda3Error;
+use crate::state::{load, load_mut, PoolState3};
+
+/// SetPaused3 — flip `pool.paused` on a pfda-amm-3 pool (#59).
+///
+/// Authority-gated: only the account equal to `pool.authority` may call
+/// this. Mirrors the pattern established for axis-vault in PR #51 and
+/// pfda-amm at instruction discriminator 6. Without this ix, a pfda-amm-3
+/// pool that went live could not be emergency-stopped — the `paused`
+/// field existed on PoolState3 but nothing could mutate it.
+///
+/// Accounts:
+///   0: [signer]   authority (must equal pool.authority)
+///   1: [writable] pool_state PDA
+///
+/// Data: [paused: u8]  (any non-zero value normalizes to 1)
+pub fn process_set_paused_3(
+    program_id: &Pubkey,
+    accounts: &[AccountInfo],
+    paused: u8,
+) -> ProgramResult {
+    let [authority, pool_ai, ..] = accounts else {
+        return Err(ProgramError::NotEnoughAccountKeys);
+    };
+
+    if !authority.is_signer() {
+        return Err(ProgramError::MissingRequiredSignature);
+    }
+
+    if pool_ai.owner() != program_id {
+        return Err(Pfda3Error::InvalidDiscriminator.into());
+    }
+
+    let stored_authority = {
+        let data = pool_ai.try_borrow_data()?;
+        let pool = unsafe { load::<PoolState3>(&data) }
+            .ok_or(ProgramError::InvalidAccountData)?;
+        if !pool.is_initialized() {
+            return Err(Pfda3Error::InvalidDiscriminator.into());
+        }
+        pool.authority
+    };
+
+    if authority.key().as_ref() != &stored_authority {
+        return Err(Pfda3Error::Unauthorized.into());
+    }
+
+    let normalized = if paused == 0 { 0 } else { 1 };
+    {
+        let mut data = pool_ai.try_borrow_mut_data()?;
+        let pool = unsafe { load_mut::<PoolState3>(&mut data) }
+            .ok_or(ProgramError::InvalidAccountData)?;
+        pool.paused = normalized;
+    }
+
+    Ok(())
+}

--- a/contracts/pfda-amm-3/src/instructions/swap_request.rs
+++ b/contracts/pfda-amm-3/src/instructions/swap_request.rs
@@ -64,6 +64,16 @@ pub fn process_swap_request_3(
             // the dedicated PoolPaused code instead.
             return Err(Pfda3Error::PoolPaused.into());
         }
+        // #59: previously this only checked the vault mint via
+        // verify_token_account_mint, which left SwapRequest open to
+        // vault-key spoofing — a crafted token account of the right
+        // mint could be passed in as the destination and user tokens
+        // would land there while the batch queue still incremented.
+        // Assert the key equals the pool's stored vault for this token
+        // index before any Transfer runs.
+        if vault.key().as_ref() != &pool.vaults[in_token_idx as usize] {
+            return Err(Pfda3Error::VaultMismatch.into());
+        }
         // Security rule 7: verify vault mint matches pool token
         crate::security::verify_token_account_mint(vault, &pool.token_mints[in_token_idx as usize])?;
         (*pool_ai.key(), pool.current_batch_id, pool.current_window_end)

--- a/contracts/pfda-amm-3/src/lib.rs
+++ b/contracts/pfda-amm-3/src/lib.rs
@@ -33,6 +33,10 @@ enum Instruction {
     Claim = 3,
     AddLiquidity = 4,
     WithdrawFees = 5,
+    /// #59: authority-gated pause toggle. Mirrors pfda-amm disc 6 and
+    /// axis-vault disc 4; without this ix the `paused` field on
+    /// PoolState3 could never be flipped in an emergency.
+    SetPaused = 6,
     CloseBatchHistory = 7,
     CloseExpiredTicket = 8,
 }
@@ -46,6 +50,7 @@ impl Instruction {
             3 => Some(Instruction::Claim),
             4 => Some(Instruction::AddLiquidity),
             5 => Some(Instruction::WithdrawFees),
+            6 => Some(Instruction::SetPaused),
             7 => Some(Instruction::CloseBatchHistory),
             8 => Some(Instruction::CloseExpiredTicket),
             _ => None,
@@ -140,6 +145,13 @@ pub fn process_instruction(
             let a1 = u64::from_le_bytes([data[8], data[9], data[10], data[11], data[12], data[13], data[14], data[15]]);
             let a2 = u64::from_le_bytes([data[16], data[17], data[18], data[19], data[20], data[21], data[22], data[23]]);
             instructions::process_withdraw_fees(program_id, accounts, [a0, a1, a2])
+        }
+
+        Instruction::SetPaused => {
+            if data.is_empty() {
+                return Err(ProgramError::InvalidInstructionData);
+            }
+            instructions::process_set_paused_3(program_id, accounts, data[0])
         }
 
         Instruction::CloseBatchHistory => {

--- a/contracts/pfda-amm/src/error.rs
+++ b/contracts/pfda-amm/src/error.rs
@@ -49,6 +49,15 @@ pub enum PfmmError {
     BidTooLow = 6021,
     /// next_window_end would overflow u64
     WindowEndOverflow = 6022,
+    /// ClearBatch bid recipient does not match `pool.authority` (#59).
+    /// pfda-amm doesn't carry a separate `treasury` field today, so the
+    /// pool authority is the canonical bid recipient until a dedicated
+    /// treasury schema is added in a follow-up.
+    TreasuryMismatch = 6023,
+    /// ClearBatch received a non-zero bid but no treasury/authority
+    /// account was supplied to receive it (#59). Without the account,
+    /// the Transfer CPI target is undefined — reject before any work.
+    BidWithoutTreasury = 6024,
 }
 
 impl From<PfmmError> for ProgramError {

--- a/contracts/pfda-amm/src/instructions/clear_batch.rs
+++ b/contracts/pfda-amm/src/instructions/clear_batch.rs
@@ -23,14 +23,17 @@ use crate::{
 /// 5. `[]`                  system_program
 /// 6. `[]` (optional)       oracle_feed_a — Switchboard price feed for token A
 /// 7. `[]` (optional)       oracle_feed_b — Switchboard price feed for token B
-/// 8. `[]` (optional)       instructions_sysvar — for Jito tip verification
+/// 8. `[writable]` (req when bid>0) bid_recipient — must equal `pool.authority`
 ///
 /// Integration points:
 ///   - Switchboard: If oracle feeds are provided (accounts 6+7), clearing price
 ///     is bounded within ±5% of oracle-derived market price.
-///   - Jito: If instructions sysvar is provided (account 8), verifies that a
-///     tip was included in the same transaction to a Jito tip account.
-///     The tip is split: protocol_share + lp_share per the revenue formula.
+///   - Jito: If `bid_lamports > 0`, account 8 receives the searcher's bid
+///     and MUST equal `pool.authority`. pfda-amm does not yet carry a
+///     dedicated `treasury` field (unlike pfda-amm-3); until that schema
+///     lands, the pool authority is the canonical recipient. #59 called
+///     out that the pre-fix code accepted ANY account here, letting the
+///     cranker redirect bid payments freely.
 pub fn process_clear_batch(program_id: &Pubkey, accounts: &[AccountInfo], bid_lamports: u64) -> ProgramResult {
     let [cranker, pool_state_ai, batch_queue_ai, history_ai, new_queue_ai, _system_program, ..] =
         accounts
@@ -42,10 +45,11 @@ pub fn process_clear_batch(program_id: &Pubkey, accounts: &[AccountInfo], bid_la
     let oracle_feed_a = if accounts.len() > 6 { Some(&accounts[6]) } else { None };
     let oracle_feed_b = if accounts.len() > 7 { Some(&accounts[7]) } else { None };
 
-    // Jito auction bid enforcement:
-    // If bid_lamports > 0 and accounts[8] is a protocol treasury,
-    // transfer SOL from cranker to treasury. This is the searcher's payment
-    // for exclusive clearing rights in this batch window.
+    // #59 / Jito bid enforcement:
+    // If bid_lamports > 0, account 8 must be present AND must equal
+    // `pool.authority`. Pre-fix, the code happily Transfer'd lamports to
+    // whatever account sat at slot 8, which let a malicious cranker
+    // redirect bid payments to themselves.
     //
     // #33: MIN_BID_LAMPORTS was never enforced on pfda-amm — pfda-amm-3's
     // ClearBatch already has the check; mirror it here so anti-spam
@@ -54,23 +58,36 @@ pub fn process_clear_batch(program_id: &Pubkey, accounts: &[AccountInfo], bid_la
         if bid_lamports < crate::jito::MIN_BID_LAMPORTS {
             return Err(PfmmError::BidTooLow.into());
         }
-        if accounts.len() > 8 {
-            let treasury = &accounts[8];
-
-            // Transfer SOL from cranker to treasury via system program CPI
-            pinocchio_system::instructions::Transfer {
-                from: cranker,
-                to: treasury,
-                lamports: bid_lamports,
-            }
-            .invoke()?;
-
-            // Compute revenue split for accounting
-            let (_protocol_share, _lp_share) = crate::jito::compute_bid_split(
-                bid_lamports,
-                crate::jito::DEFAULT_ALPHA_BPS,
-            );
+        if accounts.len() <= 8 {
+            return Err(PfmmError::BidWithoutTreasury.into());
         }
+        let treasury = &accounts[8];
+        let pool_authority = {
+            let data = pool_state_ai.try_borrow_data()?;
+            let pool = unsafe { load::<PoolState>(&data) }
+                .ok_or(ProgramError::InvalidAccountData)?;
+            if !pool.is_initialized() {
+                return Err(PfmmError::InvalidDiscriminator.into());
+            }
+            pool.authority
+        };
+        if treasury.key().as_ref() != &pool_authority {
+            return Err(PfmmError::TreasuryMismatch.into());
+        }
+
+        // Transfer SOL from cranker to treasury via system program CPI
+        pinocchio_system::instructions::Transfer {
+            from: cranker,
+            to: treasury,
+            lamports: bid_lamports,
+        }
+        .invoke()?;
+
+        // Compute revenue split for accounting
+        let (_protocol_share, _lp_share) = crate::jito::compute_bid_split(
+            bid_lamports,
+            crate::jito::DEFAULT_ALPHA_BPS,
+        );
     }
 
     if !cranker.is_signer() {


### PR DESCRIPTION
Closes #59 (three of five items — the other two are ops/governance, split into a follow-up issue below).

## What shipped

Three concrete code gaps from kidneyweakx's 2026-04-22 audit:

| Severity | Program | File | Fix |
|----------|---------|------|-----|
| P0 | pfda-amm-3 | `swap_request.rs` | Vault-key equality check added; mint-only check let a cranker redirect user Transfers |
| P1 | pfda-amm | `clear_batch.rs` | Bid recipient must now equal `pool.authority`; new errors `TreasuryMismatch = 6023` and `BidWithoutTreasury = 6024` |
| P1 | pfda-amm-3 | new `set_paused.rs` (disc 6) | Authority-gated pause toggle — the `paused` byte was dead without it |
| P1 | axis-g3m | new `set_paused.rs` (disc 5) | Same pattern — `paused` byte was dead without it |

For `pfda-amm-3 Claim` — #59 flagged this too, but the `vault_accounts[i].key() != vaults[i]` check has been in place since before PR #47. Added a regression test to lock it in.

## Why `pool.authority` and not a dedicated `treasury`

pfda-amm-3 carries `treasury` as a separate field from `authority`; pfda-amm does not. Adding one to pfda-amm is a layout change that would touch `PoolState`, `InitializePool`'s data parser, and all seeded test fixtures — worth its own PR once the schema direction is confirmed with Muse. Using `pool.authority` here closes the security hole exactly as #59 described (the cranker can no longer redirect the bid) without a schema migration.

## Tests

New file `contracts/ab-integration-tests/tests/issue_59_coverage.rs`, 8 scenarios, all green under LiteSVM:

- pfda-amm-3 SwapRequest rejects spoofed vault key (new guard)
- pfda-amm-3 Claim rejects spoofed vault key (regression — existing guard)
- pfda-amm ClearBatch rejects bid to wrong treasury
- pfda-amm ClearBatch rejects bid without treasury account
- pfda-amm-3 SetPaused toggles flag for authority
- pfda-amm-3 SetPaused rejects non-authority (error 8035)
- axis-g3m SetPaused toggles flag for authority
- axis-g3m SetPaused rejects non-authority (error 7020)

Full A/B integration suite still green — 62 tests across 8 files.

## Deferred to follow-up issue (kidney-tagged)

- [P1] pfda-amm-3 ClearBatch oracle-stale fallback policy — design call on degraded mode vs. hard abort
- [P2] PROTOCOL_TREASURY Squads V4 deploy + constant flip — ops/governance
- [P2] pfda-amm `treasury` schema (dedicated field like pfda-amm-3) — follow-up after ops confirms the treasury model

## Test plan

- [x] `cargo build-sbf` clean for pfda-amm, pfda-amm-3, axis-g3m
- [x] `cargo test --manifest-path contracts/ab-integration-tests/Cargo.toml` — 62/62 pass including the 8 new
- [x] `cargo test --lib` on each program — 19+1+11 pass
- [ ] Design review on the authority-as-treasury choice for pfda-amm (@muse0509 / @kidneyweakx) before merge