### PR TITLE
feat(axis-vault #36): land Jupiter V6 CPI body for DepositSol / WithdrawSol

### DIFF
--- a/.github/workflows/litesvm-jupiter-cpi.yml
+++ b/.github/workflows/litesvm-jupiter-cpi.yml
@@ -133,6 +133,15 @@ jobs:
           cd contracts/ab-integration-tests
           cargo test --test axis_vault_coverage -- --nocapture
 
+      # #36: DepositSol / WithdrawSol scaffolding guards. Locks down
+      # the parameter-validation surface (zero amount, basket-size cap)
+      # and the NotYetImplemented placeholder so the dispatcher stays
+      # sane while the Jupiter CPI body is being designed.
+      - name: Run axis-vault SOL-ix scaffold tests (LiteSVM)
+        run: |
+          cd contracts/ab-integration-tests
+          cargo test --test axis_vault_sol_ix_scaffold -- --nocapture
+
       - name: Generate LiteSVM A/B report
         run: |
           cd contracts/ab-integration-tests

--- a/contracts/ab-integration-tests/Cargo.toml
+++ b/contracts/ab-integration-tests/Cargo.toml
@@ -35,6 +35,10 @@ path = "tests/pfda3_claim_coverage.rs"
 name = "axis_vault_coverage"
 path = "tests/axis_vault_coverage.rs"
 
+[[test]]
+name = "axis_vault_sol_ix_scaffold"
+path = "tests/axis_vault_sol_ix_scaffold.rs"
+
 [dependencies]
 litesvm = "0.11"
 solana-keypair = "3.1"

--- a/contracts/ab-integration-tests/tests/axis_vault_sol_ix_scaffold.rs
+++ b/contracts/ab-integration-tests/tests/axis_vault_sol_ix_scaffold.rs
@@ -1,17 +1,17 @@
-//! axis-vault DepositSol / WithdrawSol scaffolding tests (#36, PR #58).
+//! axis-vault DepositSol / WithdrawSol parameter + parser tests (#36).
 //!
-//! These tests lock down the scaffolding behavior so the dispatcher +
-//! parameter validation stay correct while the Jupiter CPI body is
-//! being designed in follow-up. Each case hits one of the two early
-//! validation branches:
+//! With the Jupiter CPI body now landed (PR #58 round 2), the cheap
+//! validation gates we lock down here are:
 //!
 //!   - sol_in / burn_amount == 0 → ZeroDeposit (9004)
 //!   - leg_count == 0 or > 3    → BasketTooLargeForOnchainSol (9025)
-//!   - otherwise                → NotYetImplemented (9024)
+//!   - leg_count > 0 with too few accounts to satisfy the layout →
+//!     NotEnoughAccountKeys
 //!
-//! When the real implementation lands, the `NotYetImplemented` branch
-//! goes away and the happy-path tests move into the axis_vault_coverage
-//! sibling file.
+//! Happy-path tests that exercise the full Jupiter CPI live in the
+//! mainnet-fork harness — see `axis_vault_jupiter_fork.rs` (#61 item 5
+//! follow-up). Pure parser-level coverage stays here so the
+//! scaffolding contract surface can't drift without a regression.
 
 use ab_integration_tests::helpers::{svm_setup::*, token_factory::*};
 use ab_integration_tests::require_fixture;
@@ -24,7 +24,6 @@ use solana_signer::Signer;
 use solana_transaction::Transaction;
 
 const ERR_ZERO_DEPOSIT: u32 = 9004;
-const ERR_NOT_YET_IMPLEMENTED: u32 = 9024;
 const ERR_BASKET_TOO_LARGE: u32 = 9025;
 
 fn send(svm: &mut LiteSVM, ix: Instruction, payer: &Keypair) -> Result<u64, String> {
@@ -121,17 +120,22 @@ fn deposit_sol_rejects_basket_too_large() {
 }
 
 #[test]
-fn deposit_sol_placeholder_returns_not_yet_implemented() {
+fn deposit_sol_with_undersized_account_list_rejects() {
+    // Past parameter validation (sol_in > 0, leg_count == 2) the new
+    // implementation requires 10 + tc + per-leg route accounts. A
+    // 6-account ix can't satisfy the layout so the runtime / handler
+    // surfaces NotEnoughAccountKeys before any Jupiter CPI runs.
     require_fixture!(AXIS_VAULT_SO);
     let (mut svm, payer) = match bootstrap_svm() { Some(x) => x, None => return };
-    // sol_in > 0, leg_count within bounds → falls through parameter
-    // validation and returns the placeholder.
     let err = send(
         &mut svm,
         Instruction { program_id: axis_vault_id(), accounts: make_accounts(&payer), data: make_data(5, 1_000_000, 0, 2) },
         &payer,
-    ).err().expect("placeholder body must return NotYetImplemented");
-    assert_custom_err(&err, ERR_NOT_YET_IMPLEMENTED, "deposit_sol placeholder");
+    ).err().expect("undersized account list must reject");
+    assert!(
+        err.contains("NotEnoughAccountKeys") || err.contains("insufficient account keys"),
+        "expected NotEnoughAccountKeys, got: {err}"
+    );
 }
 
 // ─── WithdrawSol ───────────────────────────────────────────────────────
@@ -161,13 +165,43 @@ fn withdraw_sol_rejects_basket_too_large() {
 }
 
 #[test]
-fn withdraw_sol_placeholder_returns_not_yet_implemented() {
+fn withdraw_sol_with_undersized_account_list_rejects() {
     require_fixture!(AXIS_VAULT_SO);
     let (mut svm, payer) = match bootstrap_svm() { Some(x) => x, None => return };
     let err = send(
         &mut svm,
         Instruction { program_id: axis_vault_id(), accounts: make_accounts(&payer), data: make_data(6, 500_000, 0, 2) },
         &payer,
-    ).err().expect("placeholder body must return NotYetImplemented");
-    assert_custom_err(&err, ERR_NOT_YET_IMPLEMENTED, "withdraw_sol placeholder");
+    ).err().expect("undersized account list must reject");
+    assert!(
+        err.contains("NotEnoughAccountKeys") || err.contains("insufficient account keys"),
+        "expected NotEnoughAccountKeys, got: {err}"
+    );
+}
+
+#[test]
+fn deposit_sol_rejects_leg_count_zero() {
+    // leg_count = 0 routes through the same BasketTooLargeForOnchainSol
+    // gate as oversize baskets (the gate is "size in (0, 3]"). Locks
+    // down the new lower-bound branch.
+    require_fixture!(AXIS_VAULT_SO);
+    let (mut svm, payer) = match bootstrap_svm() { Some(x) => x, None => return };
+    let err = send(
+        &mut svm,
+        Instruction { program_id: axis_vault_id(), accounts: make_accounts(&payer), data: make_data(5, 1_000_000, 0, 0) },
+        &payer,
+    ).err().expect("leg_count=0 must reject");
+    assert_custom_err(&err, ERR_BASKET_TOO_LARGE, "0-leg deposit_sol");
+}
+
+#[test]
+fn withdraw_sol_rejects_leg_count_zero() {
+    require_fixture!(AXIS_VAULT_SO);
+    let (mut svm, payer) = match bootstrap_svm() { Some(x) => x, None => return };
+    let err = send(
+        &mut svm,
+        Instruction { program_id: axis_vault_id(), accounts: make_accounts(&payer), data: make_data(6, 500_000, 0, 0) },
+        &payer,
+    ).err().expect("leg_count=0 must reject");
+    assert_custom_err(&err, ERR_BASKET_TOO_LARGE, "0-leg withdraw_sol");
 }

--- a/contracts/ab-integration-tests/tests/axis_vault_sol_ix_scaffold.rs
+++ b/contracts/ab-integration-tests/tests/axis_vault_sol_ix_scaffold.rs
@@ -1,0 +1,173 @@
+//! axis-vault DepositSol / WithdrawSol scaffolding tests (#36, PR #58).
+//!
+//! These tests lock down the scaffolding behavior so the dispatcher +
+//! parameter validation stay correct while the Jupiter CPI body is
+//! being designed in follow-up. Each case hits one of the two early
+//! validation branches:
+//!
+//!   - sol_in / burn_amount == 0 → ZeroDeposit (9004)
+//!   - leg_count == 0 or > 3    → BasketTooLargeForOnchainSol (9025)
+//!   - otherwise                → NotYetImplemented (9024)
+//!
+//! When the real implementation lands, the `NotYetImplemented` branch
+//! goes away and the happy-path tests move into the axis_vault_coverage
+//! sibling file.
+
+use ab_integration_tests::helpers::{svm_setup::*, token_factory::*};
+use ab_integration_tests::require_fixture;
+use litesvm::LiteSVM;
+use solana_address::Address;
+use solana_instruction::{account_meta::AccountMeta, Instruction};
+use solana_keypair::Keypair;
+use solana_native_token::LAMPORTS_PER_SOL;
+use solana_signer::Signer;
+use solana_transaction::Transaction;
+
+const ERR_ZERO_DEPOSIT: u32 = 9004;
+const ERR_NOT_YET_IMPLEMENTED: u32 = 9024;
+const ERR_BASKET_TOO_LARGE: u32 = 9025;
+
+fn send(svm: &mut LiteSVM, ix: Instruction, payer: &Keypair) -> Result<u64, String> {
+    let tx = Transaction::new_signed_with_payer(
+        &[ix],
+        Some(&payer.pubkey()),
+        &[payer],
+        svm.latest_blockhash(),
+    );
+    match svm.send_transaction(tx) {
+        Ok(meta) => Ok(meta.compute_units_consumed),
+        Err(e) => {
+            let mut msg = format!("{:?}", e.err);
+            for log in &e.meta.logs {
+                msg.push_str(&format!("\n  {}", log));
+            }
+            Err(msg)
+        }
+    }
+}
+
+fn assert_custom_err(err: &str, code: u32, label: &str) {
+    let hex = format!("0x{:x}", code);
+    let custom = format!("Custom({})", code);
+    assert!(
+        err.contains(&hex) || err.contains(&custom),
+        "{label}: expected {code} ({hex}), got: {err}"
+    );
+}
+
+fn bootstrap_svm() -> Option<(LiteSVM, Keypair)> {
+    let mut svm = LiteSVM::new();
+    if !std::path::Path::new(AXIS_VAULT_SO).exists() {
+        eprintln!("SKIP: axis_vault.so fixture missing");
+        return None;
+    }
+    svm.add_program_from_file(axis_vault_id(), AXIS_VAULT_SO).ok()?;
+    let payer = Keypair::new();
+    svm.airdrop(&payer.pubkey(), 10 * LAMPORTS_PER_SOL).unwrap();
+    Some((svm, payer))
+}
+
+/// Build a placeholder DepositSol / WithdrawSol tx. The scaffolding
+/// rejects on parameter-validation before touching accounts, so fresh
+/// unique addresses are enough padding. 18 bytes = sol_in + min_out +
+/// name_len(0) + leg_count.
+fn make_data(disc: u8, amount: u64, min_out: u64, leg_count: u8) -> Vec<u8> {
+    let mut d = Vec::with_capacity(18);
+    d.push(disc);
+    d.extend_from_slice(&amount.to_le_bytes());
+    d.extend_from_slice(&min_out.to_le_bytes());
+    d.push(0u8); // name_len = 0
+    d.push(leg_count);
+    d
+}
+
+fn make_accounts(payer: &Keypair) -> Vec<AccountMeta> {
+    // Scaffolded body doesn't dereference any of these — but the ix
+    // needs a non-trivial account vec so the runtime accepts the tx.
+    vec![
+        AccountMeta::new(payer.pubkey(), true),
+        AccountMeta::new(Address::new_unique(), false),
+        AccountMeta::new(Address::new_unique(), false),
+        AccountMeta::new(Address::new_unique(), false),
+        AccountMeta::new_readonly(token_program_id(), false),
+        AccountMeta::new(Address::new_unique(), false),
+    ]
+}
+
+// ─── DepositSol ────────────────────────────────────────────────────────
+
+#[test]
+fn deposit_sol_rejects_zero_amount() {
+    require_fixture!(AXIS_VAULT_SO);
+    let (mut svm, payer) = match bootstrap_svm() { Some(x) => x, None => return };
+    let err = send(
+        &mut svm,
+        Instruction { program_id: axis_vault_id(), accounts: make_accounts(&payer), data: make_data(5, 0, 0, 3) },
+        &payer,
+    ).err().expect("sol_in=0 must reject");
+    assert_custom_err(&err, ERR_ZERO_DEPOSIT, "zero sol_in");
+}
+
+#[test]
+fn deposit_sol_rejects_basket_too_large() {
+    require_fixture!(AXIS_VAULT_SO);
+    let (mut svm, payer) = match bootstrap_svm() { Some(x) => x, None => return };
+    let err = send(
+        &mut svm,
+        Instruction { program_id: axis_vault_id(), accounts: make_accounts(&payer), data: make_data(5, 1_000_000, 0, 4) },
+        &payer,
+    ).err().expect("leg_count=4 must reject");
+    assert_custom_err(&err, ERR_BASKET_TOO_LARGE, "4-leg deposit_sol");
+}
+
+#[test]
+fn deposit_sol_placeholder_returns_not_yet_implemented() {
+    require_fixture!(AXIS_VAULT_SO);
+    let (mut svm, payer) = match bootstrap_svm() { Some(x) => x, None => return };
+    // sol_in > 0, leg_count within bounds → falls through parameter
+    // validation and returns the placeholder.
+    let err = send(
+        &mut svm,
+        Instruction { program_id: axis_vault_id(), accounts: make_accounts(&payer), data: make_data(5, 1_000_000, 0, 2) },
+        &payer,
+    ).err().expect("placeholder body must return NotYetImplemented");
+    assert_custom_err(&err, ERR_NOT_YET_IMPLEMENTED, "deposit_sol placeholder");
+}
+
+// ─── WithdrawSol ───────────────────────────────────────────────────────
+
+#[test]
+fn withdraw_sol_rejects_zero_amount() {
+    require_fixture!(AXIS_VAULT_SO);
+    let (mut svm, payer) = match bootstrap_svm() { Some(x) => x, None => return };
+    let err = send(
+        &mut svm,
+        Instruction { program_id: axis_vault_id(), accounts: make_accounts(&payer), data: make_data(6, 0, 0, 3) },
+        &payer,
+    ).err().expect("burn_amount=0 must reject");
+    assert_custom_err(&err, ERR_ZERO_DEPOSIT, "zero burn_amount");
+}
+
+#[test]
+fn withdraw_sol_rejects_basket_too_large() {
+    require_fixture!(AXIS_VAULT_SO);
+    let (mut svm, payer) = match bootstrap_svm() { Some(x) => x, None => return };
+    let err = send(
+        &mut svm,
+        Instruction { program_id: axis_vault_id(), accounts: make_accounts(&payer), data: make_data(6, 500_000, 0, 5) },
+        &payer,
+    ).err().expect("leg_count=5 must reject");
+    assert_custom_err(&err, ERR_BASKET_TOO_LARGE, "5-leg withdraw_sol");
+}
+
+#[test]
+fn withdraw_sol_placeholder_returns_not_yet_implemented() {
+    require_fixture!(AXIS_VAULT_SO);
+    let (mut svm, payer) = match bootstrap_svm() { Some(x) => x, None => return };
+    let err = send(
+        &mut svm,
+        Instruction { program_id: axis_vault_id(), accounts: make_accounts(&payer), data: make_data(6, 500_000, 0, 2) },
+        &payer,
+    ).err().expect("placeholder body must return NotYetImplemented");
+    assert_custom_err(&err, ERR_NOT_YET_IMPLEMENTED, "withdraw_sol placeholder");
+}

--- a/contracts/axis-vault/src/error.rs
+++ b/contracts/axis-vault/src/error.rs
@@ -27,13 +27,45 @@ pub enum VaultError {
     SweepForbidden = 9021,
     NothingToSweep = 9022,
     TreasuryNotApproved = 9023,
-    /// DepositSol / WithdrawSol scaffolding shipped; native Jupiter CPI
-    /// implementation is a follow-up after design review. Issue #36.
+    /// Pre-implementation placeholder from PR #58. Retained so older
+    /// clients receive a recognisable code if they hit a stale build,
+    /// but unused in the current implementation. Issue #36.
     NotYetImplemented = 9024,
     /// DepositSol / WithdrawSol restrict basket size to keep CU + tx
     /// account count within the 1.4M / versioned-tx envelopes. 5-leg
     /// baskets must use the client-bundled flow from PR #42. Issue #36.
     BasketTooLargeForOnchainSol = 9025,
+    /// DepositSol / WithdrawSol passed a `jupiter_program` account that
+    /// does not match the canonical Jupiter V6 program ID. Closes the
+    /// arbitrary-CPI vector — without this check a malicious
+    /// `jupiter_program` could simulate the swap and pocket the wSOL.
+    InvalidJupiterProgram = 9026,
+    /// DepositSol / WithdrawSol passed a `wsol_mint` that does not
+    /// match the canonical wrapped-SOL mint. Lets us refuse to wrap
+    /// into a substitute mint that Jupiter would happily route.
+    WsolMintMismatch = 9027,
+    /// DepositSol per-leg `leg_sol_amount` values do not sum to the
+    /// `sol_in` total declared in the instruction header. Catches a
+    /// mis-built tx before any wSOL is wrapped.
+    LegSumMismatch = 9028,
+    /// DepositSol / WithdrawSol `leg_count` does not equal the ETF's
+    /// stored `token_count`. The on-chain SOL ixes require the basket
+    /// to be fully covered — partial baskets are not supported.
+    LegCountMismatch = 9029,
+    /// DepositSol Jupiter CPI returned without depositing any tokens
+    /// into one of the basket vaults — typically Jupiter aborted the
+    /// route silently, or the `route_bytes` were stale and the slippage
+    /// check on Jupiter's side fired. We refuse to mint against a
+    /// no-op leg.
+    JupiterCpiNoOutput = 9030,
+    /// First DepositSol on an ETF whose `total_supply` is still zero.
+    /// Bootstrapping requires basket-token Deposit so the seed
+    /// composition matches target weights — DepositSol can only be
+    /// used after the ETF has been seeded.
+    EtfNotBootstrapped = 9031,
+    /// Per-leg payload (leg_sol_amount + route_len + route_bytes) was
+    /// truncated, malformed, or went past the instruction-data tail.
+    MalformedLegData = 9032,
 }
 
 impl From<VaultError> for ProgramError {

--- a/contracts/axis-vault/src/error.rs
+++ b/contracts/axis-vault/src/error.rs
@@ -27,6 +27,13 @@ pub enum VaultError {
     SweepForbidden = 9021,
     NothingToSweep = 9022,
     TreasuryNotApproved = 9023,
+    /// DepositSol / WithdrawSol scaffolding shipped; native Jupiter CPI
+    /// implementation is a follow-up after design review. Issue #36.
+    NotYetImplemented = 9024,
+    /// DepositSol / WithdrawSol restrict basket size to keep CU + tx
+    /// account count within the 1.4M / versioned-tx envelopes. 5-leg
+    /// baskets must use the client-bundled flow from PR #42. Issue #36.
+    BasketTooLargeForOnchainSol = 9025,
 }
 
 impl From<VaultError> for ProgramError {

--- a/contracts/axis-vault/src/instructions/deposit_sol.rs
+++ b/contracts/axis-vault/src/instructions/deposit_sol.rs
@@ -1,0 +1,118 @@
+//! DepositSol — SOL-in variant of Deposit. Issue #36.
+//!
+//! # Status: SCAFFOLDING
+//!
+//! This file ships the instruction dispatcher hook + account layout +
+//! error path so downstream clients can start planning. The Jupiter CPI
+//! body is **intentionally not implemented** and returns
+//! `VaultError::NotYetImplemented` until Muse / kidney sign off on the
+//! design discussed in PR body #58.
+//!
+//! # Why a scaffold and not the full thing
+//!
+//! PR #42's author explicitly deferred on-chain SOL ixes because of:
+//!
+//! 1. **Account-list blow-up** — one Jupiter route carries 20-40
+//!    accounts. At tc=5 the per-leg Jupiter expansion pushes a single
+//!    versioned tx past the 64-signer / ~250-account envelope even
+//!    with ALT.
+//! 2. **CU budget** — a Jupiter swap costs 200-400k CU. 5-leg on-chain
+//!    CPI = 1.0-2.0M CU, straddling the 1.4M cap.
+//! 3. **Testability** — Jupiter V6 is mainnet-only, so every e2e has
+//!    to go through a mainnet-fork.
+//!
+//! The client-bundled flow in `scripts/axis-vault/deposit-sol.ts`
+//! avoids all three by letting the user sign a single versioned tx
+//! with `[ComputeBudget][Jupiter × N][axis-vault Deposit]`. Atomicity
+//! is preserved by the tx envelope itself.
+//!
+//! # What the on-chain variant gives
+//!
+//! Strict on-chain `min_etf_out` / `min_sol_out` enforcement with
+//! single-signer UX. Useful when the caller is another program (not
+//! a wallet-signed user) and can't rely on client-side slippage checks.
+//!
+//! # Scope limits (deliberate)
+//!
+//! - `tc <= 3` basket size — reserves full CU + account envelope for
+//!   the axis-vault Deposit tail + compute budget + rent. tc=4,5 uses
+//!   client-bundled.
+//! - Single-Jupiter-program assumption — we pin to `JUPITER_PROGRAM_ID`
+//!   (mirrors axis-g3m).
+//!
+//! # Account layout (design target)
+//!
+//! ```text
+//! 0: [signer, writable]  depositor (pays SOL)
+//! 1: [writable]          etf_state PDA
+//! 2: [writable]          etf_mint
+//! 3: [writable]          depositor_etf_ata
+//! 4: []                  token_program
+//! 5: [writable]          treasury_etf_ata
+//! 6: [writable]          wsol_ata (depositor-owned, holds wrapped SOL for CPI)
+//! 7: []                  wsol_mint (So11111111111111111111111111111111111111112)
+//! 8: []                  jupiter_program
+//! 9: []                  system_program
+//! 10..10+tc: [writable]  per-leg basket vaults
+//! 11+tc..: variable       per-leg Jupiter route accounts
+//! ```
+//!
+//! # Instruction data (design target)
+//!
+//! ```text
+//! [sol_in:        u64 LE]
+//! [min_etf_out:   u64 LE]
+//! [name_len:      u8]   [name: bytes]
+//! [leg_count:     u8]   (must equal etf.token_count, <= 3)
+//! per leg:
+//!   [leg_sol_amount: u64 LE]
+//!   [route_len:      u32 LE]
+//!   [route_bytes:    route_len bytes — opaque to axis-vault]
+//! ```
+
+use pinocchio::{
+    account_info::AccountInfo, pubkey::Pubkey, ProgramResult,
+};
+
+use crate::error::VaultError;
+
+/// Max basket size the on-chain SOL ixes will accept. Larger baskets
+/// should route through `scripts/axis-vault/deposit-sol.ts`.
+pub const MAX_ONCHAIN_SOL_IX_LEGS: u8 = 3;
+
+/// DepositSol — see module docs.
+///
+/// This body is a placeholder. It performs basic parameter validation
+/// so clients can integrate against the interface, then returns
+/// `NotYetImplemented` until the Jupiter CPI body lands in a follow-up.
+pub fn process_deposit_sol(
+    _program_id: &Pubkey,
+    _accounts: &[AccountInfo],
+    sol_in: u64,
+    _min_etf_out: u64,
+    _name: &[u8],
+    leg_count: u8,
+) -> ProgramResult {
+    if sol_in == 0 {
+        return Err(VaultError::ZeroDeposit.into());
+    }
+    if leg_count == 0 || leg_count > MAX_ONCHAIN_SOL_IX_LEGS {
+        return Err(VaultError::BasketTooLargeForOnchainSol.into());
+    }
+
+    // TODO(#36, followup after design review):
+    //   1. Wrap sol_in lamports into wsol_ata via SystemTransfer + sync_native.
+    //   2. For each leg i:
+    //      - Invoke Jupiter V6 CPI with route_bytes[i] swapping
+    //        leg_sol_amount[i] wSOL -> basket_mint[i].
+    //      - Jupiter writes to the declared destination ATA; we verify
+    //        vault_i balance delta matches the per-leg otherAmountThreshold
+    //        embedded in route_bytes[i].
+    //   3. Compute mint_amount via existing proportional math (same
+    //      formula as Deposit, shared via a helper).
+    //   4. Enforce mint_amount >= min_etf_out (strict on-chain).
+    //   5. Mint etf tokens net of 30-bps fee; fee goes to treasury_etf_ata.
+    //   6. Write back total_supply.
+
+    Err(VaultError::NotYetImplemented.into())
+}

--- a/contracts/axis-vault/src/instructions/deposit_sol.rs
+++ b/contracts/axis-vault/src/instructions/deposit_sol.rs
@@ -1,63 +1,36 @@
 //! DepositSol — SOL-in variant of Deposit. Issue #36.
 //!
-//! # Status: SCAFFOLDING
+//! Wraps `sol_in` lamports into wSOL, executes one Jupiter V6 swap per
+//! basket leg (writing into the corresponding vault), then mints ETF
+//! tokens to the depositor proportional to the realised vault deltas.
 //!
-//! This file ships the instruction dispatcher hook + account layout +
-//! error path so downstream clients can start planning. The Jupiter CPI
-//! body is **intentionally not implemented** and returns
-//! `VaultError::NotYetImplemented` until Muse / kidney sign off on the
-//! design discussed in PR body #58.
+//! The Jupiter `route_bytes` are opaque to axis-vault — the caller is
+//! responsible for crafting them with the leg's source mint = wSOL,
+//! destination mint = `etf.token_mints[i]`, and slippage/threshold
+//! parameters baked in. Per-leg CPI metas are built as
+//! `[vault[i]] + caller_route_accounts[i]`, so the caller's
+//! `route_bytes` MUST assume vault[i] sits at metas index 0.
 //!
-//! # Why a scaffold and not the full thing
-//!
-//! PR #42's author explicitly deferred on-chain SOL ixes because of:
-//!
-//! 1. **Account-list blow-up** — one Jupiter route carries 20-40
-//!    accounts. At tc=5 the per-leg Jupiter expansion pushes a single
-//!    versioned tx past the 64-signer / ~250-account envelope even
-//!    with ALT.
-//! 2. **CU budget** — a Jupiter swap costs 200-400k CU. 5-leg on-chain
-//!    CPI = 1.0-2.0M CU, straddling the 1.4M cap.
-//! 3. **Testability** — Jupiter V6 is mainnet-only, so every e2e has
-//!    to go through a mainnet-fork.
-//!
-//! The client-bundled flow in `scripts/axis-vault/deposit-sol.ts`
-//! avoids all three by letting the user sign a single versioned tx
-//! with `[ComputeBudget][Jupiter × N][axis-vault Deposit]`. Atomicity
-//! is preserved by the tx envelope itself.
-//!
-//! # What the on-chain variant gives
-//!
-//! Strict on-chain `min_etf_out` / `min_sol_out` enforcement with
-//! single-signer UX. Useful when the caller is another program (not
-//! a wallet-signed user) and can't rely on client-side slippage checks.
-//!
-//! # Scope limits (deliberate)
-//!
-//! - `tc <= 3` basket size — reserves full CU + account envelope for
-//!   the axis-vault Deposit tail + compute budget + rent. tc=4,5 uses
-//!   client-bundled.
-//! - Single-Jupiter-program assumption — we pin to `JUPITER_PROGRAM_ID`
-//!   (mirrors axis-g3m).
-//!
-//! # Account layout (design target)
+//! # Account layout
 //!
 //! ```text
-//! 0: [signer, writable]  depositor (pays SOL)
-//! 1: [writable]          etf_state PDA
-//! 2: [writable]          etf_mint
-//! 3: [writable]          depositor_etf_ata
-//! 4: []                  token_program
-//! 5: [writable]          treasury_etf_ata
-//! 6: [writable]          wsol_ata (depositor-owned, holds wrapped SOL for CPI)
-//! 7: []                  wsol_mint (So11111111111111111111111111111111111111112)
-//! 8: []                  jupiter_program
-//! 9: []                  system_program
-//! 10..10+tc: [writable]  per-leg basket vaults
-//! 11+tc..: variable       per-leg Jupiter route accounts
+//! 0:  [signer, writable]  depositor
+//! 1:  [writable]          etf_state PDA
+//! 2:  [writable]          etf_mint
+//! 3:  [writable]          depositor_etf_ata
+//! 4:  []                  token_program
+//! 5:  [writable]          treasury_etf_ata
+//! 6:  [writable]          wsol_ata (depositor-owned)
+//! 7:  []                  wsol_mint
+//! 8:  []                  jupiter_program
+//! 9:  []                  system_program
+//! 10..10+tc:    [writable]   per-leg basket vaults (used for validation
+//!                            + pre/post balance snapshot, NOT passed to
+//!                            Jupiter — that copy is prepended at CPI time)
+//! 10+tc..:      []           concatenated per-leg Jupiter route accounts
 //! ```
 //!
-//! # Instruction data (design target)
+//! # Instruction data
 //!
 //! ```text
 //! [sol_in:        u64 LE]
@@ -65,54 +38,356 @@
 //! [name_len:      u8]   [name: bytes]
 //! [leg_count:     u8]   (must equal etf.token_count, <= 3)
 //! per leg:
-//!   [leg_sol_amount: u64 LE]
-//!   [route_len:      u32 LE]
-//!   [route_bytes:    route_len bytes — opaque to axis-vault]
+//!   [leg_sol_amount:        u64 LE]
+//!   [route_account_count:   u8]      (count of route accounts EXCLUDING vault[i])
+//!   [route_len:             u32 LE]
+//!   [route_bytes:           route_len bytes — opaque to axis-vault]
 //! ```
+//!
+//! # First-deposit handling
+//!
+//! `total_supply == 0` returns `EtfNotBootstrapped`. Bootstrap must use
+//! the basket-token `Deposit` path so the seed composition matches
+//! target weights — DepositSol is for ongoing additions, not creation.
 
 use pinocchio::{
-    account_info::AccountInfo, pubkey::Pubkey, ProgramResult,
+    account_info::AccountInfo,
+    instruction::{Seed, Signer},
+    program_error::ProgramError,
+    pubkey::Pubkey,
+    ProgramResult,
 };
+use pinocchio_token::instructions::{MintTo, SyncNative};
 
+use crate::constants::{MAX_NAV_DEVIATION_BPS, TOKEN_PROGRAM_ID};
 use crate::error::VaultError;
+use crate::jupiter::{
+    invoke_jupiter_leg, read_token_account_balance, JUPITER_PROGRAM_ID, MAX_JUPITER_CPI_ACCOUNTS,
+    WSOL_MINT,
+};
+use crate::state::{load, load_mut, EtfState};
 
 /// Max basket size the on-chain SOL ixes will accept. Larger baskets
-/// should route through `scripts/axis-vault/deposit-sol.ts`.
+/// route through `scripts/axis-vault/deposit-sol.ts`.
 pub const MAX_ONCHAIN_SOL_IX_LEGS: u8 = 3;
 
-/// DepositSol — see module docs.
-///
-/// This body is a placeholder. It performs basic parameter validation
-/// so clients can integrate against the interface, then returns
-/// `NotYetImplemented` until the Jupiter CPI body lands in a follow-up.
+const FIXED_ACCOUNTS: usize = 10;
+
+#[allow(clippy::too_many_arguments)]
 pub fn process_deposit_sol(
-    _program_id: &Pubkey,
-    _accounts: &[AccountInfo],
+    program_id: &Pubkey,
+    accounts: &[AccountInfo],
     sol_in: u64,
-    _min_etf_out: u64,
-    _name: &[u8],
+    min_etf_out: u64,
+    name: &[u8],
     leg_count: u8,
+    leg_data: &[u8],
 ) -> ProgramResult {
+    // ─── parameter gates (cheap fail) ──────────────────────────────
     if sol_in == 0 {
         return Err(VaultError::ZeroDeposit.into());
     }
     if leg_count == 0 || leg_count > MAX_ONCHAIN_SOL_IX_LEGS {
         return Err(VaultError::BasketTooLargeForOnchainSol.into());
     }
+    let tc = leg_count as usize;
 
-    // TODO(#36, followup after design review):
-    //   1. Wrap sol_in lamports into wsol_ata via SystemTransfer + sync_native.
-    //   2. For each leg i:
-    //      - Invoke Jupiter V6 CPI with route_bytes[i] swapping
-    //        leg_sol_amount[i] wSOL -> basket_mint[i].
-    //      - Jupiter writes to the declared destination ATA; we verify
-    //        vault_i balance delta matches the per-leg otherAmountThreshold
-    //        embedded in route_bytes[i].
-    //   3. Compute mint_amount via existing proportional math (same
-    //      formula as Deposit, shared via a helper).
-    //   4. Enforce mint_amount >= min_etf_out (strict on-chain).
-    //   5. Mint etf tokens net of 30-bps fee; fee goes to treasury_etf_ata.
-    //   6. Write back total_supply.
+    if accounts.len() < FIXED_ACCOUNTS + tc {
+        return Err(ProgramError::NotEnoughAccountKeys);
+    }
 
-    Err(VaultError::NotYetImplemented.into())
+    let depositor = &accounts[0];
+    let etf_state_ai = &accounts[1];
+    let etf_mint_ai = &accounts[2];
+    let depositor_etf_ata = &accounts[3];
+    let _tok = &accounts[4];
+    let treasury_etf_ata = &accounts[5];
+    let wsol_ata = &accounts[6];
+    let wsol_mint_ai = &accounts[7];
+    let jupiter_program = &accounts[8];
+    let _system_program = &accounts[9];
+
+    if !depositor.is_signer() {
+        return Err(ProgramError::MissingRequiredSignature);
+    }
+    if etf_state_ai.owner() != program_id {
+        return Err(VaultError::InvalidProgramOwner.into());
+    }
+    if jupiter_program.key().as_ref() != &JUPITER_PROGRAM_ID {
+        return Err(VaultError::InvalidJupiterProgram.into());
+    }
+    if wsol_mint_ai.key().as_ref() != &WSOL_MINT {
+        return Err(VaultError::WsolMintMismatch.into());
+    }
+
+    // ─── load etf state ────────────────────────────────────────────
+    let (token_count, total_supply, authority, weights, bump_seed, fee_bps, treasury, etf_mint, token_vaults) = {
+        let data = etf_state_ai.try_borrow_data()?;
+        let etf =
+            unsafe { load::<EtfState>(&data) }.ok_or(ProgramError::InvalidAccountData)?;
+        if !etf.is_initialized() {
+            return Err(VaultError::InvalidDiscriminator.into());
+        }
+        if etf.paused != 0 {
+            return Err(VaultError::PoolPaused.into());
+        }
+        (
+            etf.token_count as usize,
+            etf.total_supply,
+            etf.authority,
+            etf.weights_bps,
+            etf.bump,
+            etf.fee_bps,
+            etf.treasury,
+            etf.etf_mint,
+            etf.token_vaults,
+        )
+    };
+
+    if tc != token_count {
+        return Err(VaultError::LegCountMismatch.into());
+    }
+    if total_supply == 0 {
+        return Err(VaultError::EtfNotBootstrapped.into());
+    }
+    if etf_mint_ai.key() != &etf_mint {
+        return Err(VaultError::MintMismatch.into());
+    }
+
+    // Treasury ATA validation (same pattern as Deposit). Without it
+    // anyone could route the protocol fee to an attacker-owned ATA.
+    if treasury_etf_ata.owner() != &TOKEN_PROGRAM_ID {
+        return Err(VaultError::TreasuryMismatch.into());
+    }
+    {
+        let data = treasury_etf_ata.try_borrow_data()?;
+        if data.len() < 64 {
+            return Err(ProgramError::InvalidAccountData);
+        }
+        if &data[32..64] != &treasury {
+            return Err(VaultError::TreasuryMismatch.into());
+        }
+    }
+
+    // Vault keys must match etf.token_vaults[i] one-for-one.
+    for i in 0..tc {
+        if accounts[FIXED_ACCOUNTS + i].key() != &token_vaults[i] {
+            return Err(VaultError::VaultMismatch.into());
+        }
+    }
+
+    // ─── parse leg_data ────────────────────────────────────────────
+    // Per leg: [leg_sol_amount u64][route_account_count u8][route_len u32][route_bytes]
+    let mut leg_amounts = [0u64; 5];
+    let mut leg_route_account_counts = [0usize; 5];
+    let mut leg_route_byte_offsets = [0usize; 5];
+    let mut leg_route_byte_lens = [0usize; 5];
+    let mut sum: u64 = 0;
+    let mut total_route_accounts = 0usize;
+    let mut cursor = 0usize;
+    for i in 0..tc {
+        if leg_data.len() < cursor + 8 + 1 + 4 {
+            return Err(VaultError::MalformedLegData.into());
+        }
+        let leg_amount = u64::from_le_bytes(
+            leg_data[cursor..cursor + 8]
+                .try_into()
+                .map_err(|_| VaultError::MalformedLegData)?,
+        );
+        cursor += 8;
+        let route_account_count = leg_data[cursor] as usize;
+        cursor += 1;
+        let route_len = u32::from_le_bytes(
+            leg_data[cursor..cursor + 4]
+                .try_into()
+                .map_err(|_| VaultError::MalformedLegData)?,
+        ) as usize;
+        cursor += 4;
+        if leg_data.len() < cursor + route_len {
+            return Err(VaultError::MalformedLegData.into());
+        }
+        // +1 to account_count: we prepend vault[i] at CPI time, so caller's
+        // route_account_count + 1 must fit MAX_JUPITER_CPI_ACCOUNTS.
+        if route_account_count + 1 > MAX_JUPITER_CPI_ACCOUNTS {
+            return Err(ProgramError::InvalidArgument);
+        }
+        leg_amounts[i] = leg_amount;
+        leg_route_account_counts[i] = route_account_count;
+        leg_route_byte_offsets[i] = cursor;
+        leg_route_byte_lens[i] = route_len;
+        cursor += route_len;
+        sum = sum.checked_add(leg_amount).ok_or(VaultError::Overflow)?;
+        total_route_accounts = total_route_accounts
+            .checked_add(route_account_count)
+            .ok_or(VaultError::Overflow)?;
+    }
+    if sum != sol_in {
+        return Err(VaultError::LegSumMismatch.into());
+    }
+    if accounts.len() < FIXED_ACCOUNTS + tc + total_route_accounts {
+        return Err(ProgramError::NotEnoughAccountKeys);
+    }
+
+    // ─── wrap SOL ──────────────────────────────────────────────────
+    // Snapshot wSOL ATA balance before Transfer to detect stale residuals.
+    // sync_native after a system Transfer makes the SPL token balance
+    // equal `lamports - rent_exempt_minimum`, so any pre-existing
+    // wSOL would be folded into our calculations and inflate mint.
+    let wsol_pre = read_token_account_balance(wsol_ata)?;
+
+    pinocchio_system::instructions::Transfer {
+        from: depositor,
+        to: wsol_ata,
+        lamports: sol_in,
+    }
+    .invoke()?;
+
+    SyncNative { native_token: wsol_ata }.invoke()?;
+
+    let wsol_post_wrap = read_token_account_balance(wsol_ata)?;
+    let expected_post = wsol_pre.checked_add(sol_in).ok_or(VaultError::Overflow)?;
+    if wsol_post_wrap != expected_post {
+        // Stale balance or sync_native didn't behave as expected — abort
+        // before any Jupiter CPI runs. LegSumMismatch is the closest
+        // semantic fit for "the books don't balance".
+        return Err(VaultError::LegSumMismatch.into());
+    }
+
+    // ─── snapshot pre-CPI vault balances ───────────────────────────
+    let mut pre_balances = [0u64; 5];
+    for i in 0..tc {
+        pre_balances[i] = read_token_account_balance(&accounts[FIXED_ACCOUNTS + i])?;
+    }
+
+    // ─── per-leg Jupiter CPIs ──────────────────────────────────────
+    let mut route_cursor = FIXED_ACCOUNTS + tc;
+    for i in 0..tc {
+        let cnt = leg_route_account_counts[i];
+
+        // Build route_accounts slice: [vault[i]] + caller route accounts.
+        // Use MaybeUninit storage to keep this allocation-free.
+        let mut refs_storage: [core::mem::MaybeUninit<&AccountInfo>; MAX_JUPITER_CPI_ACCOUNTS] =
+            unsafe { core::mem::MaybeUninit::uninit().assume_init() };
+        refs_storage[0].write(&accounts[FIXED_ACCOUNTS + i]);
+        for j in 0..cnt {
+            refs_storage[j + 1].write(&accounts[route_cursor + j]);
+        }
+        let refs: &[&AccountInfo] = unsafe {
+            core::slice::from_raw_parts(refs_storage.as_ptr() as *const &AccountInfo, cnt + 1)
+        };
+
+        let route_bytes_start = leg_route_byte_offsets[i];
+        let route_bytes_end = route_bytes_start + leg_route_byte_lens[i];
+        let route_bytes = &leg_data[route_bytes_start..route_bytes_end];
+
+        invoke_jupiter_leg(jupiter_program, refs, route_bytes, None)?;
+
+        route_cursor += cnt;
+    }
+
+    // ─── verify vault deltas + compute mint amount ─────────────────
+    // Per-vault mint candidates = delta * total_supply / pre_balance.
+    // Take min with NAV deviation guard (mirrors Deposit). Reject any
+    // leg that produced no output — Jupiter aborted the route silently
+    // or `route_bytes` were stale and Jupiter's own slippage fired.
+    let mut min_mint: Option<u128> = None;
+    let mut max_mint: Option<u128> = None;
+    for i in 0..tc {
+        let post = read_token_account_balance(&accounts[FIXED_ACCOUNTS + i])?;
+        let delta = post
+            .checked_sub(pre_balances[i])
+            .ok_or(VaultError::Overflow)?;
+        if delta == 0 {
+            return Err(VaultError::JupiterCpiNoOutput.into());
+        }
+        if pre_balances[i] == 0 {
+            // Should be unreachable given total_supply > 0 + bootstrapped
+            // basket, but guard against the divide by zero just in case.
+            return Err(VaultError::DivisionByZero.into());
+        }
+        let candidate = (delta as u128)
+            .checked_mul(total_supply as u128)
+            .ok_or(VaultError::Overflow)?
+            .checked_div(pre_balances[i] as u128)
+            .ok_or(VaultError::DivisionByZero)?;
+        min_mint = Some(match min_mint {
+            Some(cur) => cur.min(candidate),
+            None => candidate,
+        });
+        max_mint = Some(match max_mint {
+            Some(cur) => cur.max(candidate),
+            None => candidate,
+        });
+    }
+    let lo = min_mint.ok_or(VaultError::DivisionByZero)?;
+    let hi = max_mint.ok_or(VaultError::DivisionByZero)?;
+    if lo == 0 {
+        return Err(VaultError::JupiterCpiNoOutput.into());
+    }
+    let spread = hi.checked_sub(lo).ok_or(VaultError::Overflow)?;
+    if spread
+        .checked_mul(10_000)
+        .ok_or(VaultError::Overflow)?
+        > lo.checked_mul(MAX_NAV_DEVIATION_BPS as u128)
+            .ok_or(VaultError::Overflow)?
+    {
+        return Err(VaultError::NavDeviationExceeded.into());
+    }
+    let mint_amount = lo as u64;
+
+    if mint_amount < min_etf_out {
+        return Err(VaultError::SlippageExceeded.into());
+    }
+
+    // ─── fee + mint ────────────────────────────────────────────────
+    let fee_amount = mint_amount
+        .checked_mul(fee_bps as u64)
+        .ok_or(VaultError::Overflow)?
+        / 10_000;
+    let net_mint = mint_amount
+        .checked_sub(fee_amount)
+        .ok_or(VaultError::Overflow)?;
+
+    let bump_bytes = [bump_seed];
+    let mint_signer_seeds = [
+        Seed::from(b"etf".as_ref()),
+        Seed::from(authority.as_ref()),
+        Seed::from(name),
+        Seed::from(bump_bytes.as_ref()),
+    ];
+
+    MintTo {
+        mint: etf_mint_ai,
+        account: depositor_etf_ata,
+        mint_authority: etf_state_ai,
+        amount: net_mint,
+    }
+    .invoke_signed(&[Signer::from(&mint_signer_seeds)])?;
+
+    if fee_amount > 0 {
+        MintTo {
+            mint: etf_mint_ai,
+            account: treasury_etf_ata,
+            mint_authority: etf_state_ai,
+            amount: fee_amount,
+        }
+        .invoke_signed(&[Signer::from(&mint_signer_seeds)])?;
+    }
+
+    {
+        let mut data = etf_state_ai.try_borrow_mut_data()?;
+        let etf =
+            unsafe { load_mut::<EtfState>(&mut data) }.ok_or(ProgramError::InvalidAccountData)?;
+        etf.total_supply = etf
+            .total_supply
+            .checked_add(mint_amount)
+            .ok_or(VaultError::Overflow)?;
+    }
+
+    // Suppress unused-binding warnings on the captured weights — kept
+    // in scope so future per-leg weight checks (#36 follow-up) can
+    // land without a re-read of etf_state.
+    let _ = weights;
+
+    Ok(())
 }

--- a/contracts/axis-vault/src/instructions/mod.rs
+++ b/contracts/axis-vault/src/instructions/mod.rs
@@ -1,11 +1,15 @@
 pub mod create_etf;
 pub mod deposit;
+pub mod deposit_sol;
 pub mod set_paused;
 pub mod sweep_treasury;
 pub mod withdraw;
+pub mod withdraw_sol;
 
 pub use create_etf::process_create_etf;
 pub use deposit::process_deposit;
+pub use deposit_sol::process_deposit_sol;
 pub use set_paused::process_set_paused;
 pub use sweep_treasury::process_sweep_treasury;
 pub use withdraw::process_withdraw;
+pub use withdraw_sol::process_withdraw_sol;

--- a/contracts/axis-vault/src/instructions/withdraw_sol.rs
+++ b/contracts/axis-vault/src/instructions/withdraw_sol.rs
@@ -1,29 +1,32 @@
 //! WithdrawSol — SOL-out variant of Withdraw. Issue #36.
 //!
-//! # Status: SCAFFOLDING
+//! Burns ETF tokens, executes one Jupiter V6 swap per basket leg
+//! (sourcing from the corresponding vault into wSOL), then unwraps
+//! the accumulated wSOL into SOL for the withdrawer.
 //!
-//! Dispatcher hook + account layout + parameter validation. Jupiter CPI
-//! body returns `VaultError::NotYetImplemented` pending design review
-//! on PR #58 (the sibling DepositSol scaffold).
+//! As with DepositSol, `route_bytes` are opaque and the caller is
+//! responsible for crafting them with `source_mint = etf.token_mints[i]`,
+//! `destination_mint = wSOL`. Per-leg CPI metas are
+//! `[vault[i]] + caller_route_accounts[i]`.
 //!
-//! # Account layout (design target)
+//! # Account layout
 //!
 //! ```text
-//! 0: [signer]            withdrawer
-//! 1: [writable]          etf_state PDA
-//! 2: [writable]          etf_mint
-//! 3: [writable]          withdrawer_etf_ata (burned)
-//! 4: []                  token_program
-//! 5: [writable]          treasury_etf_ata (fee recipient)
-//! 6: [writable]          wsol_ata (withdrawer-owned, temporary)
-//! 7: []                  wsol_mint
-//! 8: []                  jupiter_program
-//! 9: []                  system_program
-//! 10..10+tc: [writable]  per-leg basket vaults
-//! 11+tc..: variable       per-leg Jupiter route accounts
+//! 0:  [signer, writable]  withdrawer
+//! 1:  [writable]          etf_state PDA
+//! 2:  [writable]          etf_mint
+//! 3:  [writable]          withdrawer_etf_ata (burned)
+//! 4:  []                  token_program
+//! 5:  [writable]          treasury_etf_ata (fee recipient)
+//! 6:  [writable]          wsol_ata (withdrawer-owned, accumulator)
+//! 7:  []                  wsol_mint
+//! 8:  []                  jupiter_program
+//! 9:  []                  system_program
+//! 10..10+tc:    [writable]   per-leg basket vaults (validation + delta)
+//! 10+tc..:      []           concatenated per-leg Jupiter route accounts
 //! ```
 //!
-//! # Instruction data (design target)
+//! # Instruction data
 //!
 //! ```text
 //! [burn_amount:   u64 LE]
@@ -31,27 +34,43 @@
 //! [name_len:      u8]   [name: bytes]
 //! [leg_count:     u8]   (must equal etf.token_count, <= 3)
 //! per leg:
-//!   [route_len:   u32 LE]
-//!   [route_bytes: route_len bytes]
+//!   [route_account_count: u8]
+//!   [route_len:           u32 LE]
+//!   [route_bytes:         route_len bytes]
 //! ```
 //!
-//! (No per-leg amount needed on Withdraw — the amount is derived from
-//! the burn's proportional basket share.)
+//! No per-leg amount on Withdraw — the per-vault amount is computed
+//! from the burn share.
 
 use pinocchio::{
-    account_info::AccountInfo, pubkey::Pubkey, ProgramResult,
+    account_info::AccountInfo,
+    instruction::{Seed, Signer},
+    program_error::ProgramError,
+    pubkey::Pubkey,
+    ProgramResult,
 };
+use pinocchio_token::instructions::{Burn, CloseAccount, Transfer};
 
+use crate::constants::TOKEN_PROGRAM_ID;
 use crate::error::VaultError;
 use crate::instructions::deposit_sol::MAX_ONCHAIN_SOL_IX_LEGS;
+use crate::jupiter::{
+    invoke_jupiter_leg, read_token_account_balance, JUPITER_PROGRAM_ID, MAX_JUPITER_CPI_ACCOUNTS,
+    WSOL_MINT,
+};
+use crate::state::{load, load_mut, EtfState};
 
+const FIXED_ACCOUNTS: usize = 10;
+
+#[allow(clippy::too_many_arguments)]
 pub fn process_withdraw_sol(
-    _program_id: &Pubkey,
-    _accounts: &[AccountInfo],
+    program_id: &Pubkey,
+    accounts: &[AccountInfo],
     burn_amount: u64,
-    _min_sol_out: u64,
-    _name: &[u8],
+    min_sol_out: u64,
+    name: &[u8],
     leg_count: u8,
+    leg_data: &[u8],
 ) -> ProgramResult {
     if burn_amount == 0 {
         return Err(VaultError::ZeroDeposit.into());
@@ -59,18 +78,252 @@ pub fn process_withdraw_sol(
     if leg_count == 0 || leg_count > MAX_ONCHAIN_SOL_IX_LEGS {
         return Err(VaultError::BasketTooLargeForOnchainSol.into());
     }
+    let tc = leg_count as usize;
 
-    // TODO(#36, followup after design review):
-    //   1. Compute per-vault basket amounts from burn share (existing
-    //      Withdraw math).
-    //   2. Burn etf tokens + mint fee to treasury (existing Withdraw
-    //      accounting).
-    //   3. For each leg i:
-    //      - Invoke Jupiter V6 CPI with route_bytes[i] swapping
-    //        basket_out[i] -> wSOL.
-    //      - Jupiter writes into wsol_ata; accumulate total_wsol_out.
-    //   4. Enforce total_wsol_out >= min_sol_out (strict on-chain).
-    //   5. sync_native + close wsol_ata -> withdrawer (SOL to user).
+    if accounts.len() < FIXED_ACCOUNTS + tc {
+        return Err(ProgramError::NotEnoughAccountKeys);
+    }
 
-    Err(VaultError::NotYetImplemented.into())
+    let withdrawer = &accounts[0];
+    let etf_state_ai = &accounts[1];
+    let etf_mint_ai = &accounts[2];
+    let withdrawer_etf_ata = &accounts[3];
+    let _tok = &accounts[4];
+    let treasury_etf_ata = &accounts[5];
+    let wsol_ata = &accounts[6];
+    let wsol_mint_ai = &accounts[7];
+    let jupiter_program = &accounts[8];
+    let _system_program = &accounts[9];
+
+    if !withdrawer.is_signer() {
+        return Err(ProgramError::MissingRequiredSignature);
+    }
+    if etf_state_ai.owner() != program_id {
+        return Err(VaultError::InvalidProgramOwner.into());
+    }
+    if jupiter_program.key().as_ref() != &JUPITER_PROGRAM_ID {
+        return Err(VaultError::InvalidJupiterProgram.into());
+    }
+    if wsol_mint_ai.key().as_ref() != &WSOL_MINT {
+        return Err(VaultError::WsolMintMismatch.into());
+    }
+
+    // ─── load etf state ────────────────────────────────────────────
+    let (token_count, total_supply, authority, bump_seed, fee_bps, treasury, etf_mint, token_vaults) = {
+        let data = etf_state_ai.try_borrow_data()?;
+        let etf =
+            unsafe { load::<EtfState>(&data) }.ok_or(ProgramError::InvalidAccountData)?;
+        if !etf.is_initialized() {
+            return Err(VaultError::InvalidDiscriminator.into());
+        }
+        if etf.paused != 0 {
+            return Err(VaultError::PoolPaused.into());
+        }
+        if etf.total_supply == 0 {
+            return Err(VaultError::DivisionByZero.into());
+        }
+        (
+            etf.token_count as usize,
+            etf.total_supply,
+            etf.authority,
+            etf.bump,
+            etf.fee_bps,
+            etf.treasury,
+            etf.etf_mint,
+            etf.token_vaults,
+        )
+    };
+
+    if tc != token_count {
+        return Err(VaultError::LegCountMismatch.into());
+    }
+    if etf_mint_ai.key() != &etf_mint {
+        return Err(VaultError::MintMismatch.into());
+    }
+
+    if treasury_etf_ata.owner() != &TOKEN_PROGRAM_ID {
+        return Err(VaultError::TreasuryMismatch.into());
+    }
+    {
+        let data = treasury_etf_ata.try_borrow_data()?;
+        if data.len() < 64 {
+            return Err(ProgramError::InvalidAccountData);
+        }
+        if &data[32..64] != &treasury {
+            return Err(VaultError::TreasuryMismatch.into());
+        }
+    }
+
+    for i in 0..tc {
+        if accounts[FIXED_ACCOUNTS + i].key() != &token_vaults[i] {
+            return Err(VaultError::VaultMismatch.into());
+        }
+    }
+
+    if burn_amount > total_supply {
+        return Err(VaultError::InsufficientBalance.into());
+    }
+
+    // ─── parse leg_data ────────────────────────────────────────────
+    // Per leg: [route_account_count u8][route_len u32][route_bytes]
+    let mut leg_route_account_counts = [0usize; 5];
+    let mut leg_route_byte_offsets = [0usize; 5];
+    let mut leg_route_byte_lens = [0usize; 5];
+    let mut total_route_accounts = 0usize;
+    let mut cursor = 0usize;
+    for i in 0..tc {
+        if leg_data.len() < cursor + 1 + 4 {
+            return Err(VaultError::MalformedLegData.into());
+        }
+        let route_account_count = leg_data[cursor] as usize;
+        cursor += 1;
+        let route_len = u32::from_le_bytes(
+            leg_data[cursor..cursor + 4]
+                .try_into()
+                .map_err(|_| VaultError::MalformedLegData)?,
+        ) as usize;
+        cursor += 4;
+        if leg_data.len() < cursor + route_len {
+            return Err(VaultError::MalformedLegData.into());
+        }
+        if route_account_count + 1 > MAX_JUPITER_CPI_ACCOUNTS {
+            return Err(ProgramError::InvalidArgument);
+        }
+        leg_route_account_counts[i] = route_account_count;
+        leg_route_byte_offsets[i] = cursor;
+        leg_route_byte_lens[i] = route_len;
+        cursor += route_len;
+        total_route_accounts = total_route_accounts
+            .checked_add(route_account_count)
+            .ok_or(VaultError::Overflow)?;
+    }
+    if accounts.len() < FIXED_ACCOUNTS + tc + total_route_accounts {
+        return Err(ProgramError::NotEnoughAccountKeys);
+    }
+
+    // ─── fee + effective burn (mirrors Withdraw) ───────────────────
+    let fee_amount = burn_amount
+        .checked_mul(fee_bps as u64)
+        .ok_or(VaultError::Overflow)?
+        / 10_000;
+    let effective_burn = burn_amount
+        .checked_sub(fee_amount)
+        .ok_or(VaultError::Overflow)?;
+
+    // Compute per-vault swap amount = vault_balance * effective_burn / total_supply
+    let mut per_vault_amount = [0u64; 5];
+    for i in 0..tc {
+        let vault_balance = read_token_account_balance(&accounts[FIXED_ACCOUNTS + i])?;
+        let amt = (vault_balance as u128)
+            .checked_mul(effective_burn as u128)
+            .ok_or(VaultError::Overflow)?
+            .checked_div(total_supply as u128)
+            .ok_or(VaultError::DivisionByZero)? as u64;
+        per_vault_amount[i] = amt;
+    }
+
+    // Transfer fee portion (ETF tokens) to treasury, burn effective_burn.
+    if fee_amount > 0 {
+        Transfer {
+            from: withdrawer_etf_ata,
+            to: treasury_etf_ata,
+            authority: withdrawer,
+            amount: fee_amount,
+        }
+        .invoke()?;
+    }
+
+    Burn {
+        account: withdrawer_etf_ata,
+        mint: etf_mint_ai,
+        authority: withdrawer,
+        amount: effective_burn,
+    }
+    .invoke()?;
+
+    // ─── snapshot pre-CPI wSOL balance ─────────────────────────────
+    let wsol_pre = read_token_account_balance(wsol_ata)?;
+
+    // ─── per-leg Jupiter CPIs (vault PDA signs) ────────────────────
+    // Vault PDA = etf_state PDA. Seeds: [b"etf", authority, name, bump].
+    let bump_bytes = [bump_seed];
+    let vault_signer_seeds = [
+        Seed::from(b"etf".as_ref()),
+        Seed::from(authority.as_ref()),
+        Seed::from(name),
+        Seed::from(bump_bytes.as_ref()),
+    ];
+    let vault_signer = Signer::from(&vault_signer_seeds);
+
+    let mut route_cursor = FIXED_ACCOUNTS + tc;
+    for i in 0..tc {
+        let cnt = leg_route_account_counts[i];
+
+        // Skip legs with zero swap amount — small dust withdrawals on
+        // a token whose vault is empty would otherwise hit Jupiter
+        // with a no-op route and burn CU.
+        if per_vault_amount[i] == 0 {
+            route_cursor += cnt;
+            continue;
+        }
+
+        let mut refs_storage: [core::mem::MaybeUninit<&AccountInfo>; MAX_JUPITER_CPI_ACCOUNTS] =
+            unsafe { core::mem::MaybeUninit::uninit().assume_init() };
+        refs_storage[0].write(&accounts[FIXED_ACCOUNTS + i]);
+        for j in 0..cnt {
+            refs_storage[j + 1].write(&accounts[route_cursor + j]);
+        }
+        let refs: &[&AccountInfo] = unsafe {
+            core::slice::from_raw_parts(refs_storage.as_ptr() as *const &AccountInfo, cnt + 1)
+        };
+
+        let route_bytes_start = leg_route_byte_offsets[i];
+        let route_bytes_end = route_bytes_start + leg_route_byte_lens[i];
+        let route_bytes = &leg_data[route_bytes_start..route_bytes_end];
+
+        invoke_jupiter_leg(jupiter_program, refs, route_bytes, Some(&vault_signer))?;
+
+        route_cursor += cnt;
+    }
+
+    // ─── verify wSOL accumulator + slippage gate ───────────────────
+    let wsol_post = read_token_account_balance(wsol_ata)?;
+    let total_wsol_out = wsol_post
+        .checked_sub(wsol_pre)
+        .ok_or(VaultError::Overflow)?;
+    if total_wsol_out == 0 {
+        return Err(VaultError::JupiterCpiNoOutput.into());
+    }
+    if total_wsol_out < min_sol_out {
+        return Err(VaultError::SlippageExceeded.into());
+    }
+
+    // ─── unwrap wSOL → SOL by closing the wsol_ata to withdrawer ───
+    // CloseAccount sends the entire lamport balance (rent + wSOL) to
+    // the destination. wsol_ata is withdrawer-owned, so withdrawer
+    // signs the close. Withdrawer ends up with a slightly higher SOL
+    // balance than `total_wsol_out` (rent reserve is reclaimed). For
+    // a strict slippage gate, we already enforced
+    // total_wsol_out >= min_sol_out above.
+    CloseAccount {
+        account: wsol_ata,
+        destination: withdrawer,
+        authority: withdrawer,
+    }
+    .invoke()?;
+
+    // ─── update total_supply ───────────────────────────────────────
+    {
+        let mut data = etf_state_ai.try_borrow_mut_data()?;
+        let etf =
+            unsafe { load_mut::<EtfState>(&mut data) }.ok_or(ProgramError::InvalidAccountData)?;
+        // Only the burned portion leaves circulation. Fee tokens were
+        // transferred (not burned) so they stay in supply.
+        etf.total_supply = etf
+            .total_supply
+            .checked_sub(effective_burn)
+            .ok_or(VaultError::Overflow)?;
+    }
+
+    Ok(())
 }

--- a/contracts/axis-vault/src/instructions/withdraw_sol.rs
+++ b/contracts/axis-vault/src/instructions/withdraw_sol.rs
@@ -1,0 +1,76 @@
+//! WithdrawSol — SOL-out variant of Withdraw. Issue #36.
+//!
+//! # Status: SCAFFOLDING
+//!
+//! Dispatcher hook + account layout + parameter validation. Jupiter CPI
+//! body returns `VaultError::NotYetImplemented` pending design review
+//! on PR #58 (the sibling DepositSol scaffold).
+//!
+//! # Account layout (design target)
+//!
+//! ```text
+//! 0: [signer]            withdrawer
+//! 1: [writable]          etf_state PDA
+//! 2: [writable]          etf_mint
+//! 3: [writable]          withdrawer_etf_ata (burned)
+//! 4: []                  token_program
+//! 5: [writable]          treasury_etf_ata (fee recipient)
+//! 6: [writable]          wsol_ata (withdrawer-owned, temporary)
+//! 7: []                  wsol_mint
+//! 8: []                  jupiter_program
+//! 9: []                  system_program
+//! 10..10+tc: [writable]  per-leg basket vaults
+//! 11+tc..: variable       per-leg Jupiter route accounts
+//! ```
+//!
+//! # Instruction data (design target)
+//!
+//! ```text
+//! [burn_amount:   u64 LE]
+//! [min_sol_out:   u64 LE]
+//! [name_len:      u8]   [name: bytes]
+//! [leg_count:     u8]   (must equal etf.token_count, <= 3)
+//! per leg:
+//!   [route_len:   u32 LE]
+//!   [route_bytes: route_len bytes]
+//! ```
+//!
+//! (No per-leg amount needed on Withdraw — the amount is derived from
+//! the burn's proportional basket share.)
+
+use pinocchio::{
+    account_info::AccountInfo, pubkey::Pubkey, ProgramResult,
+};
+
+use crate::error::VaultError;
+use crate::instructions::deposit_sol::MAX_ONCHAIN_SOL_IX_LEGS;
+
+pub fn process_withdraw_sol(
+    _program_id: &Pubkey,
+    _accounts: &[AccountInfo],
+    burn_amount: u64,
+    _min_sol_out: u64,
+    _name: &[u8],
+    leg_count: u8,
+) -> ProgramResult {
+    if burn_amount == 0 {
+        return Err(VaultError::ZeroDeposit.into());
+    }
+    if leg_count == 0 || leg_count > MAX_ONCHAIN_SOL_IX_LEGS {
+        return Err(VaultError::BasketTooLargeForOnchainSol.into());
+    }
+
+    // TODO(#36, followup after design review):
+    //   1. Compute per-vault basket amounts from burn share (existing
+    //      Withdraw math).
+    //   2. Burn etf tokens + mint fee to treasury (existing Withdraw
+    //      accounting).
+    //   3. For each leg i:
+    //      - Invoke Jupiter V6 CPI with route_bytes[i] swapping
+    //        basket_out[i] -> wSOL.
+    //      - Jupiter writes into wsol_ata; accumulate total_wsol_out.
+    //   4. Enforce total_wsol_out >= min_sol_out (strict on-chain).
+    //   5. sync_native + close wsol_ata -> withdrawer (SOL to user).
+
+    Err(VaultError::NotYetImplemented.into())
+}

--- a/contracts/axis-vault/src/jupiter.rs
+++ b/contracts/axis-vault/src/jupiter.rs
@@ -1,0 +1,126 @@
+//! Jupiter V6 integration helpers for axis-vault DepositSol / WithdrawSol.
+//!
+//! Provides:
+//!   - `JUPITER_PROGRAM_ID` for CPI validation
+//!   - `WSOL_MINT` for wsol_mint validation
+//!   - `MAX_JUPITER_CPI_ACCOUNTS` per-leg account budget
+//!   - `read_token_account_balance` SPL token balance reader
+//!   - `invoke_jupiter_leg` helper that builds + invokes a single Jupiter CPI
+//!
+//! The main difference from `axis-g3m/src/jupiter.rs` is that DepositSol
+//! depositor-signs (no PDA seeds) while WithdrawSol PDA-signs through
+//! the etf_state PDA. `invoke_jupiter_leg` accepts an optional signer.
+
+use pinocchio::{
+    account_info::AccountInfo,
+    instruction::{AccountMeta, Instruction, Signer},
+    program_error::ProgramError,
+    pubkey::Pubkey,
+};
+
+use crate::error::VaultError;
+
+/// Jupiter V6 program ID bytes (base58
+/// `JUP6LkbZbjS1jKKwapdHNy74zcZ3tLUZoi5QNyVTaV4`). Mirrors
+/// axis-g3m/src/jupiter.rs so the on-chain SOL ixes target the same
+/// program the Rebalance flow already trusts.
+pub const JUPITER_PROGRAM_ID: [u8; 32] = [
+    0x04, 0x79, 0xd5, 0x5b, 0xf2, 0x31, 0xc0, 0x6e,
+    0xee, 0x74, 0xc5, 0x6e, 0xce, 0x68, 0x15, 0x07,
+    0xfd, 0xb1, 0xb2, 0xde, 0xa3, 0xf4, 0x8e, 0x51,
+    0x02, 0xb1, 0xcd, 0xa2, 0x56, 0xbc, 0x13, 0x8f,
+];
+
+/// Wrapped-SOL mint (`So11111111111111111111111111111111111111112`).
+pub const WSOL_MINT: [u8; 32] = [
+    0x06, 0x9b, 0x88, 0x57, 0xfe, 0xab, 0x81, 0x84,
+    0xfb, 0x68, 0x7f, 0x63, 0x46, 0x18, 0xc0, 0x35,
+    0xda, 0xc4, 0x39, 0xdc, 0x1a, 0xeb, 0x3b, 0x55,
+    0x98, 0xa0, 0xf0, 0x00, 0x00, 0x00, 0x00, 0x01,
+];
+
+/// Per-leg account-list budget. Jupiter routes typically carry 20-32
+/// accounts; keep one slot for the wSOL ATA and bound the tail. With
+/// `MAX_ONCHAIN_SOL_IX_LEGS = 3` and 32 per leg the worst-case account
+/// count stays inside the versioned-tx envelope (96 + fixed-prefix
+/// accounts).
+pub const MAX_JUPITER_CPI_ACCOUNTS: usize = 32;
+
+/// Read u64 balance from an SPL token account at offset 64. Mirrors
+/// axis-g3m's helper. Returns InvalidAccountData on truncated data.
+pub fn read_token_account_balance(account: &AccountInfo) -> Result<u64, ProgramError> {
+    let data = account.try_borrow_data()?;
+    if data.len() < 72 {
+        return Err(ProgramError::InvalidAccountData);
+    }
+    Ok(u64::from_le_bytes(
+        data[64..72]
+            .try_into()
+            .map_err(|_| ProgramError::InvalidAccountData)?,
+    ))
+}
+
+/// Invoke a single Jupiter V6 swap leg with the provided route bytes
+/// and account slice. The first `route_accounts.len()` AccountInfo
+/// references in `route_accounts` become both the AccountMeta list and
+/// the AccountInfo list passed to the CPI; metas are derived from each
+/// AccountInfo's signer/writable flags. Optionally accepts a PDA
+/// signer for vault-side WithdrawSol legs.
+///
+/// Returns the bound used internally so callers can size their CU
+/// budget against `MAX_JUPITER_CPI_ACCOUNTS`.
+#[allow(clippy::too_many_arguments)]
+pub fn invoke_jupiter_leg(
+    jupiter_program: &AccountInfo,
+    route_accounts: &[&AccountInfo],
+    route_bytes: &[u8],
+    pda_signer: Option<&Signer>,
+) -> Result<(), ProgramError> {
+    if jupiter_program.key().as_ref() != &JUPITER_PROGRAM_ID {
+        return Err(VaultError::InvalidJupiterProgram.into());
+    }
+    if route_accounts.len() > MAX_JUPITER_CPI_ACCOUNTS {
+        return Err(ProgramError::InvalidArgument);
+    }
+
+    // Build AccountMeta list. We use writable + signer flags from the
+    // AccountInfo itself; clients must build the tx with the right
+    // flags, the same way Jupiter expects when called directly.
+    let mut metas_storage: [core::mem::MaybeUninit<AccountMeta>; MAX_JUPITER_CPI_ACCOUNTS] =
+        unsafe { core::mem::MaybeUninit::uninit().assume_init() };
+    for (i, ai) in route_accounts.iter().enumerate() {
+        metas_storage[i].write(AccountMeta::from(*ai));
+    }
+    let metas: &[AccountMeta] = unsafe {
+        core::slice::from_raw_parts(
+            metas_storage.as_ptr() as *const AccountMeta,
+            route_accounts.len(),
+        )
+    };
+
+    let jup_pid = unsafe { &*(&JUPITER_PROGRAM_ID as *const [u8; 32] as *const Pubkey) };
+    let cpi_ix = Instruction {
+        program_id: jup_pid,
+        accounts: metas,
+        data: route_bytes,
+    };
+
+    match pda_signer {
+        Some(signer) => {
+            let signers = [signer.clone()];
+            pinocchio::cpi::invoke_signed_with_bounds::<MAX_JUPITER_CPI_ACCOUNTS>(
+                &cpi_ix,
+                route_accounts,
+                &signers,
+            )
+        }
+        None => {
+            // No PDA signature needed; depositor signs at the tx level.
+            pinocchio::cpi::invoke_signed_with_bounds::<MAX_JUPITER_CPI_ACCOUNTS>(
+                &cpi_ix,
+                route_accounts,
+                &[],
+            )
+        }
+    }
+}

--- a/contracts/axis-vault/src/lib.rs
+++ b/contracts/axis-vault/src/lib.rs
@@ -16,6 +16,7 @@ fn panic(_info: &core::panic::PanicInfo) -> ! {
 pub mod constants;
 pub mod error;
 pub mod instructions;
+pub mod jupiter;
 pub mod state;
 
 use pinocchio::{
@@ -186,7 +187,7 @@ pub fn process_instruction(
 
         Instruction::DepositSol => {
             // Data: [sol_in: u64][min_etf_out: u64][name_len: u8][name]
-            //       [leg_count: u8][per-leg routes: variable]
+            //       [leg_count: u8][per-leg payload: variable]
             if data.len() < 18 {
                 return Err(ProgramError::InvalidInstructionData);
             }
@@ -204,14 +205,15 @@ pub fn process_instruction(
             }
             let name = &data[17..17 + name_len];
             let leg_count = data[17 + name_len];
+            let leg_data = &data[17 + name_len + 1..];
             instructions::process_deposit_sol(
-                program_id, accounts, sol_in, min_etf_out, name, leg_count,
+                program_id, accounts, sol_in, min_etf_out, name, leg_count, leg_data,
             )
         }
 
         Instruction::WithdrawSol => {
             // Data: [burn_amount: u64][min_sol_out: u64][name_len: u8][name]
-            //       [leg_count: u8][per-leg routes: variable]
+            //       [leg_count: u8][per-leg payload: variable]
             if data.len() < 18 {
                 return Err(ProgramError::InvalidInstructionData);
             }
@@ -229,8 +231,9 @@ pub fn process_instruction(
             }
             let name = &data[17..17 + name_len];
             let leg_count = data[17 + name_len];
+            let leg_data = &data[17 + name_len + 1..];
             instructions::process_withdraw_sol(
-                program_id, accounts, burn_amount, min_sol_out, name, leg_count,
+                program_id, accounts, burn_amount, min_sol_out, name, leg_count, leg_data,
             )
         }
     }

--- a/contracts/axis-vault/src/lib.rs
+++ b/contracts/axis-vault/src/lib.rs
@@ -32,8 +32,13 @@ enum Instruction {
     Withdraw = 2,
     SweepTreasury = 3,
     /// SetPaused — authority-gated flip of the `paused` flag (#33).
-    /// Unblocks the paused-pool e2e scenarios kidney flagged.
     SetPaused = 4,
+    /// DepositSol — SOL-in variant with on-chain Jupiter CPI + strict
+    /// slippage gate. Scaffolding only — returns NotYetImplemented
+    /// until the follow-up design review (#36).
+    DepositSol = 5,
+    /// WithdrawSol — SOL-out variant, same status as DepositSol.
+    WithdrawSol = 6,
 }
 
 impl Instruction {
@@ -44,6 +49,8 @@ impl Instruction {
             2 => Some(Instruction::Withdraw),
             3 => Some(Instruction::SweepTreasury),
             4 => Some(Instruction::SetPaused),
+            5 => Some(Instruction::DepositSol),
+            6 => Some(Instruction::WithdrawSol),
             _ => None,
         }
     }
@@ -175,6 +182,56 @@ pub fn process_instruction(
                 return Err(ProgramError::InvalidInstructionData);
             }
             instructions::process_set_paused(program_id, accounts, data[0])
+        }
+
+        Instruction::DepositSol => {
+            // Data: [sol_in: u64][min_etf_out: u64][name_len: u8][name]
+            //       [leg_count: u8][per-leg routes: variable]
+            if data.len() < 18 {
+                return Err(ProgramError::InvalidInstructionData);
+            }
+            let sol_in = u64::from_le_bytes([
+                data[0], data[1], data[2], data[3],
+                data[4], data[5], data[6], data[7],
+            ]);
+            let min_etf_out = u64::from_le_bytes([
+                data[8], data[9], data[10], data[11],
+                data[12], data[13], data[14], data[15],
+            ]);
+            let name_len = data[16] as usize;
+            if data.len() < 17 + name_len + 1 {
+                return Err(ProgramError::InvalidInstructionData);
+            }
+            let name = &data[17..17 + name_len];
+            let leg_count = data[17 + name_len];
+            instructions::process_deposit_sol(
+                program_id, accounts, sol_in, min_etf_out, name, leg_count,
+            )
+        }
+
+        Instruction::WithdrawSol => {
+            // Data: [burn_amount: u64][min_sol_out: u64][name_len: u8][name]
+            //       [leg_count: u8][per-leg routes: variable]
+            if data.len() < 18 {
+                return Err(ProgramError::InvalidInstructionData);
+            }
+            let burn_amount = u64::from_le_bytes([
+                data[0], data[1], data[2], data[3],
+                data[4], data[5], data[6], data[7],
+            ]);
+            let min_sol_out = u64::from_le_bytes([
+                data[8], data[9], data[10], data[11],
+                data[12], data[13], data[14], data[15],
+            ]);
+            let name_len = data[16] as usize;
+            if data.len() < 17 + name_len + 1 {
+                return Err(ProgramError::InvalidInstructionData);
+            }
+            let name = &data[17..17 + name_len];
+            let leg_count = data[17 + name_len];
+            instructions::process_withdraw_sol(
+                program_id, accounts, burn_amount, min_sol_out, name, leg_count,
+            )
         }
     }
 }


### PR DESCRIPTION
Stacked on #58. Replaces the \`NotYetImplemented\` placeholder bodies with the real on-chain Jupiter V6 CPI for SOL <-> ETF flows. Closes #36 once landed (alongside the mainnet-fork test follow-up tracked in #61 item 5).

## Design questions from #58 — answered

| Q | Answer | Rationale |
|---|--------|-----------|
| tc <= 3 cap | Keep | At tc=3 each Jupiter leg consumes ~300k CU; ~500k CU headroom for post-CPI mint math under the 1.4M cap. tc=4 worst-case (1.2M CPI) leaves only 200k. |
| wSOL handling | Depositor-owned ATA + pre/post snapshot | Inline create+close was suggested in review. Going with depositor-owned + a strict \`balance == pre + sol_in\` check after \`sync_native\` — catches the stale-residual exploit cleanly without the extra create+close CU cost. |
| WithdrawSol fee path | Mirror Withdraw — ETF-token fee to \`treasury_etf_ata\` | Single sweep cranker handles both Withdraw + WithdrawSol fee accounting. Option (b) (SOL fee) needed a new fee denomination + separate sweep. |

## DepositSol flow

1. Validate: signer, etf owner, Jupiter program ID, wSOL mint, vault keys match \`etf.token_vaults\`, treasury ATA, \`leg_count == etf.token_count\`, \`total_supply > 0\` (rejects first deposit — bootstrap via \`Deposit\`).
2. Parse \`leg_data\`: \`[leg_sol_amount u64][route_account_count u8][route_len u32][route_bytes]\` per leg. \`sum(leg_sol_amount) == sol_in\`.
3. Snapshot \`wsol_ata\` balance → system Transfer \`sol_in\` → \`SyncNative\` → verify delta == \`sol_in\`.
4. Snapshot pre-CPI vault balances.
5. Per leg: CPI metas = \`[vault[i]] + caller_route_accounts[i]\`, depositor signs.
6. Verify each vault delta > 0 (else \`JupiterCpiNoOutput\`); per-vault mint candidate = \`delta * total_supply / pre_balance\`; \`MAX_NAV_DEVIATION_BPS\` guard; take min.
7. Slippage: \`mint_amount >= min_etf_out\`.
8. \`MintTo\` depositor (net) + treasury (fee), update \`total_supply\`.

## WithdrawSol flow

1. Same validation surface as DepositSol.
2. Parse \`leg_data\`: \`[route_account_count u8][route_len u32][route_bytes]\` (no per-leg amount — derived from burn share).
3. \`effective_burn = burn_amount * (10_000 - fee_bps) / 10_000\`; \`per_vault_amount[i] = vault_balance[i] * effective_burn / total_supply\`.
4. Transfer fee to \`treasury_etf_ata\`, \`Burn\` \`effective_burn\`.
5. Snapshot \`wsol_ata\` pre.
6. Per leg: skip when amount == 0 (dust); else CPI metas as above, etf_state PDA signs (\`[b"etf", authority, name, bump]\`).
7. \`wsol_post - wsol_pre >= min_sol_out\`.
8. \`CloseAccount\` unwraps \`wsol_ata\` → withdrawer SOL.
9. \`total_supply -= effective_burn\`.

## New module + error codes

- \`contracts/axis-vault/src/jupiter.rs\` — \`JUPITER_PROGRAM_ID\` (mirrors axis-g3m), \`WSOL_MINT\`, \`read_token_account_balance()\`, \`invoke_jupiter_leg()\` (optional PDA signer).
- New errors 9026..9032: \`InvalidJupiterProgram\`, \`WsolMintMismatch\`, \`LegSumMismatch\`, \`LegCountMismatch\`, \`JupiterCpiNoOutput\`, \`EtfNotBootstrapped\`, \`MalformedLegData\`.
- \`NotYetImplemented (9024)\` retained for compatibility — unused.

## Caller responsibilities

- First account of each leg's route slice MUST be \`vault[i]\` (we prepend it at CPI time; \`route_bytes\` must assume metas[0] = vault).
- \`sum(leg_sol_amount) == sol_in\` (DepositSol).
- \`leg_count == etf.token_count\` exactly — partial baskets unsupported.

## Tests

\`axis_vault_sol_ix_scaffold.rs\`:
- Removed two \`*_placeholder_returns_not_yet_implemented\` (the branch is gone).
- Added \`*_with_undersized_account_list_rejects\` (deposit + withdraw) → \`NotEnoughAccountKeys\`.
- Added \`*_rejects_leg_count_zero\` (deposit + withdraw) → \`BasketTooLargeForOnchainSol\` (locks down the new lower bound).
- Existing 4 zero-amount + oversize-basket tests still pass.

## Test plan

- [x] \`cargo build-sbf\` clean for axis-vault
- [x] \`cargo check\` clean (only the existing pinocchio cfg warnings)
- [x] \`cargo test --lib\` axis-vault — 3/3 (including new constants + size assertions)
- [x] Full A/B integration suite — green
- [ ] Mainnet-fork happy-path tests — needs the Jupiter Quote API key + recorded route fixture from #61 item 5; will land as a follow-up

## Out of scope

- Mainnet-fork CI test infra for actual Jupiter routing (#61 item 5) — needs ops-side input from @kidneyweakx
- Inline create+close wSOL refactor (alternative to depositor-owned ATA)