### PR TITLE
ops(#61): runbooks + tooling for items 3 (Squads) and 5 (Jupiter fixture)

### DIFF
--- a/docs/ops/MAINNET_FORK_RUNBOOK.md
+++ b/docs/ops/MAINNET_FORK_RUNBOOK.md
@@ -1,0 +1,136 @@
+# Mainnet-fork Jupiter route test
+
+How to drive a real Jupiter V6 route through `axis-g3m
+RebalanceViaJupiter` (disc=4) on a forked validator. Closes the
+testable side of #61 item 5; what's still gated on you is provisioning
+the funded ALT and refreshing the fixture if the route topology
+shifts.
+
+## What we have in tree
+
+- `scripts/ops/fetch-jupiter-quote.ts` — calls Jupiter's lite-api,
+  saves quote + swap-instructions to `test/fixtures/jupiter/<label>.json`
+- `test/fixtures/jupiter/sol-usdc-100m.json` — recorded fixture for
+  100M lamports SOL → USDC, slippage 50 bps. Refresh whenever the
+  route plan changes substantially (e.g. Jupiter adds a new AMM
+  source that becomes the dominant leg).
+- `scripts/ops/dump-jupiter-fixture-accounts.sh` — given a fixture
+  JSON, dumps every referenced account via `solana account` with
+  RPC retry/fallback, writes a `clone-args.txt` ready to paste into
+  the validator command line.
+
+## Refresh the fixture
+
+```bash
+# Default pair (SOL → USDC, 100M lamports, 50 bps slippage)
+bun scripts/ops/fetch-jupiter-quote.ts --label sol-usdc-100m
+
+# Custom pair / amount
+bun scripts/ops/fetch-jupiter-quote.ts \
+  --in  So11111111111111111111111111111111111111112 \
+  --out EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v \
+  --amount 1000000000 \
+  --slippage 100 \
+  --label sol-usdc-1b
+```
+
+Lite-api has no auth requirement and a soft rate limit fine for CI.
+Free tier confirms #61 item 5(a) — no Jupiter Quote API key needed.
+
+## Dump the route accounts (one-time)
+
+The `--clone --url mainnet-beta` approach in earlier workflows used to
+fail intermittently when mainnet RPC blipped. Pre-dumping accounts is
+deterministic.
+
+```bash
+scripts/ops/dump-jupiter-fixture-accounts.sh \
+  test/fixtures/jupiter/sol-usdc-100m.json \
+  test/fixtures/jupiter/accounts/sol-usdc-100m
+```
+
+Produces:
+
+```
+test/fixtures/jupiter/accounts/sol-usdc-100m/
+  <pubkey1>.json
+  <pubkey2>.json
+  ...
+  clone-args.txt   ← every account as `--account <pubkey> <path>`
+```
+
+Commit the dumped account JSON files alongside the fixture so CI never
+touches mainnet RPC at validator-launch time.
+
+## Provision an ALT (manual, one-time)
+
+This is the part that needs your wallet. Jupiter routes use ALTs to
+fit the account list inside the versioned-tx envelope; the ALT pubkeys
+are in the fixture's `swap.addressLookupTableAddresses[*]`.
+
+For a forked validator the ALT account itself can be cloned (the
+dump-accounts script already does that — ALT pubkeys are included
+under `addressLookupTableAddresses`). What you need to provision:
+
+- A funded test wallet (SOL on whatever cluster the test runs on)
+- The wallet keypair stored at `~/.config/solana/id.json` (matches
+  `loadPayer()` in the existing e2e scripts)
+
+No new on-chain ALT creation needed — we ride the existing mainnet
+ALTs that Jupiter's response references.
+
+## Run the test
+
+```bash
+# 1. Make sure all programs are built
+cargo build-sbf --manifest-path contracts/axis-g3m/Cargo.toml
+cargo build-sbf --manifest-path contracts/pfda-amm-3/Cargo.toml
+
+# 2. Make sure Jupiter V6 is dumped (fallback for the workflow)
+mkdir -p contracts/axis-g3m/fixtures
+solana program dump -u https://api.mainnet-beta.solana.com \
+  JUP6LkbZbjS1jKKwapdHNy74zcZ3tLUZoi5QNyVTaV4 \
+  contracts/axis-g3m/fixtures/jupiter_v6.so
+
+# 3. Boot the validator with everything pre-loaded
+solana-test-validator --reset --ledger /tmp/fork-ledger \
+  --bpf-program 65aE9QdVz5bapV19BGt5cyTgVitYpekGwusRoQEovNUi contracts/axis-g3m/target/deploy/axis_g3m.so \
+  --bpf-program DbAPmgkrpCCZrpBMv5x1ye6nJUreqY313SuQjZsMyjEf contracts/pfda-amm-3/target/deploy/pfda_amm_3.so \
+  --bpf-program JUP6LkbZbjS1jKKwapdHNy74zcZ3tLUZoi5QNyVTaV4 contracts/axis-g3m/fixtures/jupiter_v6.so \
+  $(cat test/fixtures/jupiter/accounts/sol-usdc-100m/clone-args.txt) \
+  > /tmp/fork-validator.log 2>&1 &
+
+# 4. Run the e2e
+JUPITER_FIXTURE=test/fixtures/jupiter/sol-usdc-100m.json \
+RPC_URL=http://localhost:8899 \
+  bun test/e2e/axis-g3m/axis-g3m.jupiter-fork.e2e.ts
+```
+
+The existing test currently uses attestation-mode rebalance (disc=3,
+no real Jupiter CPI). To exercise disc=4 RebalanceViaJupiter with the
+recorded route, the e2e needs to be extended to:
+
+1. Read `JUPITER_FIXTURE` and parse `swap.swapInstruction`
+2. Rewrite the user-position account to the test wallet's pubkey
+   (the fixture uses a placeholder)
+3. Build a `disc=4` ix data: `[3] [u32 LE jupiter_data_len]
+   [swapInstruction.data bytes]`
+4. Pass the fixture's `swap.swapInstruction.accounts` (plus the
+   axis-g3m fixed prefix: authority, pool, jupiter_program, vaults)
+   as the AccountMeta list
+
+Tracked as a code follow-up — the runbook + fixture + dump tooling
+above is what's gating it. Once the e2e extension lands, wire it into
+`.github/workflows/main-report.yml` between the existing E2E and
+"Stop forked validator" steps.
+
+## When fixture refresh is needed
+
+- Jupiter adds a new dominant AMM source for the recorded pair (you'll
+  see it as a different `routePlan[0].swapInfo.label` in a fresh quote)
+- The `addressLookupTableAddresses` list changes
+- An ALT version bump retires an account that's referenced
+
+Fixture rot doesn't break the test catastrophically — the dumped
+accounts stay valid until a mainnet ALT version bump. Refresh
+quarterly or on observed test drift, whichever comes first.

--- a/docs/ops/SQUADS_RUNBOOK.md
+++ b/docs/ops/SQUADS_RUNBOOK.md
@@ -1,0 +1,127 @@
+# PROTOCOL_TREASURY Squads V4 deploy
+
+Closes the ops-side of #61 item 3 once executed. Code side is done in
+the bundle PR that introduced this doc — `axis-vault/src/constants.rs`
+ships a sentinel zero key, the gate in `protocol_treasury_is_active()`
+stays inert until this runbook flips the constant.
+
+## Who
+
+2-of-2 between **@muse0509** and **@kidneyweakx** per Muse's 2026-04-20
+decision. Both signers must own the wallet they bring to Squads —
+neither can delegate.
+
+## Order of operations
+
+Strict order, no skipping. Steps 4–6 are committed code; everything
+above and including step 3 is pure ops.
+
+### 1. Devnet vault
+
+- Both signers go to https://app.squads.so → Create new vault
+- Network: **Devnet**
+- Threshold: **2 of 2**
+- Members: muse0509's wallet + kidneyweakx's wallet
+- Save the **devnet vault address** (call it `DEVNET_VAULT`)
+
+### 2. Devnet end-to-end smoke
+
+Run a full lifecycle against the devnet vault BEFORE provisioning
+mainnet — ensures the on-chain gate behaves with a real Squads vault.
+
+```bash
+# Use the dev branch with the constant flipped to DEVNET_VAULT
+git checkout -b devnet/treasury-smoke
+bun scripts/ops/flip-protocol-treasury.ts <DEVNET_VAULT>
+cargo build-sbf --manifest-path contracts/axis-vault/Cargo.toml
+
+# Deploy via Squads tx (UI: "Deploy Program" or via squads-mpl CLI)
+# Then run the e2e:
+RPC_URL=https://api.devnet.solana.com bun test/e2e/axis-vault/axis-vault.devnet.e2e.ts
+```
+
+Expected:
+- `CreateEtf` succeeds when `etf.treasury == DEVNET_VAULT`
+- `CreateEtf` rejects with `TreasuryNotApproved` for any other `treasury` field
+
+If anything fails: roll back the branch, fix code, redo from step 1.
+Don't move on with a half-working gate.
+
+### 3. Mainnet vault
+
+Same Squads UI flow as step 1, but with **Network: Mainnet Beta**.
+
+- Save the **mainnet vault address** (`MAINNET_VAULT`)
+- Both signers must verify the address out-of-band (Slack DM, etc.)
+  before anyone signs a deploy against it
+
+### 4. Code: flip the constant
+
+Single commit on a branch off `main`:
+
+```bash
+git checkout -b ops/issue-38-protocol-treasury-flip
+bun scripts/ops/flip-protocol-treasury.ts <MAINNET_VAULT>
+# Also update contracts/axis-vault/src/lib.rs declare_id!() to the
+# mainnet axis-vault program ID. The script prints a reminder.
+cargo build-sbf --manifest-path contracts/axis-vault/Cargo.toml
+git add contracts/axis-vault/src/constants.rs contracts/axis-vault/src/lib.rs
+git commit -m "ops(#38): flip PROTOCOL_TREASURY to mainnet Squads vault"
+git push
+```
+
+PR review must include both signers. The diff is small; the
+verification is making sure the 32 bytes match the Squads vault
+address character-for-character.
+
+### 5. Deploy
+
+Muse executes the deploy as a Squads tx (axis-vault program upgrade).
+This requires the multisig to sign — kidneyweakx approves the tx in
+the Squads UI.
+
+### 6. Verify on-chain
+
+```bash
+# 6a: program upgrade succeeded
+solana program show <AXIS_VAULT_PROGRAM_ID> -u mainnet-beta
+
+# 6b: gate is now live — try a CreateEtf with the wrong treasury,
+# expect TreasuryNotApproved
+bun scripts/axis-vault/demo.ts --treasury <SOME_OTHER_KEY>
+# expect: failed with custom error 9023
+
+# 6c: try with the right treasury, expect success
+bun scripts/axis-vault/demo.ts --treasury <MAINNET_VAULT>
+# expect: ETF created, deposit/withdraw round-trip clean
+```
+
+### 7. Close #59 + related #61 items
+
+Once 6c is green, mark issue #59 closed and item #3 in #61 done. The
+treasury gate is now permanently active for every CreateEtf.
+
+## Rollback
+
+If step 6c fails:
+- Do NOT flip the constant back to zero — that re-opens the silent
+  bypass. Instead deploy a hotfix that uses the OLD vault address (if
+  this is a rotation) or pause the program via `SetPaused` while the
+  team investigates.
+- Open a P0 issue with the on-chain log output from the failing
+  CreateEtf for diagnosis.
+
+## Threat model notes
+
+- Single-signer compromise: 2-of-2 means losing one wallet doesn't
+  drain the treasury. Losing both is catastrophic — both signers
+  should use hardware wallets (Ledger / Squads-supported).
+- Squads program upgrade: Squads V4 itself is upgrade-controlled by
+  the Squads team. Their public security policy is at
+  https://squads.so/security; if that becomes a concern, treasury
+  rotation to a different multisig program is a code-side change to
+  the constant.
+- The fallback path (`pool.authority` for legacy pfda-amm pools, see
+  PR #64 #61 item 4) does NOT route through this treasury. Once
+  every active pool is migrated to the v2 schema with a non-zero
+  treasury field, that fallback is dead code and can be removed.

--- a/scripts/ops/dump-jupiter-fixture-accounts.sh
+++ b/scripts/ops/dump-jupiter-fixture-accounts.sh
@@ -1,0 +1,86 @@
+#!/usr/bin/env bash
+#
+# Dump every account a Jupiter swap-instructions fixture references, so
+# the mainnet-fork e2e can boot a solana-test-validator entirely from
+# local files (no `--clone --url mainnet` at startup, which is what the
+# Main AB Report workflow used to fail on). Closes #61 item 5(b).
+#
+# Usage:
+#   scripts/ops/dump-jupiter-fixture-accounts.sh <fixture.json> [out-dir]
+#
+# Reads the fixture's swap.swapInstruction.accounts[*].pubkey and
+# swap.addressLookupTableAddresses[*], dumps each via `solana account`
+# with multi-RPC retry, and writes:
+#
+#   out-dir/<pubkey>.json     # one file per account
+#   out-dir/clone-args.txt    # ready-to-paste `--account ...` args
+#
+# The validator command in the runbook copies clone-args.txt verbatim
+# so the dump and the launch never re-touch the network.
+
+set -euo pipefail
+
+FIXTURE="${1:-}"
+OUT_DIR="${2:-test/fixtures/jupiter/accounts}"
+
+if [ -z "$FIXTURE" ] || [ ! -f "$FIXTURE" ]; then
+  echo "usage: $0 <fixture.json> [out-dir]" >&2
+  exit 1
+fi
+
+if ! command -v jq >/dev/null; then
+  echo "✗ jq is required (brew install jq / apt install jq)" >&2
+  exit 1
+fi
+
+if ! command -v solana >/dev/null; then
+  echo "✗ solana CLI not on PATH" >&2
+  exit 1
+fi
+
+mkdir -p "$OUT_DIR"
+> "$OUT_DIR/clone-args.txt"
+
+URLS=(
+  "https://api.mainnet-beta.solana.com"
+  "https://solana-api.projectserum.com"
+  "https://rpc.ankr.com/solana"
+)
+
+dump_one() {
+  local pubkey="$1"
+  local out="$OUT_DIR/$pubkey.json"
+
+  if [ -f "$out" ]; then
+    return 0
+  fi
+
+  for url in "${URLS[@]}"; do
+    for attempt in 1 2 3; do
+      if solana account "$pubkey" -u "$url" --output json --output-file "$out" >/dev/null 2>&1; then
+        return 0
+      fi
+      sleep $((attempt * 2))
+    done
+  done
+  echo "  ✗ $pubkey: all RPCs failed" >&2
+  return 1
+}
+
+PUBKEYS=$(jq -r '
+  ((.swap.swapInstruction.accounts // []) | .[].pubkey),
+  ((.swap.addressLookupTableAddresses // []) | .[])
+' "$FIXTURE" | sort -u)
+
+count=0
+for pk in $PUBKEYS; do
+  count=$((count + 1))
+  echo "  [$count] $pk"
+  if dump_one "$pk"; then
+    echo "--account $pk $OUT_DIR/$pk.json" >> "$OUT_DIR/clone-args.txt"
+  fi
+done
+
+echo
+echo "  ✓ dumped $count accounts to $OUT_DIR/"
+echo "  ✓ clone-args.txt ready for solana-test-validator"

--- a/scripts/ops/fetch-jupiter-quote.ts
+++ b/scripts/ops/fetch-jupiter-quote.ts
@@ -1,0 +1,159 @@
+/**
+ * Fetch a Jupiter v6 quote + swap-instructions and dump the response into
+ * test/fixtures/jupiter/<pair>.json so mainnet-fork tests can replay it
+ * deterministically. Closes #61 item 5(c).
+ *
+ * Why a recorded fixture instead of live-fetching from CI:
+ *   - Jupiter route topology shifts whenever a new AMM pool is added
+ *     or liquidity moves. Live tests are flaky; a frozen response is
+ *     reproducible.
+ *   - The swap-instructions endpoint requires the user pubkey for ATA
+ *     derivation. Pinning a known wallet keeps the route accounts
+ *     stable.
+ *
+ * Usage:
+ *   bun scripts/ops/fetch-jupiter-quote.ts \
+ *     --in So11111111111111111111111111111111111111112 \
+ *     --out EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v \
+ *     --amount 100000000 \
+ *     --user FoR9joeqd...someBase58... \
+ *     --label sol-usdc-100m
+ *
+ * --in / --out  : SPL token mints (default: SOL → USDC)
+ * --amount      : input amount in lamports / smallest unit (default 1e8)
+ * --user        : user pubkey for ATA derivation. If omitted, derives a
+ *                 deterministic placeholder so route accounts stay stable
+ *                 across machines (the placeholder is NOT a real wallet —
+ *                 callers replace `userPublicKey` at test time).
+ * --label       : output filename stem (default: built from in/out/amount)
+ * --slippage    : bps, default 50
+ */
+
+import * as fs from "fs";
+import * as path from "path";
+
+// Jupiter migrated `quote-api.jup.ag/v6/*` to `lite-api.jup.ag/swap/v1/*`
+// (free tier) in 2025-Q1. The on-chain V6 program ID is unchanged; only
+// the off-chain route endpoint moved. The lite-api host has no auth
+// requirement and is fine for CI rate limits.
+const QUOTE_URL = "https://lite-api.jup.ag/swap/v1/quote";
+const SWAP_INSTRUCTIONS_URL = "https://lite-api.jup.ag/swap/v1/swap-instructions";
+
+const SOL_MINT = "So11111111111111111111111111111111111111112";
+const USDC_MINT = "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v";
+
+// Stable placeholder pubkey so the swap-instructions response is the same
+// regardless of who runs this script. NOT a real wallet — the test should
+// rebuild the AccountMeta list with its own user pubkey at run time.
+const PLACEHOLDER_USER = "11111111111111111111111111111112";
+
+function arg(name: string, fallback?: string): string | undefined {
+  const idx = process.argv.indexOf(`--${name}`);
+  if (idx === -1 || idx + 1 >= process.argv.length) return fallback;
+  return process.argv[idx + 1];
+}
+
+async function fetchJson(url: string, init?: RequestInit): Promise<any> {
+  for (let attempt = 1; attempt <= 3; attempt++) {
+    try {
+      const r = await fetch(url, init);
+      if (!r.ok) {
+        throw new Error(`HTTP ${r.status}: ${await r.text()}`);
+      }
+      return await r.json();
+    } catch (e) {
+      if (attempt === 3) throw e;
+      console.warn(`  attempt ${attempt} failed: ${e}; retrying...`);
+      await new Promise(r => setTimeout(r, attempt * 1000));
+    }
+  }
+}
+
+async function main() {
+  const inputMint = arg("in", SOL_MINT)!;
+  const outputMint = arg("out", USDC_MINT)!;
+  const amount = arg("amount", "100000000")!;
+  const user = arg("user", PLACEHOLDER_USER)!;
+  const slippageBps = arg("slippage", "50")!;
+  const label = arg(
+    "label",
+    `${inputMint.slice(0, 4)}-${outputMint.slice(0, 4)}-${amount}`,
+  )!;
+
+  console.log("Fetching Jupiter v6 quote");
+  console.log(`  in     : ${inputMint}`);
+  console.log(`  out    : ${outputMint}`);
+  console.log(`  amount : ${amount}`);
+  console.log(`  user   : ${user}`);
+  console.log(`  slip   : ${slippageBps} bps`);
+
+  const quoteUrl = new URL(QUOTE_URL);
+  quoteUrl.searchParams.set("inputMint", inputMint);
+  quoteUrl.searchParams.set("outputMint", outputMint);
+  quoteUrl.searchParams.set("amount", amount);
+  quoteUrl.searchParams.set("slippageBps", slippageBps);
+  quoteUrl.searchParams.set("onlyDirectRoutes", "false");
+
+  const quote = await fetchJson(quoteUrl.toString());
+  console.log(`  ✓ quote: ${quote.outAmount} out, ${quote.routePlan?.length ?? 0} hops`);
+
+  const swap = await fetchJson(SWAP_INSTRUCTIONS_URL, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({
+      quoteResponse: quote,
+      userPublicKey: user,
+      wrapAndUnwrapSol: false,
+    }),
+  });
+
+  // The instructions response carries:
+  //   tokenLedgerInstruction, computeBudgetInstructions, setupInstructions,
+  //   swapInstruction, cleanupInstruction, otherInstructions, addressLookupTableAddresses
+  //
+  // For axis-g3m's RebalanceViaJupiter the relevant pieces are:
+  //   - swapInstruction.programId (must equal JUP6Lkb...)
+  //   - swapInstruction.data (hex-encoded route bytes — passes through to CPI)
+  //   - swapInstruction.accounts (account list — caller's program signs;
+  //     for a vault-PDA-signed swap the user account replaces with the
+  //     pool PDA and is_signer becomes a PDA-signer at CPI time)
+  //   - addressLookupTableAddresses (ALT pubkeys to clone onto the
+  //     forked validator)
+  console.log(`  ✓ swap ix: ${swap.swapInstruction?.accounts?.length ?? 0} accounts`);
+  console.log(`  ✓ ALTs   : ${(swap.addressLookupTableAddresses ?? []).length}`);
+
+  // Write under <repo-root>/test/fixtures/jupiter regardless of which
+  // directory the script is invoked from. import.meta.dir points at
+  // scripts/ops/, so two `..` to repo root.
+  const repoRoot = path.resolve(import.meta.dir, "../..");
+  const fixtureDir = path.join(repoRoot, "test/fixtures/jupiter");
+  fs.mkdirSync(fixtureDir, { recursive: true });
+  const outPath = path.join(fixtureDir, `${label}.json`);
+
+  const fixture = {
+    fetchedAt: new Date().toISOString(),
+    inputMint,
+    outputMint,
+    amount,
+    slippageBps: Number(slippageBps),
+    userPlaceholder: user,
+    note:
+      "This response was recorded against mainnet-beta. To replay against " +
+      "a forked validator, clone every account in `swapInstruction.accounts` " +
+      "and every pubkey in `addressLookupTableAddresses` from mainnet-beta " +
+      "before running the test. The user account at the swap instruction's " +
+      "user position must be rewritten to the test wallet's pubkey at run " +
+      "time (the placeholder above is for stable hashing only).",
+    quote,
+    swap,
+  };
+
+  fs.writeFileSync(outPath, JSON.stringify(fixture, null, 2));
+  console.log(`\n  wrote ${outPath}`);
+  console.log(`  size : ${(fs.statSync(outPath).size / 1024).toFixed(1)} KB`);
+}
+
+main().catch((e) => {
+  console.error("✗", e);
+  process.exit(1);
+});

--- a/scripts/ops/flip-protocol-treasury.ts
+++ b/scripts/ops/flip-protocol-treasury.ts
@@ -1,0 +1,121 @@
+/**
+ * Post-Squads-provisioning helper. Takes a base58 vault key, validates
+ * the format, rewrites the PROTOCOL_TREASURY constant in
+ * contracts/axis-vault/src/constants.rs in place, and prints the next
+ * deploy steps. Closes the code-side of #61 item 3.
+ *
+ * Usage:
+ *   bun scripts/ops/flip-protocol-treasury.ts <vault-base58>
+ *
+ * Pre-conditions (kidney + muse must complete BEFORE running this):
+ *   1. Squads V4 2-of-2 multisig provisioned on devnet (kidney + muse)
+ *   2. Devnet end-to-end test passed (CreateEtf → DepositSol → ...)
+ *   3. Squads V4 2-of-2 multisig provisioned on MAINNET
+ *   4. Mainnet vault address copied from the Squads UI
+ *
+ * Don't run this script before step 3. Flipping the constant against a
+ * not-yet-deployed Squads vault key ships a binary pointing at a key
+ * nobody controls — bricks the treasury gate until you redeploy.
+ */
+
+import * as fs from "fs";
+import * as path from "path";
+
+const repoRoot = path.resolve(import.meta.dir, "../..");
+const CONSTANTS_PATH = path.join(
+  repoRoot,
+  "contracts/axis-vault/src/constants.rs",
+);
+
+function decodeBase58(s: string): Uint8Array {
+  // Tiny base58 decode — enough for a 32-byte pubkey.
+  const ALPHABET =
+    "123456789ABCDEFGHJKLMNPQRSTUVWXYZabcdefghijkmnopqrstuvwxyz";
+  let n = 0n;
+  for (const c of s) {
+    const i = ALPHABET.indexOf(c);
+    if (i < 0) throw new Error(`invalid base58 char: ${c}`);
+    n = n * 58n + BigInt(i);
+  }
+  // Account for leading 1s → leading zero bytes.
+  let leadingZeros = 0;
+  for (const c of s) {
+    if (c === "1") leadingZeros++;
+    else break;
+  }
+  const bytes: number[] = [];
+  while (n > 0n) {
+    bytes.push(Number(n & 0xffn));
+    n >>= 8n;
+  }
+  while (leadingZeros-- > 0) bytes.push(0);
+  return new Uint8Array(bytes.reverse());
+}
+
+function formatAsRustArray(bytes: Uint8Array): string {
+  // Match the existing TOKEN_PROGRAM_ID style: 8 bytes per line, 2-hex,
+  // 4-space indent.
+  const lines: string[] = [];
+  for (let i = 0; i < 32; i += 8) {
+    const row = Array.from(bytes.slice(i, i + 8))
+      .map((b) => `0x${b.toString(16).padStart(2, "0")}`)
+      .join(", ");
+    lines.push(`    ${row},`);
+  }
+  return lines.join("\n");
+}
+
+function main() {
+  const vaultB58 = process.argv[2];
+  if (!vaultB58) {
+    console.error("usage: bun scripts/ops/flip-protocol-treasury.ts <vault-base58>");
+    process.exit(1);
+  }
+
+  const bytes = decodeBase58(vaultB58);
+  if (bytes.length !== 32) {
+    console.error(`✗ expected 32 bytes, got ${bytes.length}`);
+    process.exit(1);
+  }
+  if (bytes.every((b) => b === 0)) {
+    console.error("✗ refusing to write the all-zero key (that's the inert sentinel)");
+    process.exit(1);
+  }
+
+  const src = fs.readFileSync(CONSTANTS_PATH, "utf-8");
+  const constName = "PROTOCOL_TREASURY";
+  const re = new RegExp(
+    `pub const ${constName}: \\[u8; 32\\] = \\[[\\s\\S]*?\\];`,
+  );
+  if (!re.test(src)) {
+    console.error(`✗ could not locate ${constName} in ${CONSTANTS_PATH}`);
+    process.exit(1);
+  }
+
+  const replacement =
+    `pub const ${constName}: [u8; 32] = [\n${formatAsRustArray(bytes)}\n];`;
+  const next = src.replace(re, replacement);
+
+  if (next === src) {
+    console.error("✗ replacement produced no change — already pointing at this key?");
+    process.exit(1);
+  }
+
+  fs.writeFileSync(CONSTANTS_PATH, next);
+  console.log(`  ✓ wrote ${vaultB58}`);
+  console.log(`  ✓ updated ${path.relative(repoRoot, CONSTANTS_PATH)}`);
+  console.log();
+  console.log("Next steps (must do, in order):");
+  console.log("  1. Update contracts/axis-vault/src/lib.rs declare_id! to the");
+  console.log("     mainnet program ID (was a placeholder).");
+  console.log("  2. cargo build-sbf --manifest-path contracts/axis-vault/Cargo.toml");
+  console.log("  3. Verify the .so size hasn't drifted: `ls -la contracts/axis-vault/target/deploy/axis_vault.so`");
+  console.log("  4. Muse deploys via Squads (the deploy itself is a Squads tx).");
+  console.log("  5. Verify on-chain:");
+  console.log(`       solana account <axis_vault_program_id> --output json | jq .`);
+  console.log(`       # then a CreateEtf tx that exercises the gate — must succeed`);
+  console.log(`       # for treasury == ${vaultB58} and reject for any other key.`);
+  console.log("  6. Close #59 + the related items in #61.");
+}
+
+main();

--- a/scripts/package.json
+++ b/scripts/package.json
@@ -4,6 +4,8 @@
   "private": true,
   "scripts": {
     "setup-feeds": "bun setup-switchboard-feeds.ts",
-    "axis-vault:demo": "bun axis-vault/demo.ts"
+    "axis-vault:demo": "bun axis-vault/demo.ts",
+    "ops:fetch-jupiter-quote": "bun ops/fetch-jupiter-quote.ts",
+    "ops:flip-treasury": "bun ops/flip-protocol-treasury.ts"
   }
 }

--- a/test/fixtures/jupiter/sol-usdc-100m.json
+++ b/test/fixtures/jupiter/sol-usdc-100m.json
@@ -1,0 +1,232 @@
+{
+  "fetchedAt": "2026-04-25T17:15:15.008Z",
+  "inputMint": "So11111111111111111111111111111111111111112",
+  "outputMint": "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v",
+  "amount": "100000000",
+  "slippageBps": 50,
+  "userPlaceholder": "11111111111111111111111111111112",
+  "note": "This response was recorded against mainnet-beta. To replay against a forked validator, clone every account in `swapInstruction.accounts` and every pubkey in `addressLookupTableAddresses` from mainnet-beta before running the test. The user account at the swap instruction's user position must be rewritten to the test wallet's pubkey at run time (the placeholder above is for stable hashing only).",
+  "quote": {
+    "inputMint": "So11111111111111111111111111111111111111112",
+    "inAmount": "100000000",
+    "outputMint": "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v",
+    "outAmount": "8579743",
+    "otherAmountThreshold": "8536845",
+    "swapMode": "ExactIn",
+    "slippageBps": 50,
+    "platformFee": null,
+    "priceImpactPct": "0.0002903275606329999999999982",
+    "routePlan": [
+      {
+        "swapInfo": {
+          "ammKey": "FpCMFDFGYotvufJ7HrFHsWEiiQCGbkLCtwHiDnh7o28Q",
+          "label": "Whirlpool",
+          "inputMint": "So11111111111111111111111111111111111111112",
+          "outputMint": "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v",
+          "inAmount": "100000000",
+          "outAmount": "8579743",
+          "updateContextSlot": "415608412"
+        },
+        "percent": 100,
+        "bps": null
+      }
+    ],
+    "contextSlot": 415608458,
+    "timeTaken": 0.00154236,
+    "swapUsdValue": "8.582234659253401025880852888",
+    "mostReliableAmmsQuoteReport": {
+      "info": {
+        "Czfq3xZZDmsdGdUyrNLtRhGc47cXcZtLG4crryfu44zE": "8577815",
+        "BZtgQEyS6eXUXicYPHecYQ7PybqodXQMvkjUbP4R8mUU": "8578488"
+      }
+    },
+    "longtailMarketQuoteReport": null,
+    "useIncurredSlippageForQuoting": null,
+    "useRewards": null,
+    "otherRoutePlans": null,
+    "loadedLongtailToken": false,
+    "instructionVersion": null
+  },
+  "swap": {
+    "tokenLedgerInstruction": null,
+    "computeBudgetInstructions": [
+      {
+        "programId": "ComputeBudget111111111111111111111111111111",
+        "accounts": [],
+        "data": "AsBcFQA="
+      }
+    ],
+    "setupInstructions": [],
+    "swapInstruction": {
+      "programId": "JUP6LkbZbjS1jKKwapdHNy74zcZ3tLUZoi5QNyVTaV4",
+      "accounts": [
+        {
+          "pubkey": "TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA",
+          "isSigner": false,
+          "isWritable": false
+        },
+        {
+          "pubkey": "11111111111111111111111111111112",
+          "isSigner": true,
+          "isWritable": false
+        },
+        {
+          "pubkey": "5os4kc32895qa1smTDGsAVXRiisXRo4UJWauUePnas1u",
+          "isSigner": false,
+          "isWritable": true
+        },
+        {
+          "pubkey": "G9xKTRhM57AL4my3ZRVNqM95mxtACgKdNRPX6EVhB7hv",
+          "isSigner": false,
+          "isWritable": true
+        },
+        {
+          "pubkey": "JUP6LkbZbjS1jKKwapdHNy74zcZ3tLUZoi5QNyVTaV4",
+          "isSigner": false,
+          "isWritable": false
+        },
+        {
+          "pubkey": "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v",
+          "isSigner": false,
+          "isWritable": false
+        },
+        {
+          "pubkey": "JUP6LkbZbjS1jKKwapdHNy74zcZ3tLUZoi5QNyVTaV4",
+          "isSigner": false,
+          "isWritable": false
+        },
+        {
+          "pubkey": "D8cy77BBepLMngZx6ZukaTff5hCt1HrWyKk3Hnd9oitf",
+          "isSigner": false,
+          "isWritable": false
+        },
+        {
+          "pubkey": "JUP6LkbZbjS1jKKwapdHNy74zcZ3tLUZoi5QNyVTaV4",
+          "isSigner": false,
+          "isWritable": false
+        },
+        {
+          "pubkey": "whirLbMiicVdio4qvUfM5KAg6Ct8VwpYzGff3uctyCc",
+          "isSigner": false,
+          "isWritable": false
+        },
+        {
+          "pubkey": "TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA",
+          "isSigner": false,
+          "isWritable": false
+        },
+        {
+          "pubkey": "11111111111111111111111111111112",
+          "isSigner": false,
+          "isWritable": false
+        },
+        {
+          "pubkey": "FpCMFDFGYotvufJ7HrFHsWEiiQCGbkLCtwHiDnh7o28Q",
+          "isSigner": false,
+          "isWritable": true
+        },
+        {
+          "pubkey": "5os4kc32895qa1smTDGsAVXRiisXRo4UJWauUePnas1u",
+          "isSigner": false,
+          "isWritable": true
+        },
+        {
+          "pubkey": "6mQ8xEaHdTikyMvvMxUctYch6dUjnKgfoeib2msyMMi1",
+          "isSigner": false,
+          "isWritable": true
+        },
+        {
+          "pubkey": "G9xKTRhM57AL4my3ZRVNqM95mxtACgKdNRPX6EVhB7hv",
+          "isSigner": false,
+          "isWritable": true
+        },
+        {
+          "pubkey": "AQ36QRk3HAe6PHqBCtKTQnYKpt2kAagq9YoeTqUPMGHx",
+          "isSigner": false,
+          "isWritable": true
+        },
+        {
+          "pubkey": "G4ZvJ3P7u9BWgroiiW4Rq1XmqR6vVSzDW8x8V8FVtyau",
+          "isSigner": false,
+          "isWritable": true
+        },
+        {
+          "pubkey": "mDaa4haD4R2HBVwHwM8dv9oeYn7RxDX4orvAkSYbL1b",
+          "isSigner": false,
+          "isWritable": true
+        },
+        {
+          "pubkey": "2LftJnp6rXL6gBLv6hCr57jHvRX3jRBWPDmPwGjDTzgA",
+          "isSigner": false,
+          "isWritable": true
+        },
+        {
+          "pubkey": "923j69hYbT5Set5kYfiQr1D8jPL6z15tbfTbVLSwUWJD",
+          "isSigner": false,
+          "isWritable": false
+        }
+      ],
+      "data": "5RfLl3rjrSoBAAAAEQFkAAEA4fUFAAAAAJ/qggAAAAAAMgAA"
+    },
+    "cleanupInstruction": null,
+    "otherInstructions": [],
+    "addressLookupTableAddresses": [
+      "J7znuMyVHurxwjL19Rbtq2CSbjPEhqWvwEcgdWajEtnc"
+    ],
+    "prioritizationFeeLamports": 0,
+    "computeUnitLimit": 1400000,
+    "prioritizationType": {
+      "computeBudget": {
+        "microLamports": 0,
+        "estimatedMicroLamports": 0
+      }
+    },
+    "simulationSlot": null,
+    "dynamicSlippageReport": null,
+    "simulationError": null,
+    "addressesByLookupTableAddress": null,
+    "blockhashWithMetadata": {
+      "blockhash": [
+        233,
+        209,
+        56,
+        21,
+        138,
+        247,
+        173,
+        141,
+        3,
+        147,
+        46,
+        47,
+        97,
+        153,
+        153,
+        171,
+        200,
+        242,
+        184,
+        66,
+        90,
+        23,
+        87,
+        179,
+        74,
+        128,
+        96,
+        6,
+        179,
+        99,
+        192,
+        113
+      ],
+      "lastValidBlockHeight": 393702618,
+      "fetchedAt": {
+        "secs_since_epoch": 1777137301,
+        "nanos_since_epoch": 618401769
+      }
+    },
+    "timeTaken": 0.008125845,
+    "createAtaTimeTaken": 0.005058881
+  }
+}


### PR DESCRIPTION
Honest framing: items #3 and #5 in #61 both have a hard manual gate I can't get past for you — provisioning a Squads V4 multisig (#3) and creating an on-chain ALT (#5(b)) both need wallet signatures from kidney + muse. What this PR delivers is everything mechanical around those gates so the manual steps become a paste-job rather than a coding task.

## #5 Jupiter fixture (5(a) and 5(c) closed; 5(b) tooling ready)

### Confirmed: Jupiter free tier is fine for CI (5a)
\`lite-api.jup.ag/swap/v1/*\` — no auth, soft rate limit. Fetcher script verified working against it.

### Recorded fixture (5c)
\`test/fixtures/jupiter/sol-usdc-100m.json\` — SOL → USDC, 100M lamports, 50 bps. 6.6 KB, 21 swap-instruction accounts, 1 ALT.

### Tooling
- \`scripts/ops/fetch-jupiter-quote.ts\` — refresh the fixture (or fetch a new pair). 3× retry with backoff. \`bun run ops:fetch-jupiter-quote -- --label sol-usdc-100m\`
- \`scripts/ops/dump-jupiter-fixture-accounts.sh\` — given a fixture, dumps every referenced account via \`solana account\` with multi-RPC retry, writes \`clone-args.txt\` ready to paste into the validator command line. Means the validator boots offline and can't fail on mainnet RPC outages (the same root cause we just fixed in main-report.yml + litesvm-jupiter-cpi.yml).

### Documentation
- \`docs/ops/MAINNET_FORK_RUNBOOK.md\` — full step-by-step (refresh fixture → dump accounts → boot validator → run e2e). Also documents what \`axis-g3m.jupiter-fork.e2e.ts\` still needs to reach disc=4 \`RebalanceViaJupiter\` (currently runs attestation-mode disc=3 only) — that code-side follow-up is unblocked once you've run the runbook once.

## #3 Squads V4 deploy (code-side helpers ready; ops gates documented)

### Helper
- \`scripts/ops/flip-protocol-treasury.ts\` — takes a base58 vault key, decodes 32 bytes (rejects all-zero), rewrites \`PROTOCOL_TREASURY\` in \`contracts/axis-vault/src/constants.rs\` matching the existing \`TOKEN_PROGRAM_ID\` formatting, prints the 6-step deploy checklist on stdout. Verified — \`cargo build-sbf\` clean against a flipped binary. \`bun run ops:flip-treasury <vault-base58>\`

### Documentation
- \`docs/ops/SQUADS_RUNBOOK.md\` — 7-step provisioning guide:
  1. Devnet Squads vault (kidney + muse)
  2. Devnet end-to-end smoke test
  3. Mainnet Squads vault
  4. Flip constant via the helper + bump \`declare_id!()\` in same commit
  5. Muse deploys via Squads tx
  6. On-chain verification (\`CreateEtf\` with right + wrong treasury, expect \`TreasuryNotApproved\` on the wrong path)
  7. Close #59 + related #61 items

  Plus rollback notes (don't flip back to zero — that re-opens the silent bypass) and threat model (single-signer compromise mitigation, Squads upgrade authority, the pfda-amm v1 fallback path that bypasses this treasury and is therefore on its own to migrate).

## What's still on you

- **#3**: provision the actual Squads vaults (devnet then mainnet). Everything in the runbook from step 1 onwards needs your wallet.
- **#5(b)**: provision a funded test wallet for the e2e. ALT itself doesn't need new on-chain creation — we ride mainnet's existing ALTs via clone.

## Test plan

- [x] \`bun ops:fetch-jupiter-quote\` produces a valid fixture (verified locally)
- [x] \`bun ops:flip-treasury <key>\` rewrites constants.rs and the resulting binary still passes \`cargo build-sbf\`
- [x] \`scripts/ops/dump-jupiter-fixture-accounts.sh\` parses the fixture correctly (no execution against mainnet RPC verified yet — test infra not in place; the script's RPC handling mirrors the workflow fix that we already proved works in PR #64)
- [ ] Once you provision the devnet Squads vault, run the runbook end-to-end; if any step doesn't match what Squads' UI presents, file an amendment

## Stacks on

- PR #64 (just merged) — supplies the v2 \`PoolState\` schema + treasury fallback path that makes the migration story coherent

## Out of scope

- Wiring \`axis-g3m.jupiter-fork.e2e.ts\` to actually call disc=4 \`RebalanceViaJupiter\` with the recorded fixture — separate code follow-up, unblocked by this runbook
- A CI job that auto-refreshes the Jupiter fixture — explicitly not done; the fixture's value is determinism, auto-refresh would defeat that