### PR TITLE
Fix wBTC/wETH ETF seed floor

### DIFF
--- a/contracts/axis-vault/src/constants.rs
+++ b/contracts/axis-vault/src/constants.rs
@@ -21,10 +21,15 @@ pub const MAX_NAV_DEVIATION_BPS: u64 = 300;
 /// Closes the cheap-attacker leg of the inflation / donation attack:
 /// without this, an attacker could seed with `amount = 1`, then donate
 /// huge quantities of basket tokens directly into the vault ATAs to
-/// push every proportional-mint candidate to zero for the next
-/// legitimate depositor (they would revert on `ZeroDeposit`, bricking
-/// the pool). 1_000_000 = 1 token at 6 decimals.
-pub const MIN_FIRST_DEPOSIT: u64 = 1_000_000;
+/// push every proportional-mint candidate to zero for the next legitimate
+/// depositor (they would revert on `ZeroDeposit`, bricking the pool).
+///
+/// Keep this above `MINIMUM_LIQUIDITY`, but do not force a full 1.0 ETF at
+/// genesis. A 1_000_000 floor made high-value, low-raw-unit basket legs
+/// (wBTC/wETH) require too much SOL just to bootstrap. 10_000 = 0.01 ETF
+/// at 6 decimals, which preserves the virtual-liquidity defense while
+/// making mixed-decimal/high-price baskets deployable.
+pub const MIN_FIRST_DEPOSIT: u64 = 10_000;
 
 /// Virtual liquidity lock added to `etf.total_supply` on the first
 /// deposit but never minted to any holder. Combined with

--- a/frontend/src/components/CreateEtfPanel.tsx
+++ b/frontend/src/components/CreateEtfPanel.tsx
@@ -52,11 +52,11 @@ export function CreateEtfPanel({
   const [uri, setUri] = useState("");
   const [rows, setRows] = useState<BasketRow[]>([]);
   // Default 1_000_000_000 = 1000 tokens at 6 decimals, matches the e2e
-  // test. The program rejects amount < MIN_FIRST_DEPOSIT (1_000_000)
+  // test. The program rejects amount < MIN_FIRST_DEPOSIT (10_000)
   // with InsufficientFirstDeposit (0x233A / 9018) on the first deposit.
   const [depositBase, setDepositBase] = useState<number>(1_000_000_000);
-  // 0.02 SOL clears the on-chain MIN_FIRST_DEPOSIT (1.0 ETF base) for
-  // typical mainnet routes at SOL ≈ $80-150. Smaller seeds will be
+  // 0.02 SOL comfortably clears the on-chain MIN_FIRST_DEPOSIT (0.01 ETF
+  // base) for typical mainnet routes. Smaller seeds can still be
   // refused by `buildDepositSolPlan` with a recommended bump.
   const [solSeed, setSolSeed] = useState<number>(0.02);
   const [slippageBps, setSlippageBps] = useState<number>(50);
@@ -390,28 +390,28 @@ export function CreateEtfPanel({
                     />
                   </label>
                   <span className="text-[11px] text-slate-500">
-                    First deposit must yield ≥ 1.0 ETF (1_000_000 base units);
+                    First deposit must yield ≥ 0.01 ETF (10_000 base units);
                     plan-builder rejects smaller seeds before sending.
                   </span>
                 </>
               ) : doDepositAfter && (
                 <label className="flex items-center gap-1">
                   <span className="text-slate-400">
-                    base amount (≥ 1_000_000; per-leg = amount × weight ÷ 10000):
+                    base amount (≥ 10_000; per-leg = amount × weight ÷ 10000):
                   </span>
                   <input
                     type="number"
-                    min={1_000_000}
-                    step={1_000_000}
+                    min={10_000}
+                    step={10_000}
                     value={depositBase}
                     onChange={(e) => setDepositBase(Number(e.target.value))}
                     className="w-40 rounded bg-slate-800 px-2 py-1 font-mono text-slate-100"
                   />
                 </label>
               )}
-              {doDepositAfter && !config.jupiterEnabled && depositBase < 1_000_000 && (
+              {doDepositAfter && !config.jupiterEnabled && depositBase < 10_000 && (
                 <span className="text-xs text-rose-400">
-                  ✗ amount &lt; MIN_FIRST_DEPOSIT (1_000_000) — first Deposit will revert with InsufficientFirstDeposit
+                  ✗ amount &lt; MIN_FIRST_DEPOSIT (10_000) — first Deposit will revert with InsufficientFirstDeposit
                 </span>
               )}
             </div>

--- a/frontend/src/lib/depositSolPlan.ts
+++ b/frontend/src/lib/depositSolPlan.ts
@@ -37,12 +37,12 @@ export const SOLANA_MAX_TX_CU = 1_400_000;
 export const SOLANA_MAX_TX_BYTES = 1232;
 /// Lamports of priority fee per CU when Jupiter doesn't supply one.
 const FALLBACK_PRIORITY_MICRO_LAMPORTS = 50_000;
-/// Mirrors `axis-vault` constants: `MIN_FIRST_DEPOSIT = 1_000_000`
-/// (= 1.0 ETF at 6 decimals). On-chain Deposit rejects with
+/// Mirrors `axis-vault` constants: `MIN_FIRST_DEPOSIT = 10_000`
+/// (= 0.01 ETF at 6 decimals). On-chain Deposit rejects with
 /// `InsufficientFirstDeposit` (0x233a) if `total_supply == 0` and
 /// `amount < MIN_FIRST_DEPOSIT_BASE`. We mirror the constant here so a
 /// doomed plan fails before a Jupiter swap tx burns user funds.
-export const MIN_FIRST_DEPOSIT_BASE = 1_000_000n;
+export const MIN_FIRST_DEPOSIT_BASE = 10_000n;
 
 export interface DepositSolPlanArgs {
   conn: Connection;
@@ -297,7 +297,7 @@ export async function buildDepositSolPlan(
       (args.solIn * MIN_FIRST_DEPOSIT_BASE * 11n) /
       (seedPreview.depositAmount * 10n);
     throw new Error(
-      `First deposit must yield ≥ ${MIN_FIRST_DEPOSIT_BASE} base units (1.0 ETF). ` +
+      `First deposit must yield ≥ ${MIN_FIRST_DEPOSIT_BASE} base units (0.01 ETF). ` +
         `At ${args.solIn} lamports (${(Number(args.solIn) / 1e9).toFixed(6)} SOL) the bottleneck floor is ` +
         `${seedPreview.depositAmount} base. Increase SOL seed to at least ` +
         `~${suggestedLamports} lamports (≈ ${(Number(suggestedLamports) / 1e9).toFixed(4)} SOL) and retry. ` +

--- a/frontend/src/lib/jupiterSeed.ts
+++ b/frontend/src/lib/jupiterSeed.ts
@@ -40,6 +40,7 @@ export interface JupiterSeedLegPreview {
 
 export interface JupiterSeedPreview {
   mode: JupiterQuoteMode;
+  allocationMode: "weighted" | "equalized";
   solIn: bigint;
   slippageBps: number;
   depositAmount: bigint;
@@ -97,19 +98,38 @@ export async function buildJupiterSeedPreview({
   );
   validateSeedInputs(mints, weights, solIn);
 
-  const legLamports = splitWeightedLamports(solIn, weights);
-  const quoteResults = await Promise.all(
-    mints.map((mint, i) =>
-      quoteClient.getQuote({
-        inputMint: SOL_MINT,
-        outputMint: mint,
-        amount: legLamports[i],
-        slippageBps,
-        swapMode: "ExactIn",
-        maxAccounts,
-      }),
-    ),
+  const quoteRound = (legLamports: bigint[]) =>
+    Promise.all(
+      mints.map((mint, i) =>
+        quoteLegSol(quoteClient, mint, legLamports[i], slippageBps, maxAccounts),
+      ),
+    );
+
+  const legLamports0 = splitWeightedLamports(solIn, weights);
+  const quotes0 = await quoteRound(legLamports0);
+
+  const legLamports1 = reallocateEqualizingCandidates(
+    solIn,
+    weights,
+    legLamports0,
+    quotes0,
   );
+  let legLamports = legLamports0;
+  let quoteResults = quotes0;
+  let allocationMode: JupiterSeedPreview["allocationMode"] = "weighted";
+  if (legLamports1 !== legLamports0) {
+    try {
+      const quotes1 = await quoteRound(legLamports1);
+      if (minDepositCandidate(quotes1, weights) > minDepositCandidate(quotes0, weights)) {
+        legLamports = legLamports1;
+        quoteResults = quotes1;
+        allocationMode = "equalized";
+      }
+    } catch {
+      // Equalization is an optimization. If a reduced cheap leg falls under a
+      // Jupiter route floor, keep the already-valid weighted quote.
+    }
+  }
 
   const legs = quoteResults.map((quote, i) => {
     const minOut = BigInt(quote.otherAmountThreshold);
@@ -134,6 +154,7 @@ export async function buildJupiterSeedPreview({
 
   return {
     mode: quoteClient.mode,
+    allocationMode,
     solIn,
     slippageBps,
     depositAmount: legs[bottleneckIndex].depositCandidate,
@@ -170,6 +191,87 @@ function splitWeightedLamports(solIn: bigint, weights: number[]): bigint[] {
   const assigned = legs.reduce((sum, lamports) => sum + lamports, 0n);
   legs[legs.length - 1] += solIn - assigned;
   return legs;
+}
+
+function quoteLegSol(
+  quoteClient: JupiterQuoteClient,
+  mint: PublicKey,
+  lamports: bigint,
+  slippageBps: number,
+  maxAccounts: number,
+): Promise<JupiterQuoteResponse> {
+  if (mint.equals(SOL_MINT)) {
+    const out = lamports.toString();
+    return Promise.resolve({
+      inputMint: SOL_MINT.toBase58(),
+      outputMint: mint.toBase58(),
+      inAmount: out,
+      outAmount: out,
+      otherAmountThreshold: out,
+      swapMode: "ExactIn",
+      slippageBps,
+      priceImpactPct: "0",
+      routePlan: [{ swapInfo: { label: "wrap" }, percent: 100 }],
+      contextSlot: 0,
+    });
+  }
+  return quoteClient.getQuote({
+    inputMint: SOL_MINT,
+    outputMint: mint,
+    amount: lamports,
+    slippageBps,
+    swapMode: "ExactIn",
+    maxAccounts,
+  });
+}
+
+function minDepositCandidate(
+  quotes: JupiterQuoteResponse[],
+  weights: number[],
+): bigint {
+  let lo: bigint | null = null;
+  for (let i = 0; i < quotes.length; i++) {
+    const candidate =
+      (BigInt(quotes[i].otherAmountThreshold) * 10_000n) / BigInt(weights[i]);
+    if (lo === null || candidate < lo) lo = candidate;
+  }
+  return lo ?? 0n;
+}
+
+function reallocateEqualizingCandidates(
+  solIn: bigint,
+  weights: number[],
+  legLamports0: bigint[],
+  quotes0: JupiterQuoteResponse[],
+): bigint[] {
+  const scale = 1_000_000_000_000n;
+  const ratios: bigint[] = new Array(weights.length);
+  for (let i = 0; i < weights.length; i++) {
+    const minOut0 = BigInt(quotes0[i].otherAmountThreshold);
+    if (legLamports0[i] <= 0n || minOut0 <= 0n) return legLamports0;
+    const ratio = (BigInt(weights[i]) * legLamports0[i] * scale) / minOut0;
+    if (ratio <= 0n) return legLamports0;
+    ratios[i] = ratio;
+  }
+  const ratioSum = ratios.reduce((a, b) => a + b, 0n);
+  if (ratioSum <= 0n) return legLamports0;
+
+  const out = ratios.map((ratio) => (solIn * ratio) / ratioSum);
+  const assigned = out.reduce((a, b) => a + b, 0n);
+  let biggest = 0;
+  for (let i = 1; i < out.length; i++) if (out[i] > out[biggest]) biggest = i;
+  out[biggest] += solIn - assigned;
+  for (const leg of out) if (leg <= 0n) return legLamports0;
+
+  let changed = false;
+  for (let i = 0; i < out.length; i++) {
+    const diff = Number(out[i] - legLamports0[i]);
+    if (Math.abs(diff) > Number(legLamports0[i]) * 0.005 + 1) {
+      changed = true;
+      break;
+    }
+  }
+  return changed ? out : legLamports0;
 }
 
 function extractRouteLabel(quote: JupiterQuoteResponse): string {

--- a/frontend/src/lib/tx.ts
+++ b/frontend/src/lib/tx.ts
@@ -213,7 +213,7 @@ function labelForCode(hex: string): string | null {
     "0x2337": "axis-vault: SlippageExceeded",           // 9015
     "0x2338": "axis-vault: NavDeviationExceeded",       // 9016
     "0x2339": "axis-vault: TreasuryMismatch",           // 9017
-    "0x233a": "axis-vault: InsufficientFirstDeposit (amount must be >= 1_000_000 base units)", // 9018
+    "0x233a": "axis-vault: InsufficientFirstDeposit (amount must be >= 10_000 base units)", // 9018
     "0x233b": "axis-vault: InvalidTicker (A-Z 0-9, 2..16 bytes)", // 9019
     "0x233c": "axis-vault: InvalidName (>32 bytes or empty)", // 9020
     "0x233d": "axis-vault: SweepForbidden",            // 9021

--- a/test/e2e/axis-vault/axis-vault.local.e2e.ts
+++ b/test/e2e/axis-vault/axis-vault.local.e2e.ts
@@ -1174,10 +1174,10 @@ async function main() {
   {
     const fresh = await spinUpFreshEtf("DONATE");
 
-    // Legit first deposit at exactly MIN_FIRST_DEPOSIT (1 token @ 6 dp).
+    // Legit first deposit at exactly MIN_FIRST_DEPOSIT (0.01 ETF @ 6 dp).
     const firstData = Buffer.concat([
       Buffer.from([1]),
-      u64Le(1_000_000n),
+      u64Le(10_000n),
       u64Le(0n),
       Buffer.from([fresh.name.length]),
       fresh.name,
@@ -1205,7 +1205,7 @@ async function main() {
     // (bypasses Deposit) at the target weight ratio so NAV deviation
     // does not fire. Scale = 10_000x the legit leg amounts.
     for (let i = 0; i < TOKEN_COUNT; i++) {
-      const legitLeg = 1_000_000n * BigInt(WEIGHTS[i]) / 10_000n;
+      const legitLeg = 10_000n * BigInt(WEIGHTS[i]) / 10_000n;
       const donation = legitLeg * 10_000n;
       await mintTo(conn, payer, mints[i], fresh.vPks[i], payer, donation);
     }

--- a/test/frontend/programs.test.ts
+++ b/test/frontend/programs.test.ts
@@ -5,6 +5,7 @@ import {
 } from "../../frontend/src/lib/programs";
 import {
   buildJupiterSeedPreview,
+  createMockJupiterQuoteClient,
   type JupiterQuoteClient,
 } from "../../frontend/src/lib/jupiterSeed";
 
@@ -66,5 +67,28 @@ describe("frontend Jupiter seed preview", () => {
     expect(preview.depositAmount).toBe(60_000n);
     expect(preview.bottleneckIndex).toBe(1);
     expect(preview.mode).toBe("mock");
+  });
+
+  test("reallocates SOL toward the deposit-floor bottleneck when quotes improve", async () => {
+    const mintA = "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v";
+    const mintB = "Es9vMFrzaCERmJfrF4H2FYD4KCoNkY8wYb6Fq4jmWZtj";
+    const quoteClient = createMockJupiterQuoteClient({
+      outputBpsByMint: {
+        [mintA]: 20_000,
+        [mintB]: 10_000,
+      },
+    });
+
+    const preview = await buildJupiterSeedPreview({
+      basketMints: [mintA, mintB],
+      weights: [6_000, 4_000],
+      solIn: 1_000n,
+      slippageBps: 0,
+      quoteClient,
+    });
+
+    expect(preview.allocationMode).toBe("equalized");
+    expect(preview.legs.map((leg) => leg.solLamports)).toEqual([428n, 572n]);
+    expect(preview.depositAmount).toBeGreaterThan(1_000n);
   });
 });


### PR DESCRIPTION
## Summary
- reduce the axis-vault first-deposit floor from 1.0 ETF to 0.01 ETF so high-price low-base-unit legs like wBTC/wETH do not force excessive SOL during bootstrap
- add Jupiter seed preview reallocation that shifts SOL into the bottleneck asset only when fixed-point quote simulation improves the min deposit candidate
- keep SOL legs as SOL passthrough instead of routing a self-swap through Jupiter
- update frontend copy, error labels, and e2e seed floor expectations

## Tests
- cargo test (contracts/axis-vault)
- bun test test/frontend/programs.test.ts
- bun run typecheck
- bash ci/job-typescript.sh
- bash ci/rust-lint.sh
- git diff --check

## CI coverage
- added test/frontend/programs.test.ts coverage for the wBTC/wETH bottleneck reallocation path; this file is included by ci/jest.sh via ci/job-typescript.sh and the PR TypeScript workflow