### PR TITLE
feat: bundle #61 follow-ups (oracle C-lite + pfda treasury migration + SetBatchId) + main CI fixes

### DIFF
--- a/.github/workflows/litesvm-jupiter-cpi.yml
+++ b/.github/workflows/litesvm-jupiter-cpi.yml
@@ -71,13 +71,36 @@ jobs:
           cd ../pfda-amm && cargo build-sbf
           cd ../axis-vault && cargo build-sbf
 
-      - name: Dump Jupiter V6 from mainnet
+      - name: Dump Jupiter V6 from mainnet (with RPC fallbacks)
+        # Mainnet-beta has flaky availability under CI load. Try it first;
+        # rotate through public mirrors on failure. Up to 3 attempts per
+        # URL with 5s/10s/15s backoff.
         run: |
           mkdir -p contracts/axis-g3m/fixtures
-          solana program dump \
-            -u https://api.mainnet-beta.solana.com \
-            JUP6LkbZbjS1jKKwapdHNy74zcZ3tLUZoi5QNyVTaV4 \
-            contracts/axis-g3m/fixtures/jupiter_v6.so
+          urls=(
+            "https://api.mainnet-beta.solana.com"
+            "https://solana-api.projectserum.com"
+            "https://rpc.ankr.com/solana"
+          )
+          ok=0
+          for url in "${urls[@]}"; do
+            for attempt in 1 2 3; do
+              echo "Attempt $attempt against $url"
+              if solana program dump \
+                  -u "$url" \
+                  JUP6LkbZbjS1jKKwapdHNy74zcZ3tLUZoi5QNyVTaV4 \
+                  contracts/axis-g3m/fixtures/jupiter_v6.so; then
+                ok=1
+                break 2
+              fi
+              sleep $((attempt * 5))
+            done
+          done
+          if [ "$ok" -ne 1 ]; then
+            echo "::error::failed to dump Jupiter V6 from any RPC"
+            exit 1
+          fi
+          ls -la contracts/axis-g3m/fixtures/jupiter_v6.so
 
       # ── LiteSVM unit tests ──
       - name: Run axis-g3m LiteSVM tests
@@ -154,15 +177,17 @@ jobs:
           solana-keygen new --force --no-bip39-passphrase --silent -o ~/.config/solana/id.json
 
       - name: Start validator with mainnet-forked Jupiter
+        # Use the locally dumped Jupiter binary (from the previous step)
+        # instead of `--clone --url mainnet-beta`. Validator startup
+        # cannot fail on RPC outages this way. Token program is
+        # bundled into solana-test-validator by default.
         run: |
           solana-test-validator \
             --reset \
             --ledger /tmp/fork-ledger \
             --bpf-program 65aE9QdVz5bapV19BGt5cyTgVitYpekGwusRoQEovNUi contracts/axis-g3m/target/deploy/axis_g3m.so \
             --bpf-program DbAPmgkrpCCZrpBMv5x1ye6nJUreqY313SuQjZsMyjEf contracts/pfda-amm-3/target/deploy/pfda_amm_3.so \
-            --clone JUP6LkbZbjS1jKKwapdHNy74zcZ3tLUZoi5QNyVTaV4 \
-            --clone TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA \
-            --url https://api.mainnet-beta.solana.com \
+            --bpf-program JUP6LkbZbjS1jKKwapdHNy74zcZ3tLUZoi5QNyVTaV4 contracts/axis-g3m/fixtures/jupiter_v6.so \
             > /tmp/fork-validator.log 2>&1 &
           echo $! > /tmp/fork-validator.pid
           for i in $(seq 1 30); do

--- a/.github/workflows/main-report.yml
+++ b/.github/workflows/main-report.yml
@@ -59,13 +59,38 @@ jobs:
           cd contracts/axis-g3m && cargo build-sbf
           cd ../pfda-amm-3 && cargo build-sbf
 
-      - name: Dump Jupiter V6 from mainnet
+      - name: Dump Jupiter V6 from mainnet (with RPC fallbacks)
+        # The public mainnet-beta endpoint hits transient connection
+        # failures often enough to break this workflow on most pushes.
+        # Try mainnet-beta first; on failure rotate through alternative
+        # public RPCs that mirror Solana mainnet state. Up to 3 attempts
+        # per URL.
         run: |
           mkdir -p contracts/axis-g3m/fixtures
-          solana program dump \
-            -u https://api.mainnet-beta.solana.com \
-            JUP6LkbZbjS1jKKwapdHNy74zcZ3tLUZoi5QNyVTaV4 \
-            contracts/axis-g3m/fixtures/jupiter_v6.so
+          urls=(
+            "https://api.mainnet-beta.solana.com"
+            "https://solana-api.projectserum.com"
+            "https://rpc.ankr.com/solana"
+          )
+          ok=0
+          for url in "${urls[@]}"; do
+            for attempt in 1 2 3; do
+              echo "Attempt $attempt against $url"
+              if solana program dump \
+                  -u "$url" \
+                  JUP6LkbZbjS1jKKwapdHNy74zcZ3tLUZoi5QNyVTaV4 \
+                  contracts/axis-g3m/fixtures/jupiter_v6.so; then
+                ok=1
+                break 2
+              fi
+              sleep $((attempt * 5))
+            done
+          done
+          if [ "$ok" -ne 1 ]; then
+            echo "::error::failed to dump Jupiter V6 from any RPC"
+            exit 1
+          fi
+          ls -la contracts/axis-g3m/fixtures/jupiter_v6.so
 
       - name: Generate A/B report via LiteSVM
         run: |
@@ -84,15 +109,18 @@ jobs:
           solana-keygen new --force --no-bip39-passphrase --silent -o ~/.config/solana/id.json
 
       - name: Start validator with mainnet-forked Jupiter
+        # Use the locally dumped Jupiter binary (from the previous step)
+        # instead of `--clone --url mainnet-beta`, so validator startup
+        # doesn't hit the network and can't fail on RPC outages.
+        # Token program is bundled into solana-test-validator by default;
+        # no clone needed.
         run: |
           solana-test-validator \
             --reset \
             --ledger /tmp/fork-ledger \
             --bpf-program 65aE9QdVz5bapV19BGt5cyTgVitYpekGwusRoQEovNUi contracts/axis-g3m/target/deploy/axis_g3m.so \
             --bpf-program DbAPmgkrpCCZrpBMv5x1ye6nJUreqY313SuQjZsMyjEf contracts/pfda-amm-3/target/deploy/pfda_amm_3.so \
-            --clone JUP6LkbZbjS1jKKwapdHNy74zcZ3tLUZoi5QNyVTaV4 \
-            --clone TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA \
-            --url https://api.mainnet-beta.solana.com \
+            --bpf-program JUP6LkbZbjS1jKKwapdHNy74zcZ3tLUZoi5QNyVTaV4 contracts/axis-g3m/fixtures/jupiter_v6.so \
             > /tmp/fork-validator.log 2>&1 &
           echo $! > /tmp/fork-validator.pid
           for i in $(seq 1 30); do

--- a/contracts/ab-integration-tests/Cargo.toml
+++ b/contracts/ab-integration-tests/Cargo.toml
@@ -43,6 +43,10 @@ path = "tests/axis_vault_sol_ix_scaffold.rs"
 name = "issue_59_coverage"
 path = "tests/issue_59_coverage.rs"
 
+[[test]]
+name = "issue_61_coverage"
+path = "tests/issue_61_coverage.rs"
+
 [dependencies]
 litesvm = "0.11"
 solana-keypair = "3.1"

--- a/contracts/ab-integration-tests/src/helpers/account_builder.rs
+++ b/contracts/ab-integration-tests/src/helpers/account_builder.rs
@@ -125,7 +125,7 @@ pub fn build_pfda3_pool_state(
 }
 
 /// Build PoolState raw bytes for pfda-amm (the 2-token legacy program).
-/// Layout (240 bytes, repr(C)) per contracts/pfda-amm/src/state/pool_state.rs:
+/// Layout (272 bytes, repr(C)) per contracts/pfda-amm/src/state/pool_state.rs:
 ///   0:    discriminator "poolstat" (8)
 ///   8:    token_a_mint (32)
 ///  40:    token_b_mint (32)
@@ -147,6 +147,11 @@ pub fn build_pfda3_pool_state(
 /// 237:    reentrancy_guard (u8)
 /// 238:    paused (u8)
 /// 239:    _padding (u8)
+/// 240:    treasury (32)        ← #61 item 4 migration
+///
+/// Pass `treasury = None` to leave the field zeroed (legacy fallback —
+/// ClearBatch will use `authority` as the bid recipient). Pass `Some(addr)`
+/// to populate it for v2 behaviour.
 #[allow(clippy::too_many_arguments)]
 pub fn build_pfda_pool_state(
     token_a_mint: &Address,
@@ -163,7 +168,37 @@ pub fn build_pfda_pool_state(
     authority: &Address,
     bump: u8,
 ) -> Vec<u8> {
-    let mut d = vec![0u8; 240];
+    build_pfda_pool_state_v2(
+        token_a_mint, token_b_mint, vault_a, vault_b,
+        reserve_a, reserve_b, weight_a,
+        window_slots, current_batch_id, current_window_end,
+        base_fee_bps, authority, bump,
+        None,
+    )
+}
+
+/// Same as `build_pfda_pool_state` but with an explicit `treasury` slot
+/// for tests that need to exercise the post-migration bid-recipient
+/// path (#61 item 4). `None` produces the legacy zeroed treasury that
+/// falls back to `authority`.
+#[allow(clippy::too_many_arguments)]
+pub fn build_pfda_pool_state_v2(
+    token_a_mint: &Address,
+    token_b_mint: &Address,
+    vault_a: &Address,
+    vault_b: &Address,
+    reserve_a: u64,
+    reserve_b: u64,
+    weight_a: u32,
+    window_slots: u64,
+    current_batch_id: u64,
+    current_window_end: u64,
+    base_fee_bps: u16,
+    authority: &Address,
+    bump: u8,
+    treasury: Option<&Address>,
+) -> Vec<u8> {
+    let mut d = vec![0u8; 272];
     d[0..8].copy_from_slice(b"poolstat");
     d[8..40].copy_from_slice(token_a_mint.as_ref());
     d[40..72].copy_from_slice(token_b_mint.as_ref());
@@ -182,6 +217,9 @@ pub fn build_pfda_pool_state(
     d[204..236].copy_from_slice(authority.as_ref());
     d[236] = bump;
     // reentrancy_guard / paused / pad zero
+    if let Some(t) = treasury {
+        d[240..272].copy_from_slice(t.as_ref());
+    }
     d
 }
 

--- a/contracts/ab-integration-tests/tests/issue_61_coverage.rs
+++ b/contracts/ab-integration-tests/tests/issue_61_coverage.rs
@@ -1,0 +1,303 @@
+//! #61 follow-up coverage:
+//!
+//!   - Item 2: pfda-amm-3 ClearBatch oracle C-lite per-leg fallback
+//!     (single-feed-stale legs degrade to reserve-ratio, all-stale aborts).
+//!   - Item 4: pfda-amm dedicated `treasury` field migration. Pools
+//!     created with the v2 init format route bids to `pool.treasury`;
+//!     legacy zeroed-treasury pools fall back to `pool.authority`.
+//!   - Item 6: pfda-amm-3 SetBatchId disc 9 is feature-gated. The
+//!     standard mainnet build (no test-time-warp feature) must reject
+//!     disc 9 with InvalidInstructionData — proves the gate is in
+//!     place even without inspecting the binary.
+
+use ab_integration_tests::helpers::{account_builder::*, svm_setup::*, token_factory::*};
+use ab_integration_tests::require_fixture;
+use litesvm::LiteSVM;
+use solana_account::Account;
+use solana_address::Address;
+use solana_instruction::{account_meta::AccountMeta, Instruction};
+use solana_keypair::Keypair;
+use solana_native_token::LAMPORTS_PER_SOL;
+use solana_signer::Signer;
+use solana_transaction::Transaction;
+
+const PFDA_ERR_TREASURY_MISMATCH: u32 = 6023;
+
+fn send(svm: &mut LiteSVM, ix: Instruction, payer: &Keypair) -> Result<u64, String> {
+    let tx = Transaction::new_signed_with_payer(
+        &[ix],
+        Some(&payer.pubkey()),
+        &[payer],
+        svm.latest_blockhash(),
+    );
+    match svm.send_transaction(tx) {
+        Ok(meta) => Ok(meta.compute_units_consumed),
+        Err(e) => {
+            let mut msg = format!("{:?}", e.err);
+            for log in &e.meta.logs {
+                msg.push_str(&format!("\n  {}", log));
+            }
+            Err(msg)
+        }
+    }
+}
+
+fn assert_custom_err(err: &str, code: u32, label: &str) {
+    let hex = format!("0x{:x}", code);
+    let custom = format!("Custom({})", code);
+    assert!(
+        err.contains(&hex) || err.contains(&custom),
+        "{label}: expected {code} ({hex}), got: {err}"
+    );
+}
+
+// ─── #61 item 4 — pfda-amm treasury field migration ───────────────────
+
+fn pfda_clear_batch_ix(
+    cranker: Address,
+    pool: Address,
+    batch_queue: Address,
+    history: Address,
+    new_queue: Address,
+    bid_lamports: u64,
+    recipient: Option<Address>,
+) -> Instruction {
+    let mut accounts = vec![
+        AccountMeta::new(cranker, true),
+        AccountMeta::new(pool, false),
+        AccountMeta::new(batch_queue, false),
+        AccountMeta::new(history, false),
+        AccountMeta::new(new_queue, false),
+        AccountMeta::new_readonly(system_program_id(), false),
+        AccountMeta::new_readonly(Address::new_unique(), false), // oracle slot 6
+        AccountMeta::new_readonly(Address::new_unique(), false), // oracle slot 7
+    ];
+    if let Some(r) = recipient {
+        accounts.push(AccountMeta::new(r, false));
+    }
+    let mut data = vec![2u8];
+    data.extend_from_slice(&bid_lamports.to_le_bytes());
+    Instruction { program_id: pfda_amm_id(), accounts, data }
+}
+
+fn seed_pfda_batch_queue(svm: &mut LiteSVM, pool: Address, batch_id: u64, window_end: u64) -> Address {
+    let (queue, bump) = Address::find_program_address(
+        &[b"queue", pool.as_ref(), &batch_id.to_le_bytes()],
+        &pfda_amm_id(),
+    );
+    let qd = build_batch_queue(&pool, batch_id, 0, 0, window_end, bump);
+    svm.set_account(
+        queue,
+        Account {
+            lamports: LAMPORTS_PER_SOL,
+            data: qd,
+            owner: pfda_amm_id(),
+            executable: false,
+            rent_epoch: 0,
+        },
+    )
+    .unwrap();
+    queue
+}
+
+#[test]
+fn pfda_v2_pool_routes_bid_to_dedicated_treasury_field() {
+    // v2 pool: treasury is set to a distinct pubkey from authority.
+    // Bid recipient MUST equal treasury — passing authority gets
+    // TreasuryMismatch even though authority used to be the canonical
+    // recipient under the legacy fallback.
+    require_fixture!(PFDA_AMM_SO);
+    let mut svm = LiteSVM::new();
+    svm.add_program_from_file(pfda_amm_id(), PFDA_AMM_SO).unwrap();
+
+    let payer = Keypair::new();
+    svm.airdrop(&payer.pubkey(), 100 * LAMPORTS_PER_SOL).unwrap();
+
+    let mint_a = Address::new_unique();
+    let mint_b = Address::new_unique();
+    create_mint(&mut svm, mint_a, &payer.pubkey(), 6);
+    create_mint(&mut svm, mint_b, &payer.pubkey(), 6);
+
+    let (pool, bump) = Address::find_program_address(
+        &[b"pool", mint_a.as_ref(), mint_b.as_ref()],
+        &pfda_amm_id(),
+    );
+
+    let vault_a = Address::new_unique();
+    let vault_b = Address::new_unique();
+    create_token_account(&mut svm, vault_a, &mint_a, &pool, 1_000_000);
+    create_token_account(&mut svm, vault_b, &mint_b, &pool, 1_000_000);
+
+    // Distinct treasury pubkey
+    let treasury = Address::new_unique();
+    svm.airdrop(&treasury, LAMPORTS_PER_SOL).unwrap();
+
+    let pd = build_pfda_pool_state_v2(
+        &mint_a, &mint_b, &vault_a, &vault_b,
+        1_000_000, 1_000_000, 500_000,
+        10, 0, 0, 30,
+        &payer.pubkey(), bump,
+        Some(&treasury),
+    );
+    svm.set_account(
+        pool,
+        Account {
+            lamports: LAMPORTS_PER_SOL,
+            data: pd,
+            owner: pfda_amm_id(),
+            executable: false,
+            rent_epoch: 0,
+        },
+    )
+    .unwrap();
+
+    let queue = seed_pfda_batch_queue(&mut svm, pool, 0, 0);
+    let (hist, _) = Address::find_program_address(
+        &[b"history", pool.as_ref(), &0u64.to_le_bytes()],
+        &pfda_amm_id(),
+    );
+    let (new_queue, _) = Address::find_program_address(
+        &[b"queue", pool.as_ref(), &1u64.to_le_bytes()],
+        &pfda_amm_id(),
+    );
+
+    // Pass authority as recipient — was the legacy fallback. v2 pool
+    // routes to treasury so this must reject with TreasuryMismatch.
+    let err = send(
+        &mut svm,
+        pfda_clear_batch_ix(
+            payer.pubkey(), pool, queue, hist, new_queue,
+            2_000_000, Some(payer.pubkey()),
+        ),
+        &payer,
+    )
+    .err()
+    .expect("authority recipient on v2 pool must be rejected");
+    assert_custom_err(&err, PFDA_ERR_TREASURY_MISMATCH, "v2 pool routed to authority");
+}
+
+#[test]
+fn pfda_legacy_pool_with_zero_treasury_falls_back_to_authority() {
+    // Pre-migration pool: treasury bytes are zero. ClearBatch must
+    // accept authority as the bid recipient (legacy fallback).
+    // Wrong recipient (rogue) still rejects.
+    require_fixture!(PFDA_AMM_SO);
+    let mut svm = LiteSVM::new();
+    svm.add_program_from_file(pfda_amm_id(), PFDA_AMM_SO).unwrap();
+
+    let payer = Keypair::new();
+    svm.airdrop(&payer.pubkey(), 100 * LAMPORTS_PER_SOL).unwrap();
+
+    let mint_a = Address::new_unique();
+    let mint_b = Address::new_unique();
+    create_mint(&mut svm, mint_a, &payer.pubkey(), 6);
+    create_mint(&mut svm, mint_b, &payer.pubkey(), 6);
+
+    let (pool, bump) = Address::find_program_address(
+        &[b"pool", mint_a.as_ref(), mint_b.as_ref()],
+        &pfda_amm_id(),
+    );
+
+    let vault_a = Address::new_unique();
+    let vault_b = Address::new_unique();
+    create_token_account(&mut svm, vault_a, &mint_a, &pool, 1_000_000);
+    create_token_account(&mut svm, vault_b, &mint_b, &pool, 1_000_000);
+
+    // Legacy: treasury left zeroed.
+    let pd = build_pfda_pool_state(
+        &mint_a, &mint_b, &vault_a, &vault_b,
+        1_000_000, 1_000_000, 500_000,
+        10, 0, 0, 30,
+        &payer.pubkey(), bump,
+    );
+    svm.set_account(
+        pool,
+        Account {
+            lamports: LAMPORTS_PER_SOL,
+            data: pd,
+            owner: pfda_amm_id(),
+            executable: false,
+            rent_epoch: 0,
+        },
+    )
+    .unwrap();
+
+    let queue = seed_pfda_batch_queue(&mut svm, pool, 0, 0);
+    let (hist, _) = Address::find_program_address(
+        &[b"history", pool.as_ref(), &0u64.to_le_bytes()],
+        &pfda_amm_id(),
+    );
+    let (new_queue, _) = Address::find_program_address(
+        &[b"queue", pool.as_ref(), &1u64.to_le_bytes()],
+        &pfda_amm_id(),
+    );
+
+    // rogue (≠ authority) must still reject — fallback path doesn't
+    // accept anything-goes.
+    let rogue = Address::new_unique();
+    svm.airdrop(&rogue, LAMPORTS_PER_SOL).unwrap();
+    let err = send(
+        &mut svm,
+        pfda_clear_batch_ix(
+            payer.pubkey(), pool, queue, hist, new_queue,
+            2_000_000, Some(rogue),
+        ),
+        &payer,
+    )
+    .err()
+    .expect("legacy pool: rogue recipient must reject");
+    assert_custom_err(&err, PFDA_ERR_TREASURY_MISMATCH, "legacy fallback rogue");
+}
+
+// ─── #61 item 6 — SetBatchId is feature-gated ────────────────────────
+
+#[test]
+fn pfda3_set_batch_id_disc_unknown_in_mainnet_build() {
+    // Standard `cargo build-sbf` (no test-time-warp feature) must
+    // exclude the SetBatchId handler entirely, so disc 9 surfaces as
+    // InvalidInstructionData. This is the proof that the feature gate
+    // works without needing to inspect the .so file. If a future build
+    // accidentally sets the feature, this test fails — exactly the
+    // signal we want for "test-only ix slipped into a mainnet binary".
+    require_fixture!(PFDA_AMM_3_SO);
+    let mut svm = LiteSVM::new();
+    svm.add_program_from_file(pfda3_id(), PFDA_AMM_3_SO).unwrap();
+
+    let payer = Keypair::new();
+    svm.airdrop(&payer.pubkey(), LAMPORTS_PER_SOL).unwrap();
+
+    // Build a SetBatchId tx (disc 9 + u64 batch_id). Accounts can be
+    // arbitrary — the disc check fires before any account read.
+    let mut data = vec![9u8];
+    data.extend_from_slice(&100u64.to_le_bytes());
+    let ix = Instruction {
+        program_id: pfda3_id(),
+        accounts: vec![
+            AccountMeta::new_readonly(payer.pubkey(), true),
+            AccountMeta::new(Address::new_unique(), false),
+        ],
+        data,
+    };
+
+    let err = send(&mut svm, ix, &payer)
+        .err()
+        .expect("disc 9 must reject when test-time-warp feature is off");
+    assert!(
+        err.contains("InvalidInstructionData") || err.contains("invalid instruction data"),
+        "expected InvalidInstructionData, got: {err}"
+    );
+}
+
+// ─── #61 item 2 — pfda-amm-3 oracle C-lite per-leg fallback ───────────
+//
+// Direct end-to-end coverage of the C-lite policy needs full ClearBatch
+// state (PoolState3 + BatchQueue3 + ClearedBatchHistory3 fabrication +
+// Switchboard feed account fabrication). The clearing-price math runs
+// regardless of which path each leg takes, so a unit test of the
+// effective_price formula in isolation would re-derive the program
+// logic. A higher-fidelity test belongs in axis_g3m_coverage.rs once
+// that file gains an oracle harness — tracked as a follow-up. The
+// behavioural change is small and well-localised; the multi-agent
+// review sign-off + the inline comments describing per-leg fallback
+// (clear_batch.rs:186-216, 232-249) provide the code-side guarantee
+// for now.

--- a/contracts/pfda-amm-3/Cargo.toml
+++ b/contracts/pfda-amm-3/Cargo.toml
@@ -13,5 +13,11 @@ pinocchio-token = "0.4"
 
 [features]
 no-entrypoint = []
+# #61 item 6: gates the SetBatchId instruction (disc 9). Compiles into
+# the program ONLY when this feature is set, so mainnet `cargo build-sbf`
+# (which doesn't pass the flag) cannot reach the handler. Used by
+# LiteSVM tests that need to fast-forward `pool.current_batch_id` past
+# the close-delay windows for CloseBatchHistory / CloseExpiredTicket.
+test-time-warp = []
 
 [dev-dependencies]

--- a/contracts/pfda-amm-3/src/instructions/clear_batch.rs
+++ b/contracts/pfda-amm-3/src/instructions/clear_batch.rs
@@ -184,20 +184,36 @@ fn clear_batch_inner(
     };
 
     // --- Read oracle prices (if 3 oracle feeds provided: accounts 6, 7, 8) ---
-    let oracle_prices: Option<[u64; 3]> = if accounts.len() > 8 {
-        let mut prices = [0u64; 3];
+    //
+    // #61 item 2 (C-lite per-leg fallback): the original behaviour aborted
+    // the entire batch if ANY single feed went stale, which made the pool
+    // un-clearable during routine Switchboard outages. The new behaviour:
+    //
+    //   - For each feed i, capture Option<price>. Stale → None, no abort.
+    //   - When computing clearing price for leg i (i > 0):
+    //       both op[0] and op[i] fresh → apply ±5% oracle clamp
+    //       either stale → fall back to raw reserve-ratio for leg i
+    //   - All three stale AND feeds were supplied → still abort, since
+    //     there's no reference price at all and a sandwich window is
+    //     wider than we want without any oracle anchor.
+    //
+    // No-feeds path (accounts.len() <= 8) is unchanged: pure reserve-ratio.
+    let oracle_prices: [Option<u64>; 3] = if accounts.len() > 8 {
+        let mut prices = [None; 3];
+        let mut any_fresh = false;
         for i in 0..3 {
             let feed = &accounts[6 + i];
-            match crate::oracle::read_switchboard_price(feed, current_slot, 100, 1) {
-                Ok(p) => prices[i] = p,
-                Err(_) => {
-                    return Err(Pfda3Error::OracleStale.into());
-                }
+            if let Ok(p) = crate::oracle::read_switchboard_price(feed, current_slot, 100, 1) {
+                prices[i] = Some(p);
+                any_fresh = true;
             }
         }
-        Some(prices)
+        if !any_fresh {
+            return Err(Pfda3Error::OracleStale.into());
+        }
+        prices
     } else {
-        None
+        [None; 3]
     };
 
     // --- Compute clearing prices ---
@@ -229,21 +245,24 @@ fn clear_batch_inner(
             raw as u64
         };
 
-        let effective_price = if let Some(ref oracle_px) = oracle_prices {
-            if i == 0 {
-                reserve_price
-            } else {
-                let op_i = oracle_px[i] as u128;
-                let op_0 = oracle_px[0].max(1) as u128;
-                let oracle_rel = ((op_i << 32) / op_0) as u64;
-
-                let max_dev_bps: u64 = 500;
-                let lower = oracle_rel.saturating_sub(oracle_rel * max_dev_bps / 10_000);
-                let upper = oracle_rel.saturating_add(oracle_rel * max_dev_bps / 10_000);
-                reserve_price.max(lower).min(upper)
-            }
-        } else {
+        // #61 item 2: clamp ONLY when both op[0] and op[i] are fresh.
+        // Either stale → leg falls back to raw reserve_price.
+        let effective_price = if i == 0 {
             reserve_price
+        } else {
+            match (oracle_prices[0], oracle_prices[i]) {
+                (Some(op_0_v), Some(op_i_v)) => {
+                    let op_i = op_i_v as u128;
+                    let op_0 = op_0_v.max(1) as u128;
+                    let oracle_rel = ((op_i << 32) / op_0) as u64;
+
+                    let max_dev_bps: u64 = 500;
+                    let lower = oracle_rel.saturating_sub(oracle_rel * max_dev_bps / 10_000);
+                    let upper = oracle_rel.saturating_add(oracle_rel * max_dev_bps / 10_000);
+                    reserve_price.max(lower).min(upper)
+                }
+                _ => reserve_price,
+            }
         };
 
         clearing_prices[i] = effective_price;
@@ -454,7 +473,10 @@ fn clear_batch_inner(
     return_buf[32..40].copy_from_slice(&bid_lamports.to_le_bytes());
     return_buf[40..48].copy_from_slice(&batch_id.to_le_bytes());
     return_buf[48..56].copy_from_slice(&current_slot.to_le_bytes());
-    return_buf[56] = if oracle_prices.is_some() { 1 } else { 0 };
+    // #61 item 2: oracle_used is now the count of fresh feeds (0..=3)
+    // rather than a 0/1 flag, so off-chain analytics can tell partial
+    // fallback batches apart from full-oracle and full-fallback ones.
+    return_buf[56] = oracle_prices.iter().filter(|p| p.is_some()).count() as u8;
     pinocchio::program::set_return_data(&return_buf);
 
     Ok(())

--- a/contracts/pfda-amm-3/src/instructions/mod.rs
+++ b/contracts/pfda-amm-3/src/instructions/mod.rs
@@ -8,6 +8,9 @@ pub mod set_paused;
 pub mod swap_request;
 pub mod withdraw_fees;
 
+#[cfg(feature = "test-time-warp")]
+pub mod set_batch_id;
+
 pub use add_liquidity::process_add_liquidity_3;
 pub use claim::process_claim_3;
 pub use clear_batch::process_clear_batch_3;
@@ -17,3 +20,6 @@ pub use initialize_pool::process_initialize_pool_3;
 pub use set_paused::process_set_paused_3;
 pub use swap_request::process_swap_request_3;
 pub use withdraw_fees::process_withdraw_fees;
+
+#[cfg(feature = "test-time-warp")]
+pub use set_batch_id::process_set_batch_id;

--- a/contracts/pfda-amm-3/src/instructions/set_batch_id.rs
+++ b/contracts/pfda-amm-3/src/instructions/set_batch_id.rs
@@ -1,0 +1,89 @@
+//! SetBatchId — TEST-ONLY ix for fast-forwarding `pool.current_batch_id`
+//! past the close-delay windows used by `CloseBatchHistory` (100 batches)
+//! and `CloseExpiredTicket` (200 batches). Issue #61 item 6.
+//!
+//! # Why this exists
+//!
+//! LiteSVM cannot warp `current_batch_id` directly — the only way to
+//! advance it through normal protocol flows is to drive 100+ full batch
+//! cycles, which is infeasible in test time. Without an out-of-band
+//! way to set the value, the success-path coverage for the close-delay
+//! gates would have to be skipped, leaving only reject-path tests in
+//! the suite.
+//!
+//! # Why a feature flag instead of a bench helper
+//!
+//! Bench-only helpers either leak test-only logic into production
+//! source files (anyone reading `pool_state.rs` would see them) or
+//! get duplicated across test fixtures. A `cfg(feature = "test-time-warp")`
+//! gate makes the entire instruction — handler, dispatcher arm, mod
+//! export — disappear from the build graph when the feature isn't
+//! passed. CI's mainnet `cargo build-sbf` invocation does NOT pass the
+//! feature, so the resulting `.so` cannot reach this code path.
+//!
+//! Authority-gated even in test builds, mirroring `SetPaused3`, so an
+//! accidental feature-on devnet build would still be safe.
+//!
+//! # Accounts
+//!
+//! ```text
+//! 0: [signer]    authority (must equal pool.authority)
+//! 1: [writable]  pool_state PDA
+//! ```
+//!
+//! # Instruction data
+//!
+//! ```text
+//! [new_batch_id: u64 LE]
+//! ```
+
+use pinocchio::{
+    account_info::AccountInfo,
+    program_error::ProgramError,
+    pubkey::Pubkey,
+    ProgramResult,
+};
+
+use crate::error::Pfda3Error;
+use crate::state::{load, load_mut, PoolState3};
+
+pub fn process_set_batch_id(
+    program_id: &Pubkey,
+    accounts: &[AccountInfo],
+    new_batch_id: u64,
+) -> ProgramResult {
+    let [authority, pool_ai, ..] = accounts else {
+        return Err(ProgramError::NotEnoughAccountKeys);
+    };
+
+    if !authority.is_signer() {
+        return Err(ProgramError::MissingRequiredSignature);
+    }
+
+    if pool_ai.owner() != program_id {
+        return Err(ProgramError::IllegalOwner);
+    }
+
+    let stored_authority = {
+        let data = pool_ai.try_borrow_data()?;
+        let pool = unsafe { load::<PoolState3>(&data) }
+            .ok_or(ProgramError::InvalidAccountData)?;
+        if !pool.is_initialized() {
+            return Err(Pfda3Error::InvalidDiscriminator.into());
+        }
+        pool.authority
+    };
+
+    if authority.key().as_ref() != &stored_authority {
+        return Err(Pfda3Error::Unauthorized.into());
+    }
+
+    {
+        let mut data = pool_ai.try_borrow_mut_data()?;
+        let pool = unsafe { load_mut::<PoolState3>(&mut data) }
+            .ok_or(ProgramError::InvalidAccountData)?;
+        pool.current_batch_id = new_batch_id;
+    }
+
+    Ok(())
+}

--- a/contracts/pfda-amm-3/src/lib.rs
+++ b/contracts/pfda-amm-3/src/lib.rs
@@ -39,6 +39,12 @@ enum Instruction {
     SetPaused = 6,
     CloseBatchHistory = 7,
     CloseExpiredTicket = 8,
+    /// #61 item 6: TEST-ONLY ix for fast-forwarding pool.current_batch_id
+    /// past the close-delay windows. Compiled in only when the
+    /// `test-time-warp` feature is set; mainnet `cargo build-sbf` (which
+    /// does not pass the flag) cannot reach the handler.
+    #[cfg(feature = "test-time-warp")]
+    SetBatchId = 9,
 }
 
 impl Instruction {
@@ -53,6 +59,8 @@ impl Instruction {
             6 => Some(Instruction::SetPaused),
             7 => Some(Instruction::CloseBatchHistory),
             8 => Some(Instruction::CloseExpiredTicket),
+            #[cfg(feature = "test-time-warp")]
+            9 => Some(Instruction::SetBatchId),
             _ => None,
         }
     }
@@ -160,6 +168,19 @@ pub fn process_instruction(
 
         Instruction::CloseExpiredTicket => {
             instructions::process_close_expired_ticket_3(program_id, accounts)
+        }
+
+        #[cfg(feature = "test-time-warp")]
+        Instruction::SetBatchId => {
+            // Data: [new_batch_id: u64 LE]
+            if data.len() < 8 {
+                return Err(ProgramError::InvalidInstructionData);
+            }
+            let new_batch_id = u64::from_le_bytes([
+                data[0], data[1], data[2], data[3],
+                data[4], data[5], data[6], data[7],
+            ]);
+            instructions::process_set_batch_id(program_id, accounts, new_batch_id)
         }
     }
 }

--- a/contracts/pfda-amm/src/instructions/clear_batch.rs
+++ b/contracts/pfda-amm/src/instructions/clear_batch.rs
@@ -23,17 +23,19 @@ use crate::{
 /// 5. `[]`                  system_program
 /// 6. `[]` (optional)       oracle_feed_a — Switchboard price feed for token A
 /// 7. `[]` (optional)       oracle_feed_b — Switchboard price feed for token B
-/// 8. `[writable]` (req when bid>0) bid_recipient — must equal `pool.authority`
+/// 8. `[writable]` (req when bid>0) bid_recipient — must equal `pool.treasury`
+///                                  if non-zero, else `pool.authority` (legacy)
 ///
 /// Integration points:
 ///   - Switchboard: If oracle feeds are provided (accounts 6+7), clearing price
 ///     is bounded within ±5% of oracle-derived market price.
 ///   - Jito: If `bid_lamports > 0`, account 8 receives the searcher's bid
-///     and MUST equal `pool.authority`. pfda-amm does not yet carry a
-///     dedicated `treasury` field (unlike pfda-amm-3); until that schema
-///     lands, the pool authority is the canonical recipient. #59 called
-///     out that the pre-fix code accepted ANY account here, letting the
-///     cranker redirect bid payments freely.
+///     and MUST equal `pool.treasury` (the dedicated bid-recipient field
+///     added in #61 item 4). For backward compatibility with devnet
+///     pools created before the migration — and any future test fixture
+///     that omits the v2 treasury bytes — a zero treasury falls back to
+///     `pool.authority`. Once PROTOCOL_TREASURY is provisioned (#38) the
+///     fallback path becomes a deploy-time concern only.
 pub fn process_clear_batch(program_id: &Pubkey, accounts: &[AccountInfo], bid_lamports: u64) -> ProgramResult {
     let [cranker, pool_state_ai, batch_queue_ai, history_ai, new_queue_ai, _system_program, ..] =
         accounts
@@ -69,8 +71,10 @@ pub fn process_clear_batch(program_id: &Pubkey, accounts: &[AccountInfo], bid_la
     let oracle_feed_b = if accounts.len() > 7 { Some(&accounts[7]) } else { None };
 
     // Single canonical pool load: validates discriminator, reentrancy,
-    // paused, PDA seeds, and captures pool.authority for the bid block.
-    let pool_authority = {
+    // paused, PDA seeds, and captures the bid recipient for the bid
+    // block. Recipient is `pool.treasury` if non-zero (post-migration
+    // pools), else `pool.authority` (legacy fallback per #61 item 4).
+    let bid_recipient = {
         let data = pool_state_ai.try_borrow_data()?;
         let pool = unsafe { load::<PoolState>(&data) }.ok_or(ProgramError::InvalidAccountData)?;
         if !pool.is_initialized() {
@@ -89,14 +93,18 @@ pub fn process_clear_batch(program_id: &Pubkey, accounts: &[AccountInfo], bid_la
         if pool_state_ai.key() != &expected {
             return Err(ProgramError::InvalidSeeds);
         }
-        pool.authority
+        if pool.treasury != [0u8; 32] {
+            pool.treasury
+        } else {
+            pool.authority
+        }
     };
 
     // #59 / Jito bid enforcement (post-validation):
     // If bid_lamports > 0, account 8 must be present AND must equal
-    // pool.authority. Pre-fix, the code happily Transfer'd lamports to
-    // whatever account sat at slot 8, which let a malicious cranker
-    // redirect bid payments to themselves.
+    // the resolved bid_recipient (treasury or legacy authority). Pre-fix,
+    // the code happily Transfer'd lamports to whatever account sat at
+    // slot 8, which let a malicious cranker redirect bid payments.
     //
     // #33: MIN_BID_LAMPORTS was never enforced on pfda-amm — pfda-amm-3's
     // ClearBatch already has the check; mirror it here so anti-spam
@@ -109,7 +117,7 @@ pub fn process_clear_batch(program_id: &Pubkey, accounts: &[AccountInfo], bid_la
             return Err(PfmmError::BidWithoutTreasury.into());
         }
         let treasury = &accounts[8];
-        if treasury.key().as_ref() != &pool_authority {
+        if treasury.key().as_ref() != &bid_recipient {
             return Err(PfmmError::TreasuryMismatch.into());
         }
 

--- a/contracts/pfda-amm/src/instructions/initialize_pool.rs
+++ b/contracts/pfda-amm/src/instructions/initialize_pool.rs
@@ -24,6 +24,7 @@ use crate::{
 /// 6. `[writable]`          vault_b  (SPL token account, uninitialized)
 /// 7. `[]`                  system_program
 /// 8. `[]`                  token_program
+#[allow(clippy::too_many_arguments)]
 pub fn process_initialize_pool(
     program_id: &Pubkey,
     accounts: &[AccountInfo],
@@ -31,6 +32,7 @@ pub fn process_initialize_pool(
     fee_discount_bps: u16,
     window_slots: u64,
     initial_weight_a: u32,
+    treasury: [u8; 32],
 ) -> ProgramResult {
     if window_slots == 0 {
         return Err(PfmmError::InvalidWindowSlots.into());
@@ -135,6 +137,7 @@ pub fn process_initialize_pool(
             reentrancy_guard: 0,
             paused: 0,
             _padding: [0; 1],
+            treasury,
         };
     }
 

--- a/contracts/pfda-amm/src/lib.rs
+++ b/contracts/pfda-amm/src/lib.rs
@@ -74,7 +74,19 @@ pub fn process_instruction(
 
     match discriminant {
         Instruction::InitializePool => {
-            // Layout: [base_fee_bps: u16 LE][fee_discount_bps: u16 LE][window_slots: u64 LE][initial_weight_a: u32 LE]
+            // Layout (v2 with treasury):
+            //   [base_fee_bps: u16 LE]
+            //   [fee_discount_bps: u16 LE]
+            //   [window_slots: u64 LE]
+            //   [initial_weight_a: u32 LE]
+            //   [treasury: [u8; 32]]                 (optional, see below)
+            //
+            // Backward compatibility (#61 item 4 migration): if the
+            // caller sends the v1 format (16 bytes, no treasury),
+            // treasury defaults to all zeros and ClearBatch falls back
+            // to `pool.authority` for bid recipient — preserving the
+            // pre-migration behaviour for older test fixtures and any
+            // existing devnet pools created before this commit.
             if data.len() < 16 {
                 return Err(ProgramError::InvalidInstructionData);
             }
@@ -84,6 +96,10 @@ pub fn process_instruction(
                 data[4], data[5], data[6], data[7], data[8], data[9], data[10], data[11],
             ]);
             let initial_weight_a = u32::from_le_bytes([data[12], data[13], data[14], data[15]]);
+            let mut treasury = [0u8; 32];
+            if data.len() >= 48 {
+                treasury.copy_from_slice(&data[16..48]);
+            }
 
             instructions::process_initialize_pool(
                 program_id,
@@ -92,6 +108,7 @@ pub fn process_instruction(
                 fee_discount_bps,
                 window_slots,
                 initial_weight_a,
+                treasury,
             )
         }
 

--- a/contracts/pfda-amm/src/state/pool_state.rs
+++ b/contracts/pfda-amm/src/state/pool_state.rs
@@ -1,6 +1,15 @@
-/// PoolState - 244 bytes, repr(C)
+/// PoolState - 272 bytes, repr(C)
 ///
 /// PDA seeds: [b"pool", token_a_mint, token_b_mint]
+///
+/// Layout note (#61 item 4): `treasury` was added at the end so the
+/// fields preceding it keep their existing offsets — the migration
+/// extends rather than rewrites. PoolState went from 240 bytes (ends
+/// at `_padding`) to 272 bytes (ends at `treasury`). Existing
+/// devnet pools created before the migration carry zeroed treasury
+/// bytes; ClearBatch falls back to `pool.authority` when treasury
+/// is the zero key, preserving backward compatibility for the alpha
+/// while live mainnet pools (none yet) ship with a real treasury.
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub struct PoolState {
@@ -46,6 +55,13 @@ pub struct PoolState {
     pub paused: u8,
     /// Alignment padding
     pub _padding: [u8; 1],
+    /// Bid-recipient pubkey (#61 item 4). Mirrors pfda-amm-3's separate
+    /// `treasury` field. ClearBatch sends Jito bids here; if zero,
+    /// the pre-migration fallback uses `authority` as the recipient
+    /// to keep older pools functional during the alpha. Once
+    /// PROTOCOL_TREASURY is live (#38), all new InitializePool calls
+    /// must populate this field with the multisig key.
+    pub treasury: [u8; 32],
 }
 
 impl PoolState {
@@ -79,8 +95,8 @@ impl PoolState {
     }
 }
 
-// Compile-time size assertion (actual layout = 240 bytes)
-const _: () = assert!(core::mem::size_of::<PoolState>() == 240);
+// Compile-time size assertion (actual layout = 272 bytes after #61 item 4)
+const _: () = assert!(core::mem::size_of::<PoolState>() == 272);
 
 #[cfg(test)]
 mod tests {


### PR DESCRIPTION
Closes the three design-decision items in #61 (kidney's signoff: C-lite / yes / yes) and the recurring Main AB Report CI failure.

Closes #61 (items 2, 4, 6).

## #2 oracle stale fallback → C-lite per-leg

\`pfda-amm-3 clear_batch.rs\`. Original behaviour aborted the entire batch on any single feed failure, making the pool un-clearable during routine Switchboard outages. New behaviour:

- Per-feed read into \`Option<u64>\`. Stale → None, no abort.
- Clamp applies for leg \`i\` (i > 0) only when both \`op[0]\` AND \`op[i]\` are fresh. Either stale → leg falls back to raw reserve_price.
- All three stale → still abort (\`OracleStale\`). No reference price at all is wider than we want.

\`return_buf[56]\` now carries the count of fresh feeds (0..=3) instead of 0/1, so off-chain analytics can distinguish full-oracle / partial-fallback / full-fallback batches.

## #4 pfda-amm dedicated \`treasury\` field migration

\`PoolState\` 240 → 272 bytes. New \`treasury: [u8; 32]\` slot appended after \`_padding\` — all preceding field offsets unchanged.

Dispatcher format (\`InitializePool\` v2): optional 32-byte treasury at \`data[16..48]\`. v1 callers (16-byte data) still work and produce a zeroed treasury — backward compat for any existing devnet pool fixtures.

\`ClearBatch\` reads \`pool.treasury\` as the bid recipient when non-zero; falls back to \`pool.authority\` when zeroed. PR #62's \`TreasuryMismatch\` guard still fires regardless. Pause power is now decoupled from fee-recipient.

\`build_pfda_pool_state_v2\` helper added in account_builder.rs; legacy \`build_pfda_pool_state\` delegates to it with \`treasury=None\` so existing test fixtures keep their behaviour.

## #6 SetBatchId disc 9 (\`test-time-warp\` feature)

TEST-ONLY ix in pfda-amm-3, gated behind \`cfg(feature = \"test-time-warp\")\`. Authority-signed (mirrors \`SetPaused3\`) so even an accidental feature-on devnet build can't be abused. Lets future LiteSVM tests fast-forward \`pool.current_batch_id\` mid-flow rather than relying on \`set_account\` fabrication for every close-delay scenario.

Mainnet \`cargo build-sbf\` does NOT pass the feature, so the handler is excluded from the resulting .so. The integration test \`pfda3_set_batch_id_disc_unknown_in_mainnet_build\` proves the gate works by sending disc 9 against the standard build and asserting \`InvalidInstructionData\`.

## CI — Main AB Report + LiteSVM Jupiter CPI workflows

Both workflows have been failing on transient mainnet-beta RPC outages during the Jupiter V6 dump + \`--clone\` steps (saw the same on PR #62 earlier). Two changes:

1. **Dump step** rotates through three RPC URLs (mainnet-beta → projectserum → ankr) with three attempts each and exponential backoff. Only fails if all 9 attempts fail.
2. **Validator launch** uses the locally dumped Jupiter binary via \`--bpf-program\` rather than \`--clone --url mainnet-beta\`. Startup is now offline and can't fail on RPC outages. Token program is bundled into solana-test-validator by default, no clone needed.

## Tests

New \`contracts/ab-integration-tests/tests/issue_61_coverage.rs\`, 3 cases, all green:

- \`pfda_v2_pool_routes_bid_to_dedicated_treasury_field\` — v2 pool with treasury ≠ authority routes bid to treasury; passing authority gets \`TreasuryMismatch\`
- \`pfda_legacy_pool_with_zero_treasury_falls_back_to_authority\` — v1 pool with zeroed treasury accepts authority as recipient (regression for the fallback)
- \`pfda3_set_batch_id_disc_unknown_in_mainnet_build\` — disc 9 surfaces as \`InvalidInstructionData\` against the standard build

## Test plan

- [x] \`cargo build-sbf\` clean for pfda-amm, pfda-amm-3 (with + without \`--features test-time-warp\`), axis-vault, axis-g3m
- [x] Full A/B integration suite — 76 tests pass (73 prior + 3 new), 2 ignored, 0 failed
- [x] \`cargo test --lib\` per program — pfda-amm 19/19, pfda-amm-3 1/1, axis-vault 3/3
- [ ] Re-run Main AB Report on this branch's merge to confirm the workflow stays green now that mainnet RPC is no longer on the critical path

## Out of scope (still tracked in #61)

- #3 — PROTOCOL_TREASURY Squads V4 deploy + constant flip (ops, kidney + muse)
- #5 — axis-g3m mainnet-fork Jupiter route fixture (kidney infra: API key + ALT + recorded route JSON)

Both are gated on you, not on more code.