### PR TITLE
feat(pfda-amm-3): cap InitializePool base_fee_bps at 100 bps

### DIFF
--- a/contracts/ab-integration-tests/tests/scenario_coverage.rs
+++ b/contracts/ab-integration-tests/tests/scenario_coverage.rs
@@ -450,8 +450,8 @@ fn pfda3_init_ix_bogus(
     data.extend_from_slice(&333_333u32.to_le_bytes());
     data.extend_from_slice(&333_334u32.to_le_bytes());
 
-    // 12-account minimum. base_fee_bps=10_000 rejection fires before
-    // any account is read, so unique fresh keys are enough.
+    // 12-account minimum. The base_fee_bps validation rejection fires
+    // before any account is read, so unique fresh keys are enough.
     let mut accts = vec![
         AccountMeta::new(payer.pubkey(), true),
         AccountMeta::new(pool, false),
@@ -484,6 +484,30 @@ fn pfda3_init_rejects_fee_100_percent() {
     .err()
     .expect("base_fee_bps=10_000 should reject");
     assert_custom_err(&err, ERR_INVALID_FEE_BPS, "pfda3 fee=100%");
+}
+
+#[test]
+fn pfda3_init_rejects_fee_above_max_cap() {
+    // pre-mainnet hardening: tighten the init-time fee cap from
+    // `>= 10_000` to `> MAX_BASE_FEE_BPS` (= 100 bps, Uniswap V3 top
+    // tier). One bp above the cap must reject so the whitepaper claim
+    // "f bounded by 100 bps at initialization" has a test backing it.
+    require_fixture!(PFDA_AMM_3_SO);
+    let mut svm = LiteSVM::new();
+    if !std::path::Path::new(PFDA_AMM_3_SO).exists() { return; }
+    svm.add_program_from_file(pfda3_id(), PFDA_AMM_3_SO).unwrap();
+    let payer = Keypair::new();
+    svm.airdrop(&payer.pubkey(), LAMPORTS_PER_SOL).unwrap();
+
+    let bogus_pool = Address::new_unique();
+    let err = send(
+        &mut svm,
+        pfda3_init_ix_bogus(&payer, 101, bogus_pool),
+        &payer,
+    )
+    .err()
+    .expect("base_fee_bps=101 should reject (cap is 100)");
+    assert_custom_err(&err, ERR_INVALID_FEE_BPS, "pfda3 fee one above cap");
 }
 
 #[test]

--- a/contracts/pfda-amm-3/src/constants.rs
+++ b/contracts/pfda-amm-3/src/constants.rs
@@ -1,0 +1,19 @@
+//! Shared constants for pfda-amm-3.
+
+/// Hard ceiling for `base_fee_bps` accepted by `InitializePool`.
+///
+/// pfda-amm-3 has no post-deploy fee-update instruction: `base_fee_bps`
+/// is set once at init and is immutable for the pool's lifetime. The
+/// init-time guard is therefore the only bound on `f` that ever
+/// applies, which makes a tight ceiling load-bearing for the security
+/// story rather than belt-and-suspenders.
+///
+/// 100 bps (1.0 %) matches the upper Uniswap V3 fee tier and is the
+/// number readers immediately recognise as "the high end of a normal
+/// AMM fee," removing the "why is this effectively unbounded?" question
+/// auditors and VCs raise against the legacy `>= 10_000` guard.
+///
+/// Raising this cap requires a state migration (existing pools keep
+/// their `base_fee_bps` but new pools deploy under the new constant)
+/// — a deliberate, versioned decision rather than per-pool slack.
+pub const MAX_BASE_FEE_BPS: u16 = 100;

--- a/contracts/pfda-amm-3/src/error.rs
+++ b/contracts/pfda-amm-3/src/error.rs
@@ -40,7 +40,10 @@ pub enum Pfda3Error {
     BidExcessive = 8031,
     /// WithdrawFees requested amount exceeds tracked reserves (#33)
     FeeWithdrawExceedsReserves = 8032,
-    /// InitializePool base_fee_bps ≥ 10_000 (#33)
+    /// InitializePool `base_fee_bps` exceeds `constants::MAX_BASE_FEE_BPS`
+    /// (currently 100 bps). Originally introduced for `>= 10_000` (#33);
+    /// pre-mainnet hardening tightened the cap to 100 bps to match the
+    /// upper Uniswap V3 fee tier.
     InvalidFeeBps = 8033,
     /// PDA substitution: passed-in account does not match the PDA
     /// derived from the declared seeds (#33 claim history/ticket)

--- a/contracts/pfda-amm-3/src/instructions/initialize_pool.rs
+++ b/contracts/pfda-amm-3/src/instructions/initialize_pool.rs
@@ -9,6 +9,7 @@ use pinocchio::{
 use pinocchio_system::instructions::CreateAccount;
 use pinocchio_token::instructions::InitializeAccount3;
 
+use crate::constants::MAX_BASE_FEE_BPS;
 use crate::error::Pfda3Error;
 use crate::state::{load_mut, BatchQueue3, PoolState3};
 
@@ -42,9 +43,12 @@ pub fn process_initialize_pool_3(
         return Err(Pfda3Error::InvalidWeight.into());
     }
 
-    // #33: reject a fee ≥ 100% up-front so a misconfigured pool can
-    // never deploy. Mirrors the guard added to pfda-amm.
-    if base_fee_bps >= 10_000 {
+    // Init-time hard ceiling. pfda-amm-3 has no SetFee path, so
+    // `base_fee_bps` is fixed for the pool's life — the guard here is
+    // the only bound that ever applies. Capped at 100 bps (Uniswap V3
+    // top tier) to remove the "fee can be dialled to ~100 %" optic
+    // that the legacy `>= 10_000` guard left for auditors.
+    if base_fee_bps > MAX_BASE_FEE_BPS {
         return Err(Pfda3Error::InvalidFeeBps.into());
     }
 

--- a/contracts/pfda-amm-3/src/lib.rs
+++ b/contracts/pfda-amm-3/src/lib.rs
@@ -11,6 +11,7 @@ fn panic(_info: &core::panic::PanicInfo) -> ! {
     unsafe { core::hint::unreachable_unchecked() }
 }
 
+pub mod constants;
 pub mod error;
 pub mod instructions;
 pub mod jito;

--- a/docs/architecture/MAINNET_SCOPE.md
+++ b/docs/architecture/MAINNET_SCOPE.md
@@ -33,7 +33,7 @@ Everything else in this repo (`axis-g3m`, `pfda-amm`, `solana-tfmm-rs`, A/B harn
 
 | Disc | Name | Authority required | Purpose |
 |---|---|---|---|
-| 0 | `InitializePool` | Pool creator | One-time pool setup with 3 mints, weights, fee, window |
+| 0 | `InitializePool` | Pool creator | One-time pool setup with 3 mints, weights, fee, window. `base_fee_bps` capped at `MAX_BASE_FEE_BPS = 100` (1.0 %, Uniswap V3 top tier) and immutable post-init |
 | 1 | `SwapRequest` | User (signer) | Add a swap intent to the current batch queue |
 | 2 | `ClearBatch` | Cranker (signer) | Settle the batch; pays bid to treasury, computes clearing prices |
 | 3 | `Claim` | User (signer) | Withdraw the user's pro-rata share of the cleared batch |
@@ -218,7 +218,7 @@ The program author trusts:
 The program author DOES NOT trust:
 - Any other program ID passed in as a CPI target — verified by exact-match before invoke
 - Any account passed in as writable — verified to be SPL Token-owned, key-matching expected vault, before any data read
-- Pool authority — limited to fee/cap/pause adjustments within bounds (`MAX_FEE_BPS_CEILING = 300`, monotonic cap)
+- Pool authority — limited to fee/cap/pause adjustments within bounds (axis-vault `MAX_FEE_BPS_CEILING = 300`, monotonic cap; pfda-amm-3 has no fee-update path — `base_fee_bps` fixed at init under `MAX_BASE_FEE_BPS = 100`)
 - Treasury keypair — limited to sweep operation; no slippage exposure
 - User submitted instruction data — bounds-checked, integer overflow-checked
 


### PR DESCRIPTION
## Summary

- Tightens the `InitializePool` fee guard from `>= 10_000` to `> MAX_BASE_FEE_BPS` where `MAX_BASE_FEE_BPS = 100`, matching the Uniswap V3 top fee tier.
- Addresses whitepaper-review feedback: the legacy `9999 bps` ceiling reads as a rug vector to auditors and VCs even though pfda-amm-3 has no post-deploy fee-update path.
- pfda-amm-3 has no SetFee instruction, so `base_fee_bps` is **immutable post-init** — the init guard is the only bound that ever applies, which makes a tight ceiling load-bearing rather than belt-and-suspenders.
- Mirrors the hard-ceiling pattern already in `axis-vault` (`MAX_FEE_BPS_CEILING = 300`) so both v1 programs share the same init-time bound story for the audit narrative.

## Changes

| File | Change |
|---|---|
| `contracts/pfda-amm-3/src/constants.rs` (new) | `pub const MAX_BASE_FEE_BPS: u16 = 100;` |
| `contracts/pfda-amm-3/src/lib.rs` | `pub mod constants;` |
| `contracts/pfda-amm-3/src/instructions/initialize_pool.rs` | Guard tightened: `>= 10_000` → `> MAX_BASE_FEE_BPS` |
| `contracts/pfda-amm-3/src/error.rs` | Doc-comment refreshed; reuses error code 8033 (`InvalidFeeBps`) — no client ABI churn |
| `contracts/ab-integration-tests/tests/scenario_coverage.rs` | New test `pfda3_init_rejects_fee_above_max_cap` (sends `base_fee_bps=101`, expects reject) |
| `docs/architecture/MAINNET_SCOPE.md` | InitializePool row + audit-surface section note the cap and immutability |

## Why 100, not 300

- pfda-amm-3 fee is **immutable**; for axis-vault `MAX_FEE_BPS_CEILING = 300` is a SetFee headroom (multi-layer cap), here the init cap is the entire bound for the pool's lifetime.
- 100 bps = Uniswap V3 top tier; readers immediately recognise it as "the high end of a normal AMM fee."
- If v1.1 ever needs exotic-pair headroom, raising the cap is a deliberate state-migration moment with a paper trail — strictly better than leaving slack now.

## Test plan

- [x] Rust unit (pfda-amm-3): 1 pass
- [x] LiteSVM integration (`ab-integration-tests`): 86 pass / 2 ignored / 0 fail (was 85 → 86 with the new test)
- [x] Old test `pfda3_init_rejects_fee_100_percent` (sends 10_000) still passes — backwards compatible
- [x] cargo build-sbf clean
- [ ] CI run on this PR (this PR triggers)

## Whitepaper wording suggested

> swap fee `f` is bounded by `MAX_BASE_FEE_BPS = 100 bps` at initialization, **immutable post-init** (no SetFee instruction in pfda-amm-3).

The immutability clause is the load-bearing property the cap actually buys.