### PR TITLE
fix(ci): swap import.meta.dir for __dirname in ops scripts

### DIFF
--- a/scripts/ops/fetch-jupiter-quote.ts
+++ b/scripts/ops/fetch-jupiter-quote.ts
@@ -123,9 +123,10 @@ async function main() {
   console.log(`  ✓ ALTs   : ${(swap.addressLookupTableAddresses ?? []).length}`);
 
   // Write under <repo-root>/test/fixtures/jupiter regardless of which
-  // directory the script is invoked from. import.meta.dir points at
-  // scripts/ops/, so two `..` to repo root.
-  const repoRoot = path.resolve(import.meta.dir, "../..");
+  // directory the script is invoked from. __dirname points at
+  // scripts/ops/, so two `..` to repo root. Using __dirname instead of
+  // bun's import.meta.dir keeps the TS check (module: commonjs) green.
+  const repoRoot = path.resolve(__dirname, "../..");
   const fixtureDir = path.join(repoRoot, "test/fixtures/jupiter");
   fs.mkdirSync(fixtureDir, { recursive: true });
   const outPath = path.join(fixtureDir, `${label}.json`);

--- a/scripts/ops/flip-protocol-treasury.ts
+++ b/scripts/ops/flip-protocol-treasury.ts
@@ -21,7 +21,10 @@
 import * as fs from "fs";
 import * as path from "path";
 
-const repoRoot = path.resolve(import.meta.dir, "../..");
+// __dirname (provided by bun/CJS) instead of import.meta.dir keeps the
+// project's TS check (module: commonjs) happy without adding bun-specific
+// type declarations.
+const repoRoot = path.resolve(__dirname, "../..");
 const CONSTANTS_PATH = path.join(
   repoRoot,
   "contracts/axis-vault/src/constants.rs",


### PR DESCRIPTION
PR #65's new ops scripts broke the TypeScript check on main. Repo typecheck uses \`module: commonjs\` (\`scripts/tsconfig.json\`) which doesn't allow \`import.meta\`:

\`\`\`
scripts/ops/fetch-jupiter-quote.ts(128,33): TS1343: 'import.meta' meta-property not allowed under module: commonjs
scripts/ops/flip-protocol-treasury.ts(24,31): TS1343
\`\`\`

Both files now use \`__dirname\` instead — same approach as \`setup-switchboard-feeds.ts\` already in the repo. bun emulates \`__dirname\` for ESM-syntax files so runtime behaviour is unchanged.

Verified locally: \`bun run typecheck\` clean across all 7 tsconfig roots.

This unblocks the next CI run; nothing else changed.